### PR TITLE
Fall back to market snapshot when yfinance rate-limits

### DIFF
--- a/backend/app/services/market_data.py
+++ b/backend/app/services/market_data.py
@@ -181,6 +181,10 @@ def _snapshot_window(symbol: str, start: date, end: date) -> Any:
 
 @lru_cache(maxsize=128)
 def _download_close_series_in_window(symbol: str, start: date, end: date) -> Any:
+    # Returns a defensive copy of the underlying Series. The lru_cache
+    # holds the canonical object; copying on the way out keeps any caller
+    # in-place mutation (``.iloc[i] = ...``, ``.where(..., inplace=True)``)
+    # from corrupting the cached value for the next request.
     if _market_source() == "snapshot":
         window = _snapshot_window(symbol, start, end)
         if window.empty:
@@ -188,7 +192,7 @@ def _download_close_series_in_window(symbol: str, start: date, end: date) -> Any
                 f"Snapshot has no rows for {symbol} in [{start}, {end}). "
                 "Re-run scripts/snapshot_market_data.py to widen the window."
             )
-        return window
+        return window.copy()
 
     try:
         ticker = yf.Ticker(symbol)
@@ -206,7 +210,7 @@ def _download_close_series_in_window(symbol: str, start: date, end: date) -> Any
         except Exception:
             window = None
         if window is not None and not window.empty:
-            return window
+            return window.copy()
         raise RuntimeError(
             f"Live market fetch failed for {symbol} ({type(exc).__name__}); "
             "no snapshot fallback available. "
@@ -219,7 +223,7 @@ def _download_close_series_in_window(symbol: str, start: date, end: date) -> Any
     close_series = _close_series_from_frame(frame)
     if close_series.empty:
         raise RuntimeError(f"No close prices available for {symbol}")
-    return close_series
+    return close_series.copy()
 
 
 def _download_close_series(

--- a/backend/app/services/market_data.py
+++ b/backend/app/services/market_data.py
@@ -174,10 +174,15 @@ def _parse_iso_date(value: str) -> date:
         raise ValueError("date must be in YYYY-MM-DD format") from exc
 
 
+def _snapshot_window(symbol: str, start: date, end: date) -> Any:
+    series = _load_snapshot_series(symbol)
+    return series.loc[(series.index.date >= start) & (series.index.date < end)]
+
+
+@lru_cache(maxsize=128)
 def _download_close_series_in_window(symbol: str, start: date, end: date) -> Any:
     if _market_source() == "snapshot":
-        series = _load_snapshot_series(symbol)
-        window = series.loc[(series.index.date >= start) & (series.index.date < end)]
+        window = _snapshot_window(symbol, start, end)
         if window.empty:
             raise RuntimeError(
                 f"Snapshot has no rows for {symbol} in [{start}, {end}). "
@@ -185,12 +190,29 @@ def _download_close_series_in_window(symbol: str, start: date, end: date) -> Any
             )
         return window
 
-    ticker = yf.Ticker(symbol)
-    frame = ticker.history(
-        start=start.isoformat(),
-        end=end.isoformat(),
-        auto_adjust=True,
-    )
+    try:
+        ticker = yf.Ticker(symbol)
+        frame = ticker.history(
+            start=start.isoformat(),
+            end=end.isoformat(),
+            auto_adjust=True,
+        )
+    except Exception as exc:
+        # yfinance throws YFRateLimitError plus various transient network
+        # errors. When a committed snapshot covers the window, prefer the
+        # snapshot over surfacing the upstream failure to the user.
+        try:
+            window = _snapshot_window(symbol, start, end)
+        except Exception:
+            window = None
+        if window is not None and not window.empty:
+            return window
+        raise RuntimeError(
+            f"Live market fetch failed for {symbol} ({type(exc).__name__}); "
+            "no snapshot fallback available. "
+            f"Run scripts/snapshot_market_data.py --symbols {symbol} to seed one."
+        ) from exc
+
     if frame.empty:
         raise RuntimeError(f"No market data found for {symbol}")
 

--- a/frontend/lib/analyze/shared-context.tsx
+++ b/frontend/lib/analyze/shared-context.tsx
@@ -192,6 +192,12 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
             ...prev,
             [symKey]: { data, loading: false, error: null },
           }));
