### PR TITLE
Replace volume HAR cold-start spec with 10y walk-forward fit

### DIFF
--- a/backend/app/models/registry.yaml
+++ b/backend/app/models/registry.yaml
@@ -483,7 +483,7 @@ artefacts:
 
   volume_har_canonical:
     hf_uri: hf://yusufizzetmurat/fomc-volume-har
-    revision: "540b25a8d66c6f0110dd02b89f10e507139c80b8"
+    revision: "c63ca9c7d15649f5e54719a6d263ffa5311dac6f"
     eager: true
     description: |
       HAR Corsi log-volume artifact for the Expected Volume card. JSON
@@ -492,6 +492,11 @@ artefacts:
       residual quantiles. Eager-pulled into
       ``backend/models/volume_har/volume_har_artifact.json`` so cold
       starts skip the in-process fit against live yfinance volume.
+      Fitted on 3121 daily bars of ^GSPC volume (2014-01-02 to
+      2026-06-02) with 5-fold expanding walk-forward; pooled OOS R^2
+      h1 0.4676, h5 0.5479, h22 0.5053. Replaces the earlier
+      180-bar cold-start spec which surfaced negative R^2 on the
+      Expected Volume card.
     inference_features: []
 
   retrieval_bundle:


### PR DESCRIPTION
## Summary

- Expected Volume card was surfacing R² −2 / −2.5 / −6.9 because the cold-start fit only saw 180 days (~126 bars), barely above the 5×22 walk-forward floor.
- Refit `volume_har_canonical` against 3121 daily ^GSPC volume bars (2014-01-02 → 2026-06-02) via the existing `app.data.late_fusion_volume.fit_production_artifact` builder.
- Pooled OOS R² now 0.4676 / 0.5479 / 0.5053 at h=1 / h=5 / h=22.
- Pushed to HF as a new revision; registry pinned to `c63ca9c7`.

## Verification

- `curl -sf https://huggingface.co/api/models/yusufizzetmurat/fomc-volume-har/revision/c63ca9c7 | head -5`
- Restart backend, load `/`, confirm Expected Volume card shows positive R² and the `vs baseline %` numbers are sensible.