+          // Mirror ensureHarBaselines / ensureRecentHistory: clear the
+          // in-flight guard on success so an explicit refresh can re-fetch.
+          // On error the guard stays set so a re-running effect cannot
+          // thrash the endpoint; the user recovers by changing the symbol
+          // or reloading.
+          inFlight.current.delete(key);
         })
         .catch((err) => {
           setCoverageMap((prev) => ({

--- a/frontend/lib/analyze/shared-context.tsx
+++ b/frontend/lib/analyze/shared-context.tsx
@@ -381,9 +381,13 @@ export function useSharedCalendar(): CalendarState {
 export function useSharedCoverage(symbol: string | undefined): CoverageState {
   const ctx = useSharedContext();
   const symKey = symbol ?? "";
+  const { ensureCoverage } = ctx;
   React.useEffect(() => {
-    ctx.ensureCoverage(symbol);
-  }, [ctx, symbol]);
+    ensureCoverage(symbol);
+    // Pull the stable callback out of ctx so the effect re-runs only when
+    // symbol actually changes, not on every provider re-render — matches
+    // the pattern used by useHarBaselines below.
+  }, [ensureCoverage, symbol]);
   return ctx.coverageMap[symKey] ?? LOADING_COVERAGE;
 }
 
@@ -407,8 +411,13 @@ export function useSharedRecentHistory(
   const ctx = useSharedContext();
   const symKey = symbol ?? "";
   const mapKey = `${symKey}|${limit}`;
+  const { ensureRecentHistory } = ctx;
   React.useEffect(() => {
-    ctx.ensureRecentHistory(symbol, limit);
-  }, [ctx, symbol, limit]);
+    ensureRecentHistory(symbol, limit);
+    // Pull the stable callback out of ctx so the effect re-runs only on
+    // (symbol, limit) change. Putting `ctx` in deps thrashes the endpoint
+    // because every fetch updates state inside the provider, which gives
+    // ctx a new reference, which re-fires the effect, which re-fetches.
+  }, [ensureRecentHistory, symbol, limit]);
   return ctx.recentHistoryMap[mapKey] ?? LOADING_RECENT_HISTORY;
 }

--- a/tests/unit/test_market_snapshot.py
+++ b/tests/unit/test_market_snapshot.py
@@ -50,6 +50,7 @@ def snapshot_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     from app.services import market_data
 
     market_data._load_snapshot_series.cache_clear()
+    market_data._download_close_series_in_window.cache_clear()
     return snapshot_dir
 
 


### PR DESCRIPTION
## Summary

- The user-facing "Model unavailable" on `/analyze` was actually `YFRateLimitError` from yfinance propagating unhandled.
- `_download_close_series_in_window` now catches yfinance exceptions and prefers the committed snapshot at `data/raw/market/`.
- Added `@lru_cache(maxsize=128)` to the same function so back-to-back identical requests don't re-hit the upstream.
- Snapshot is seeded by `scripts/snapshot_market_data.py --symbols '^GSPC' --snapshot-dir /data/raw/market` (committed parquet lives under `data/raw/`, gitignored).
- If both the live call and the snapshot are absent the error message now names the script to run, instead of a generic 500.

## Verification

- `curl -s -X POST http://localhost:8000/analyze -H 'Content-Type: application/json' -d '{"text":"...","date":"2026-06-02","symbol":"^GSPC","horizon":"10d"}'`
- `docker compose run --rm backend python /app/scripts/snapshot_market_data.py --symbols '^GSPC' --snapshot-dir /data/raw/market`