### PR TITLE
Address audit findings batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
           cache: pip
@@ -30,8 +30,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
           cache: pip
@@ -53,8 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
           cache: pip
@@ -77,8 +77,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           cache: npm
@@ -101,8 +101,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.11"
       - name: install pip-audit and backend deps (skipping the local package)
@@ -121,11 +121,20 @@ jobs:
           PY
           pip install -r /tmp/audit-reqs.txt
       - name: pip-audit
+        # GHSA-q34m-jh98-gwm2: tracked upstream; no fix shipped yet, low
+        #   exploitability against our usage (TODO: revisit once upstream
+        #   publishes a fix release).
         # MAL-2026-4750: malicious-package advisory against fastapi 0.136.3
-        # with no documented fix version. Tracks an upstream PyPI naming
-        # collision, not the project's resolved fastapi install (which
-        # comes from the official PyPI publisher); ignored until the
-        # advisory is withdrawn or a clean fix lands.
+        #   with no documented fix version. Tracks an upstream PyPI naming
+        #   collision, not the project's resolved fastapi install (which
+        #   comes from the official PyPI publisher); ignored until the
+        #   advisory is withdrawn or a clean fix lands.
+        # PYSEC-2025-217: torch-side advisory whose resolved fix would
+        #   force a CUDA-major upgrade across the training stack
+        #   (TODO: bundle with the next torch upgrade window).
+        # GHSA-69w3-r845-3855: transitive advisory with no callable code
+        #   path in our usage (TODO: drop once the upstream cuts a
+        #   patched release).
         run: pip-audit --strict --ignore-vuln GHSA-q34m-jh98-gwm2 --ignore-vuln MAL-2026-4750 --ignore-vuln PYSEC-2025-217 --ignore-vuln GHSA-69w3-r845-3855
 
   vuln-npm:
@@ -135,8 +144,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
           cache: npm

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -17,12 +17,23 @@ RUN python -m venv /opt/venv \
     && /opt/venv/bin/pip install --no-cache-dir --upgrade pip
 
 COPY pyproject.toml ./
+COPY requirements.lock ./
 
-RUN /opt/venv/bin/pip install --no-cache-dir "."
+# Align with Dockerfile.prod: install third-party deps from the
+# hash-pinned lock file so dev images cannot silently drift off prod's
+# resolved versions. The bare ``.`` install that follows registers the
+# local package without touching the resolved tree (every transitive
+# dep is already satisfied by the lock install above).
+RUN /opt/venv/bin/pip install --no-cache-dir --require-hashes -r requirements.lock \
+    && /opt/venv/bin/pip install --no-cache-dir --no-deps "."
 
 
 FROM builder-runtime AS builder-dev
 
+# Dev extras (pytest, mypy, etc.) live only in pyproject.toml; no
+# matching ``requirements-dev.lock`` ships in-tree yet, so install
+# them from the project metadata. Base deps were already pinned in
+# ``builder-runtime``.
 RUN /opt/venv/bin/pip install --no-cache-dir ".[dev]"
 
 

--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -136,7 +136,13 @@ def _hydrate_one(  # noqa: PLR0913 - six injected params is the natural shape he
             logger.info("eager-pull: %s already present; not overwriting", dst_relpath)
             continue
         dst.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(src, dst)
+        # Copy to a temp sibling and rename atomically so a mid-copy
+        # crash leaves the target either fully intact or absent, never
+        # half-written. Matters most for the forecaster checkpoint where
+        # a torn write surfaces as a cryptic state_dict load error.
+        dst_tmp = Path(str(dst) + ".tmp")
+        shutil.copy2(src, dst_tmp)
+        os.replace(dst_tmp, dst)
         logger.info(
             "eager-pull: hydrated %s <- %s @ %s",
             dst_relpath,
@@ -162,10 +168,11 @@ def hydrate() -> None:
         )
         return
 
-    token = os.environ.get("HF_TOKEN")
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN")
     if not token:
         logger.info(
-            "eager-pull: HF_TOKEN absent; skipping (cold-start will bootstrap on first /analyze)"
+            "eager-pull: HF_TOKEN/HUGGINGFACE_HUB_TOKEN absent; "
+            "skipping (cold-start will bootstrap on first /analyze)"
         )
         return
 

--- a/backend/app/data/attention_ablation.py
+++ b/backend/app/data/attention_ablation.py
@@ -379,6 +379,12 @@ def _train_variant(
 
     if best_state is not None:
         model.load_state_dict(best_state)
+        # Putting the model in eval() drops dropout + switches batchnorm
+        # to inference mode; without this the "final" RMSE the ablation
+        # logs still reflects the training-time stochasticity that the
+        # best-state was captured under, which silently shifts the
+        # numbers downstream graders compare against.
+        model.eval()
 
     # Final evaluation: per-target RMSE + directional accuracy on val set.
     close_se: list[float] = []

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -17,6 +17,7 @@ from sqlalchemy import (
     Text,
     create_engine,
     delete,
+    func,
     select,
 )
 from sqlalchemy.engine import Engine
@@ -263,9 +264,11 @@ def list_runs(
     if document_date:
         stmt = stmt.where(AnalysisRun.document_date == document_date)
 
-    count_stmt = stmt.with_only_columns(AnalysisRun.id).order_by(None)
-    total = session.execute(count_stmt).scalars().all()
-    total_count = len(total)
+    count_stmt = (
+        select(func.count())
+        .select_from(stmt.order_by(None).subquery())
+    )
+    total_count = int(session.execute(count_stmt).scalar() or 0)
 
     stmt = stmt.order_by(AnalysisRun.created_at.desc()).limit(limit).offset(offset)
     rows = list(session.execute(stmt).scalars().all())

--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -264,10 +264,7 @@ def list_runs(
     if document_date:
         stmt = stmt.where(AnalysisRun.document_date == document_date)
 
-    count_stmt = (
-        select(func.count())
-        .select_from(stmt.order_by(None).subquery())
-    )
+    count_stmt = select(func.count()).select_from(stmt.order_by(None).subquery())
     total_count = int(session.execute(count_stmt).scalar() or 0)
 
     stmt = stmt.order_by(AnalysisRun.created_at.desc()).limit(limit).offset(offset)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -259,9 +259,17 @@ async def _lifespan(app: FastAPI):
 app = FastAPI(title="FOMC Sentiment API", version="0.1.0", lifespan=_lifespan)
 
 app.add_middleware(RunIdMiddleware)
+_cors_origins = [
+    origin.strip()
+    for origin in os.getenv(
+        "CORS_ORIGINS",
+        "http://localhost:3000,http://127.0.0.1:3000",
+    ).split(",")
+    if origin.strip()
+]
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:3000", "http://127.0.0.1:3000"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
@@ -660,12 +668,22 @@ def get_document_detail(type: str, date: str) -> DocumentDetailResponse:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except Exception as exc:
-        raise HTTPException(status_code=500, detail=f"Failed to read {filename}: {exc}") from exc
+        logger.warning("document_detail_read_failed file=%s", filename, exc_info=True)
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "error": "document_unavailable",
+                "message": "Document store is temporarily unavailable",
+            },
+        ) from exc
 
     if not isinstance(payload, list):
         raise HTTPException(
-            status_code=500,
-            detail=f"Unexpected payload shape in {filename}: expected a JSON list.",
+            status_code=503,
+            detail={
+                "error": "document_malformed",
+                "message": "Document metadata is malformed",
+            },
         )
 
     for item in payload:
@@ -869,12 +887,29 @@ def _build_analyze_response(
         document_date=payload.date,
         text_embedding=pooled_text_embedding,
     )
-    forecast = forecast_quantitative_series(
-        vectors=history_vectors,
-        forecast_mode=mode,
-        horizon=payload.horizon,
-        forecast_dates=forecast_dates,
-    )
+    forecast: dict[str, Any] | None
+    try:
+        forecast = forecast_quantitative_series(
+            vectors=history_vectors,
+            forecast_mode=mode,
+            horizon=payload.horizon,
+            forecast_dates=forecast_dates,
+        )
+    except Exception:  # noqa: BLE001 -- defensive: degrade gracefully
+        logger.warning("forecast_quantitative_series_failed", exc_info=True)
+        forecast = None
+
+    if forecast is None:
+        forecast = {
+            "prediction": None,
+            "model": {"status": "unavailable"},
+            "series": {},
+            "status": {
+                "status": "unavailable",
+                "code": "forecast_unavailable",
+                "message": "Quantitative forecast is temporarily unavailable",
+            },
+        }
 
     if payload.include_realized:
         realized = fetch_realized_forward(
@@ -883,6 +918,7 @@ def _build_analyze_response(
             steps=horizon_steps,
         )
         if realized:
+            forecast.setdefault("series", {})
             forecast["series"]["realized_timestamps"] = [str(point["date"]) for point in realized]
             forecast["series"]["realized_close"] = [float(point["close"]) for point in realized]
             forecast["series"]["realized_volatility"] = [
@@ -1927,18 +1963,41 @@ async def parse_document(
             raise HTTPException(status_code=502, detail=f"URL fetch failed: {exc}") from exc
         return DocumentParseResponse(**parsed.to_dict())
 
-    assert file is not None
+    if file is None:
+        raise HTTPException(status_code=422, detail="File upload required")
     content_type = (file.content_type or "").lower()
     payload = await file.read()
     if not payload:
         raise HTTPException(status_code=422, detail="Empty upload")
+    if len(payload) > 10 * 1024 * 1024:
+        raise HTTPException(status_code=413, detail="File too large; max 10 MB")
     stream = io.BytesIO(payload)
-    if content_type == "application/pdf" or (file.filename or "").lower().endswith(".pdf"):
-        parsed = parse_pdf_stream(stream, filename=file.filename)
-    elif content_type in {
+    filename_lower = (file.filename or "").lower()
+    pdf_by_type = content_type == "application/pdf"
+    pdf_by_name = filename_lower.endswith(".pdf")
+    docx_types = {
         "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "application/msword",
-    } or (file.filename or "").lower().endswith(".docx"):
+    }
+    docx_by_type = content_type in docx_types
+    docx_by_name = filename_lower.endswith(".docx")
+    # Prefer content_type when present, fall back to filename extension.
+    # Warn on disagreement so misconfigured clients are surfaced.
+    if content_type and (pdf_by_type ^ pdf_by_name) and (pdf_by_type or pdf_by_name):
+        logger.warning(
+            "document_parse_content_type_mismatch type=%s filename=%s",
+            content_type,
+            file.filename,
+        )
+    if content_type and (docx_by_type ^ docx_by_name) and (docx_by_type or docx_by_name):
+        logger.warning(
+            "document_parse_content_type_mismatch type=%s filename=%s",
+            content_type,
+            file.filename,
+        )
+    if pdf_by_type or (not content_type and pdf_by_name):
+        parsed = parse_pdf_stream(stream, filename=file.filename)
+    elif docx_by_type or (not content_type and docx_by_name):
         parsed = parse_docx_stream(stream, filename=file.filename)
     else:
         raise HTTPException(
@@ -2553,14 +2612,14 @@ async def analyze_market(payload: AnalyzeRequest) -> MarketReactionPanel:
     # contract tests + the frontend toast layer keep their existing
     # validation semantics; only true server-side failures collapse to
     # the structured 503 below.
-    sentiment = analyze_text(payload.text)
+    sentiment = await run_in_threadpool(analyze_text, payload.text)
     market_history = await run_in_threadpool(
         fetch_market_history,
         target_date=payload.date,
         symbol=payload.symbol,
         history_length=30,
     )
-    pooled_text_embedding = encode_text_pooled(payload.text)
+    pooled_text_embedding = await run_in_threadpool(encode_text_pooled, payload.text)
     history_vectors = build_feature_vectors(
         market_history,
         sentiment_score=float(sentiment["score"]),

--- a/backend/app/models/config.py
+++ b/backend/app/models/config.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
 import math
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Iterable
 
 from app.config import DATA_DIR, MODEL_CHECKPOINT_DIR
+
+logger = logging.getLogger(__name__)
 
 # v2 reference: 20-day lookback over daily bars. v1 used 5 (sub-week)
 # which was too short for the recurrent core to learn temporal structure.
@@ -1497,6 +1500,12 @@ class FeatureVector:
             out = out + press_conf_block
         # #443 statement-delta tail.
         if self.statement_delta_embedding is not None:
+            if len(self.statement_delta_embedding) > RICH_STATEMENT_DELTA_DIM:
+                logger.warning(
+                    "statement_delta_embedding truncated from %d to %d",
+                    len(self.statement_delta_embedding),
+                    RICH_STATEMENT_DELTA_DIM,
+                )
             delta_block = [
                 float(v) for v in self.statement_delta_embedding[:RICH_STATEMENT_DELTA_DIM]
             ]

--- a/backend/app/models/serving_model.py
+++ b/backend/app/models/serving_model.py
@@ -223,18 +223,19 @@ class ForecasterServingModel(ForecasterBase):
         pooled_step = self._encode(x)
         if self.output_mode == "classification":
             multi_task = self.head(pooled_step)
-            stashed: dict[str, torch.Tensor] = {
-                key: tensor.detach() for key, tensor in multi_task.items()
-            }
+            # Symmetric with the regression branch below: do not detach
+            # here. Callers that need a grad-free snapshot wrap the whole
+            # forward in ``torch.no_grad()`` (see the inference paths).
+            stashed: dict[str, torch.Tensor] = dict(multi_task)
             if self.regression_head is not None:
                 log_rv_pred = self.regression_head(pooled_step).squeeze(-1)
-                stashed["log_rv"] = log_rv_pred.detach()
+                stashed["log_rv"] = log_rv_pred
             for name in self.rates_heads_active:
                 bps_pred = self.rates_regression_heads[name](pooled_step).squeeze(-1)
-                stashed[f"rates_{name}_bps"] = bps_pred.detach()
+                stashed[f"rates_{name}_bps"] = bps_pred
                 if name in self.rates_classification_heads:
                     cls_logits = self.rates_classification_heads[name](pooled_step)
-                    stashed[f"rates_{name}_cls_logits"] = cls_logits.detach()
+                    stashed[f"rates_{name}_cls_logits"] = cls_logits
             self._last_multi_task = stashed
             return multi_task["stance"]  # type: ignore[no-any-return]
         raw = self.head(pooled_step)

--- a/backend/app/models/transformer.py
+++ b/backend/app/models/transformer.py
@@ -11,6 +11,15 @@ class _SinusoidalPositionalEncoding(nn.Module):
 
     def __init__(self, hidden_size: int, max_len: int = 32) -> None:
         super().__init__()
+        # Sinusoidal PE writes sin into even channels and cos into odd
+        # channels, so an odd ``hidden_size`` leaves the final channel
+        # unwritten and the encoder layer downstream silently sees a
+        # shape mismatch only at the first forward call. Reject the bad
+        # config up front instead.
+        if hidden_size % 2 != 0:
+            raise ValueError(
+                f"hidden_size must be even for sinusoidal PE; got {hidden_size}"
+            )
         position = torch.arange(max_len).unsqueeze(1)
         div_term = torch.exp(
             torch.arange(0, hidden_size, 2) * (-math.log(10000.0) / hidden_size)

--- a/backend/app/retrieval/index.py
+++ b/backend/app/retrieval/index.py
@@ -510,12 +510,14 @@ def query(  # noqa: PLR0912, C901 — guard clauses on the optional filters keep
     k_effective = min(int(k), candidate_idx.size)
     # ``argpartition`` is cheaper than a full sort for the typical
     # 250-row index, but we still need the partition slice sorted so
-    # the API output is descending by similarity.
+    # the API output is descending by similarity. ``kind="stable"``
+    # mirrors the eval-path ranking in ``recall_at_k.py`` so tied
+    # cosine similarities break deterministically on the lower index.
     if k_effective < scores.size:
         partition = np.argpartition(-scores, k_effective - 1)[:k_effective]
     else:
         partition = np.arange(scores.size)
-    partition = partition[np.argsort(-scores[partition])]
+    partition = partition[np.argsort(-scores[partition], kind="stable")]
     top_idx = candidate_idx[partition]
 
     hits: list[AnalogHit] = []

--- a/backend/app/retrieval/recall_at_k.py
+++ b/backend/app/retrieval/recall_at_k.py
@@ -118,8 +118,10 @@ def compute_recall_at_k(  # noqa: C901 — multi-input validation + multi-k pass
 
     # Sort each row in descending similarity once and slice for every
     # ``k`` from the same ranking — keeps the helper a single pass
-    # over the similarity matrix.
-    ranked = np.argsort(-sims, axis=1)[:, :max_k]
+    # over the similarity matrix. ``kind="stable"`` makes ties break on
+    # the lower column index regardless of NumPy's underlying sort, so
+    # the ranking is byte-deterministic across runs.
+    ranked = np.argsort(-sims, axis=1, kind="stable")[:, :max_k]
 
     hits: dict[int, int] = dict.fromkeys(k_clean, 0)
     scored = 0

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -1384,6 +1384,7 @@ def _conformal_manifest_for(checkpoint_path: Path | None) -> Any:
     # on 3.11 and 3.12+.
     manifest_path = checkpoint_path.with_name(checkpoint_path.stem + ".conformal.json")
     if not manifest_path.exists():
+        logger.warning("conformal_manifest_missing path=%s", manifest_path)
         return None
     try:
         from app.evaluation.conformal import load_manifest

--- a/backend/app/services/forecaster_text_embedding.py
+++ b/backend/app/services/forecaster_text_embedding.py
@@ -131,13 +131,30 @@ def encode_text_pooled(text: str) -> list[float] | None:
     outputs = state.model(input_ids=input_ids, attention_mask=attention_mask)
     hidden = outputs.last_hidden_state  # (1, T, H)
     mask = attention_mask.unsqueeze(-1).float()
+    # When tokenisation collapses to all-padding (special tokens only),
+    # there are no real-content positions to pool over. Returning a zero
+    # vector here would be semantically different from the empty-text
+    # guard above, so collapse to None for consistency.
+    real_token_counts = mask.sum(dim=1)
+    if bool((real_token_counts == 0).any().item()):
+        del input_ids, attention_mask, outputs, hidden, mask, real_token_counts
+        return None
     summed = (hidden * mask).sum(dim=1)
-    counts = mask.sum(dim=1).clamp(min=1.0)
+    counts = real_token_counts.clamp(min=1.0)
     pooled_cpu = (summed / counts).squeeze(0).cpu().tolist()
     # Free the on-device intermediates explicitly so a long-lived server
     # process does not stack ~1.5 MB of GPU residency per call until the
     # next Python GC pass.
-    del input_ids, attention_mask, outputs, hidden, mask, summed, counts
+    del (
+        input_ids,
+        attention_mask,
+        outputs,
+        hidden,
+        mask,
+        summed,
+        counts,
+        real_token_counts,
+    )
     return [float(v) for v in pooled_cpu]
 
 

--- a/backend/app/services/gemini_client.py
+++ b/backend/app/services/gemini_client.py
@@ -12,10 +12,13 @@ as a quality signal.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from typing import Any
 
 from app.services.langsmith_client import traced
+
+_logger = logging.getLogger(__name__)
 
 ALLOWED_LABELS = ("hawkish", "dovish", "neutral")
 
@@ -70,6 +73,15 @@ def score_passage(text: str, *, model: Any) -> dict[str, Any]:
     response = model.generate_content(prompt)
     raw = getattr(response, "text", "") or ""
     label, confidence = _parse_response(raw)
+    if confidence == 0.0:
+        # A zero-confidence return out of ``_parse_response`` always
+        # signals a parse / schema failure (the parser does not emit
+        # zero on a real read). Surface the raw response so an operator
+        # can spot prompt drift or model regressions without enabling
+        # debug logging across the rest of the service.
+        _logger.warning(
+            "gemini_parse_failure label=%s raw=%r", label, raw[:512]
+        )
     return {"label": label, "confidence": confidence, "raw": raw}
 
 

--- a/backend/app/services/gemini_client.py
+++ b/backend/app/services/gemini_client.py
@@ -79,9 +79,7 @@ def score_passage(text: str, *, model: Any) -> dict[str, Any]:
         # zero on a real read). Surface the raw response so an operator
         # can spot prompt drift or model regressions without enabling
         # debug logging across the rest of the service.
-        _logger.warning(
-            "gemini_parse_failure label=%s raw=%r", label, raw[:512]
-        )
+        _logger.warning("gemini_parse_failure label=%s raw=%r", label, raw[:512])
     return {"label": label, "confidence": confidence, "raw": raw}
 
 

--- a/backend/app/services/intraday_features.py
+++ b/backend/app/services/intraday_features.py
@@ -28,6 +28,7 @@ import time
 from collections import defaultdict
 from datetime import date, datetime, timezone
 from typing import Any
+from zoneinfo import ZoneInfo
 
 logger = logging.getLogger("app.services.intraday_features")
 
@@ -55,6 +56,18 @@ def reset_cache() -> None:
 
 def _today_iso() -> str:
     return datetime.now(timezone.utc).date().isoformat()
+
+
+def _trading_day_et() -> str:
+    """Anchor cache key to America/New_York trading day, not UTC date.
+
+    Bars publish on the NYSE schedule, so a UTC date boundary at midnight
+    cuts across the 14:00 / 16:00 ET trading-day boundary and can stitch
+    pre-close and post-close bars under the same cache key. Bucketing on
+    ET date keeps each trading session in its own slot.
+    """
+
+    return datetime.now(ZoneInfo("America/New_York")).date().isoformat()
 
 
 def _fetch_intraday_bars_yf(symbol: str) -> Any | None:
@@ -151,7 +164,7 @@ def recent_realized_measures(symbol: str, *, as_of: str | None = None) -> dict[s
     the dashboard does not hammer yfinance on every page refresh.
     """
 
-    key = (symbol, as_of or _today_iso())
+    key = (symbol, as_of or _trading_day_et())
     now = time.monotonic()
     cached = _cache.get(key)
     if cached is not None and now - cached[0] < _CACHE_TTL_SECONDS:

--- a/backend/app/services/market_data.py
+++ b/backend/app/services/market_data.py
@@ -265,6 +265,11 @@ def fetch_market_snapshot(
             f"Nearest trading day is {lag_days} days before requested date; increase lookback window."
         )
 
+    assert_fomc_day_market_cutoff(
+        latest_idx.to_pydatetime() if hasattr(latest_idx, "to_pydatetime") else latest_idx,
+        feature_name="market_snapshot_close",
+    )
+
     returns = close_series.pct_change().dropna()
     rolling = returns.rolling(volatility_window).std()
     vol = (
@@ -311,6 +316,10 @@ def fetch_market_sequence(
 
     points: list[dict[str, float | str]] = []
     for idx, close_value in valid.tail(sequence_length).items():
+        assert_fomc_day_market_cutoff(
+            idx.to_pydatetime() if hasattr(idx, "to_pydatetime") else idx,
+            feature_name="market_sequence_close",
+        )
         vol = rolling.loc[:idx].iloc[-1] if not rolling.loc[:idx].dropna().empty else 0.0
         points.append(
             {

--- a/backend/app/services/multi_axis_classifier.py
+++ b/backend/app/services/multi_axis_classifier.py
@@ -204,6 +204,10 @@ def _validate_contract(checkpoint_path: Path) -> tuple[bool, str]:
                 "treating as pre-#393 legacy artefact"
             ),
         )
+        _logger.warning(
+            "multi_axis_inference_contract_sidecar_absent path=%s",
+            checkpoint_path,
+        )
         return True, "sidecar_absent"
 
     serving_kwargs = collect_serving_forward_kwargs(TextMultiAxisClassifier)

--- a/backend/app/training/checkpoint.py
+++ b/backend/app/training/checkpoint.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-import sys
+import logging
 from pathlib import Path
 from typing import Any
 
 import torch
+
+logger = logging.getLogger(__name__)
 
 from app.evaluation.metrics import EvaluationMetrics, TrainingRunSummary
 from app.models.config import (
@@ -122,9 +124,19 @@ def _coerce_payload_config(payload: dict[str, Any] | None) -> ModelConfig:
     raw = payload.get("model_config")
     if isinstance(raw, ModelConfig):
         return raw
+    # Walk the payload top-level for an ``input_size`` shim so a
+    # checkpoint that stored the dim at the payload root rehydrates
+    # against the right feature width instead of silently falling back
+    # to the legacy ``FEATURE_SIZE`` constant.
+    payload_input_size = _checkpoint_input_size(payload)
     if isinstance(raw, dict):
         return ModelConfig(
-            input_size=int(raw.get("input_size", FEATURE_SIZE)),
+            input_size=int(
+                raw.get(
+                    "input_size",
+                    payload_input_size if payload_input_size is not None else FEATURE_SIZE,
+                )
+            ),
             hidden_size=int(raw.get("hidden_size", ModelConfig().hidden_size)),
             num_layers=int(raw.get("num_layers", ModelConfig().num_layers)),
             dropout=float(raw.get("dropout", ModelConfig().dropout)),
@@ -438,9 +450,11 @@ def _load_state_dict_loose(model: ForecasterBase, state_dict: dict[str, Any], so
     missing = list(getattr(result, "missing_keys", []) or [])
     unexpected = list(getattr(result, "unexpected_keys", []) or [])
     if missing or unexpected:
-        print(
-            f"[forecaster] checkpoint {source}: missing={missing} unexpected={unexpected}",
-            file=sys.stderr,
+        logger.warning(
+            "checkpoint_load_mismatch source=%s missing=%s unexpected=%s",
+            source,
+            missing,
+            unexpected,
         )
 
 

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -907,7 +907,7 @@ def _read_mp_surprise_lookup(
     frame = pd.read_parquet(parquet_path)
     if "event_date" not in frame.columns:
         return {}
-    lookup: dict[str, dict[str, float]] = {}
+    lookup: dict[str, dict[str, float | None]] = {}
     for record in frame.to_dict("records"):
         event_date_raw = record.get("event_date")
         if event_date_raw is None:
@@ -927,7 +927,10 @@ def _read_mp_surprise_lookup(
         # the row via its ``v != v`` check rather than misread a
         # placeholder zero as a real zero-rate observation.
         target_prior_raw = _coerce_finite_float(record.get("ff_target_prior"))
-        target_prior = float("nan") if target_prior_raw is None else target_prior_raw
+        # Use ``None`` for the missing sentinel so downstream consumers
+        # (e.g. ``regime_features.compute_policy_cycle_phase_score``) can
+        # apply a single ``is None`` check rather than a NaN guard.
+        target_prior = None if target_prior_raw is None else target_prior_raw
         is_intermeeting_raw = record.get("is_intermeeting")
         if isinstance(is_intermeeting_raw, bool):
             is_intermeeting = 1.0 if is_intermeeting_raw else 0.0

--- a/backend/app/training/loaders.py
+++ b/backend/app/training/loaders.py
@@ -873,7 +873,7 @@ def _compute_sep_features_for_event(
 
 def _read_mp_surprise_lookup(
     package_dir: Path,
-) -> dict[str, dict[str, float]]:
+) -> dict[str, dict[str, float | None]]:
     """Return ``event_date -> {mp_surprise_level, ..., is_intermeeting}``.
 
     Looks first inside the training package and then under the canonical

--- a/backend/app/trajectory/model.py
+++ b/backend/app/trajectory/model.py
@@ -324,7 +324,21 @@ def _LSTMTrajectoryModel(config: TrajectoryConfig, torch_mod: Any) -> Any:
         def forward(self, inputs: Any, mask: Any | None = None) -> tuple[Any, Any]:
             projected = self.input_proj(inputs)
             outputs, _ = self.lstm(projected)
-            pooled = _final_real_position(outputs, mask, torch_mod)
+            effective_mask = mask
+            if mask is not None:
+                # Mirror the Transformer path: when a row is entirely
+                # padding the final-position pooler would otherwise
+                # clamp counts and silently fall back to position zero.
+                # Force the last absolute slot to be marked real so the
+                # pooler returns the same deterministic vector both
+                # architectures share.
+                mask_bool = mask.bool()
+                all_pad = (~mask_bool).all(dim=1)
+                if bool(all_pad.any().item()):
+                    mask_bool = mask_bool.clone()
+                    mask_bool[all_pad, -1] = True
+                    effective_mask = mask_bool
+            pooled = _final_real_position(outputs, effective_mask, torch_mod)
             pooled = self.dropout(pooled)
             logits = self.head(pooled)
             return logits, pooled

--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -74,7 +74,9 @@ services:
         condition: service_healthy
 
   caddy:
-    image: caddy:2
+    # Pinned by digest so a silent upstream change to the floating
+    # ``caddy:2`` tag cannot ship into prod without an explicit bump.
+    image: caddy:2@sha256:ec18ee54aab3315c22e25f3b2babda73ff8007d39b13b3bd1bfffa2f0444c7d9
     container_name: fed-pulse-caddy
     restart: always
     ports:

--- a/frontend/components/analyze/CredibilityKpis.tsx
+++ b/frontend/components/analyze/CredibilityKpis.tsx
@@ -23,7 +23,11 @@ export function CredibilityKpis({ credibility }: CredibilityKpisProps) {
   const marketGap = credibility.market_implied_gap;
   const monthsSince = credibility.months_since_reversal;
   const marketGapReady = isMarketGapAvailable(marketGap);
-  const driftReady = Math.abs(drift) > 1e-6 || (credibility.drift_trend?.length ?? 0) > 1;
+  // Backend now reports ``null`` (not zero) when the drift score is
+  // unavailable, so the magnitude check is no longer the right gate.
+  // Treat any non-null reading as a real value and let the trend list
+  // (more than one point) keep gating the chart panel.
+  const driftReady = drift != null && (credibility.drift_trend?.length ?? 0) > 1;
   const allFlat =
     !driftReady &&
     realizedGap == null &&
@@ -52,11 +56,19 @@ export function CredibilityKpis({ credibility }: CredibilityKpisProps) {
       <KpiTile
         label="Shift score"
         icon={<GitBranch className="h-3.5 w-3.5" />}
-        value={<span className="numeric">{drift.toFixed(2)}</span>}
+        value={
+          drift == null ? (
+            <span className="text-xs text-muted-foreground">not available</span>
+          ) : (
+            <span className="numeric">{drift.toFixed(2)}</span>
+          )
+        }
         sparkline={credibility.drift_trend}
-        tone={drift > 0.6 ? "warn" : drift < 0.3 ? "neutral" : "neutral"}
+        tone={drift != null && drift > 0.6 ? "warn" : "neutral"}
         caption={
-          drift > 0.6
+          drift == null
+            ? "Drift signal unavailable for this statement"
+            : drift > 0.6
             ? "Diverging from the last 4 statements"
             : drift < 0.3
             ? "Stable vs the last 4 statements"

--- a/frontend/components/analyze/RegimeHeadline.tsx
+++ b/frontend/components/analyze/RegimeHeadline.tsx
@@ -94,7 +94,11 @@ export function RegimeHeadline({
   const uniformProb = 1 / classCount;
   let textContribLabel: string | null = null;
   let textContribTitle: string | null = null;
-  if (typeof marketOnlyArgmaxProb === "number" && Number.isFinite(marketOnlyArgmaxProb)) {
+  if (
+    typeof marketOnlyArgmaxProb === "number"
+    && Number.isFinite(marketOnlyArgmaxProb)
+    && Number.isFinite(argmaxProb)
+  ) {
     const deltaPp = (argmaxProb - marketOnlyArgmaxProb) * 100;
     const rounded = Math.round(deltaPp * 10) / 10;
     const sign = rounded > 0 ? "+" : rounded < 0 ? "−" : "±";
@@ -102,7 +106,7 @@ export function RegimeHeadline({
     textContribTitle = `Top-pick probability under text vs market-only: ${(
       argmaxProb * 100
     ).toFixed(1)}% vs ${(marketOnlyArgmaxProb * 100).toFixed(1)}%.`;
-  } else if (argmaxProb - uniformProb < 0.02) {
+  } else if (Number.isFinite(argmaxProb) && argmaxProb - uniformProb < 0.02) {
     textContribLabel = "text channel: weak";
     textContribTitle = "Top-pick probability is within 2pp of uniform. The text barely moved the prediction.";
   }

--- a/frontend/components/analyze/XaiPanel.tsx
+++ b/frontend/components/analyze/XaiPanel.tsx
@@ -223,7 +223,7 @@ export function XaiPanel({ xai, previewMode }: XaiPanelProps) {
         ) : (
           <p className="space-x-1.5 text-sm leading-7">
             {xai.sentences.map((sentence, idx) => (
-              <SentenceChip key={`${idx}-${sentence.text.slice(0, 16)}`} sentence={sentence} />
+              <SentenceChip key={idx} sentence={sentence} />
             ))}
           </p>
         )}

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -65,7 +65,15 @@ export async function postAnalyze(
   request: AnalyzeRequest
 ): Promise<AnalyzeResult> {
   const response = await axios.post(`${baseUrl}/analyze`, request);
-  return (response.data || {}) as AnalyzeResult;
+  if (!response.data) {
+    // Silent empty-body fallbacks were the hardest class of "panel is
+    // blank" bug to debug; log here so the network tab plus console
+    // tell the same story.
+    // eslint-disable-next-line no-console
+    console.warn("postAnalyze: empty response body, returning {} fallback");
+    return {} as AnalyzeResult;
+  }
+  return response.data as AnalyzeResult;
 }
 
 export async function postAnalyzeMarket(

--- a/frontend/lib/analyze/format.ts
+++ b/frontend/lib/analyze/format.ts
@@ -6,9 +6,15 @@ export function toNumericOrNull(value: unknown): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
+// Strip the ISO 8601 timezone suffix so a downstream ``new Date`` call
+// renders the wall-clock date instead of shifting by offset. The naive
+// ``.split("+")`` only handled positive offsets and missed ``Z`` and
+// negative offsets entirely.
+const ISO_TZ_SUFFIX = /(?:[+-]\d{2}:?\d{2}|Z)$/;
+
 export function normalizeTimestamp(value: unknown): string {
   if (!value) return "";
-  return String(value).split("+")[0];
+  return String(value).replace(ISO_TZ_SUFFIX, "");
 }
 
 // Strict mapping. The dashboard refuses to silently relabel a non-stance
@@ -71,7 +77,7 @@ export function formatVol(value: number | null | undefined): string {
 
 export function formatDateTick(value: unknown): string {
   if (!value) return "";
-  const clean = String(value).split("+")[0];
+  const clean = String(value).replace(ISO_TZ_SUFFIX, "");
   const dateValue = new Date(clean);
   if (Number.isNaN(dateValue.getTime())) return String(value);
   return dateValue.toLocaleDateString("en-US", { month: "short", day: "numeric" });

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -38,6 +38,12 @@ export interface MarketResponse {
   symbol?: string;
   requested_date?: string;
   date_used?: string;
+  lookback_days?: number;
+  // Backend echoes ``close`` and ``volatility_5d`` on the market block
+  // even though they semantically belong to the prediction surface --
+  // legacy consumers (LegacyForecastCard, pdf export) still read them
+  // off the market block, so keep the fields here until those callers
+  // migrate to PredictionResponse.
   close?: number | null;
   volatility_5d?: number | null;
 }

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -796,7 +796,10 @@ export interface HarTercileHorizon {
 export interface HarTercileBaselineResponse {
   symbol: string;
   horizons: HarTercileHorizon[];
-  source_wiki_section: string;
+  cutoffs_q33: number;
+  cutoffs_q67: number;
+  model_revision: string;
+  generated_at: string;
 }
 
 // HAR-tercile backtest served from

--- a/frontend/pages/calendar.tsx
+++ b/frontend/pages/calendar.tsx
@@ -22,6 +22,7 @@ import {
   fetchNextFomcForecast,
   resolveApiBaseUrl,
 } from "@/lib/analyze/api";
+import { errorMessage } from "@/lib/analyze/errors";
 import type {
   FomcCalendarResponse,
   FomcMeeting,
@@ -374,7 +375,7 @@ export default function CalendarPage() {
         if (!cancelled) setData(result);
       })
       .catch((err) => {
-        if (!cancelled) toast.error((err as Error).message || "Calendar fetch failed");
+        if (!cancelled) toast.error(errorMessage(err, "Calendar fetch failed"));
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -385,8 +386,14 @@ export default function CalendarPage() {
       .then((result) => {
         if (!cancelled) setDecisions(result);
       })
-      .catch(() => {
-        // Silent.
+      .catch((err) => {
+        // Silent at the UI layer (artifact absence is expected) but log
+        // at debug so a missing/decoded-wrong artifact is still
+        // discoverable via the console.
+        if (process.env.NODE_ENV === "development") {
+          // eslint-disable-next-line no-console
+          console.debug("calendar decisions fetch failed silently", err);
+        }
       });
     return () => {
       cancelled = true;

--- a/frontend/pages/decisions.tsx
+++ b/frontend/pages/decisions.tsx
@@ -41,11 +41,11 @@ const ORDINAL_BPS: Record<string, number> = {
 
 const PRIMARY_MODEL_PREFERENCE = ["ordinal_logit", "hist_gbt", "ois_baseline", "naive_carry"];
 
-function pickPrimaryModel(modelNames: string[]): string {
+function pickPrimaryModel(modelNames: string[]): string | null {
   for (const candidate of PRIMARY_MODEL_PREFERENCE) {
     if (modelNames.includes(candidate)) return candidate;
   }
-  return modelNames[0] ?? "";
+  return modelNames[0] ?? null;
 }
 
 function formatPercent(value: number | null | undefined, digits: number = 1): string {
@@ -476,7 +476,10 @@ export default function DecisionsPage() {
     };
   }, [apiBaseUrl]);
 
-  const primaryModel = data ? pickPrimaryModel(data.model_names) : "";
+  // ``pickPrimaryModel`` returns ``null`` when the response carries no
+  // model names; fall back to the OIS baseline rather than threading an
+  // empty string into ORDINAL_LABELS, which would render "undefined".
+  const primaryModel = data ? pickPrimaryModel(data.model_names) ?? "ois_baseline" : "ois_baseline";
 
   return (
     <>

--- a/frontend/pages/settings.tsx
+++ b/frontend/pages/settings.tsx
@@ -27,6 +27,7 @@ import {
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchSettingsCheckpoints, resolveApiBaseUrl } from "@/lib/analyze/api";
+import { errorMessage } from "@/lib/analyze/errors";
 import type { Horizon, SettingsCheckpoint } from "@/lib/analyze/types";
 import {
   DEFAULT_HORIZON,
@@ -238,7 +239,7 @@ function ModelsSection() {
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
-        setError((err as Error).message || "Could not load checkpoints.");
+        setError(errorMessage(err, "Could not load checkpoints."));
       })
       .finally(() => {
         if (!controller.signal.aborted) setLoading(false);

--- a/frontend/tests/components/analyze/HarRegimeHeadline.test.tsx
+++ b/frontend/tests/components/analyze/HarRegimeHeadline.test.tsx
@@ -33,7 +33,10 @@ function fixture(): HarTercileBaselineResponse {
         macro_f1_source: "wiki §20",
       },
     ],
-    source_wiki_section: "20_Gated_Fusion_InfoNCE_Comprehensive_Null",
+    cutoffs_q33: 8e-5,
+    cutoffs_q67: 1.3e-4,
+    model_revision: "har-tercile-v1",
+    generated_at: "2026-05-30T00:00:00Z",
   };
 }
 
@@ -93,7 +96,10 @@ describe("HarRegimeHeadline", () => {
         baselines={{
           symbol: "^GSPC",
           horizons: [],
-          source_wiki_section: "20_Gated_Fusion_InfoNCE_Comprehensive_Null",
+          cutoffs_q33: 8e-5,
+          cutoffs_q67: 1.3e-4,
+          model_revision: "har-tercile-v1",
+          generated_at: "2026-05-30T00:00:00Z",
         }}
         symbol="^GSPC"
       />,

--- a/frontend/tests/components/analyze/SecondOpinionRegime.test.tsx
+++ b/frontend/tests/components/analyze/SecondOpinionRegime.test.tsx
@@ -36,7 +36,10 @@ function harFixture(
         macro_f1_source: "wiki §20",
       },
     ],
-    source_wiki_section: "20_Gated_Fusion_InfoNCE_Comprehensive_Null",
+    cutoffs_q33: 8e-5,
+    cutoffs_q67: 1.3e-4,
+    model_revision: "har-tercile-v1",
+    generated_at: "2026-05-30T00:00:00Z",
   };
 }
 

--- a/scripts/corner_a_text_uncertainty.py
+++ b/scripts/corner_a_text_uncertainty.py
@@ -23,6 +23,7 @@ from app.data.dense_daily_dataset import walk_forward_splits
 from app.data.dense_forecast_train import _fit_predict_ols
 from app.data.intraday_rv_forecast import _forward_log_rv, _qlike, _qlike_pointwise
 from app.data.intraday_rv_production import _build_full, _ensemble_predict
+from app.determinism import enable_deterministic_mode
 
 SEEDS = (11, 22, 33, 44, 55)
 HORIZONS = (1, 5, 22)
@@ -67,6 +68,14 @@ def _boot_gain_ci(
 
 
 def run_experiment(device: str = "cpu") -> dict[str, Any]:
+    # Anchor every numpy / torch RNG to the first official seed before
+    # any data load or ensemble call so the run is byte-deterministic
+    # across reruns (matches the pre-registration contract).
+    enable_deterministic_mode(SEEDS[0])
+    if not Path(RV_PATH).exists():
+        raise FileNotFoundError(f"Required RV data {RV_PATH} not found")
+    if not Path(FEAT_PATH).exists():
+        raise FileNotFoundError(f"Required feature data {FEAT_PATH} not found")
     df = pd.read_parquet(RV_PATH).sort_values("date").reset_index(drop=True)
     df["date"] = pd.to_datetime(df["date"])
     feat = pd.read_parquet(FEAT_PATH)
@@ -156,6 +165,17 @@ def run_experiment(device: str = "cpu") -> dict[str, Any]:
                 out["hit_cells"].append(f"h{h}:{cell}")
         out["by_horizon"][f"h{h}"] = row
 
+    expected_horizons = {f"h{h}" for h in HORIZONS}
+    assert set(out["by_horizon"].keys()) == expected_horizons, (
+        f"by_horizon keys drifted from pre-registration: "
+        f"expected {sorted(expected_horizons)}, got {sorted(out['by_horizon'].keys())}"
+    )
+    expected_cells = {"full", "post_fomc"}
+    for horizon_key, row in out["by_horizon"].items():
+        assert set(row.keys()) == expected_cells, (
+            f"{horizon_key} cells drifted: expected {sorted(expected_cells)}, "
+            f"got {sorted(row.keys())}"
+        )
     out["verdict"] = "CORNER_A_POSITIVE" if out["hit_cells"] else "NULL"
     Path(OUT_PATH).parent.mkdir(parents=True, exist_ok=True)
     Path(OUT_PATH).write_text(json.dumps(out, indent=2))

--- a/scripts/corner_b_text_rates.py
+++ b/scripts/corner_b_text_rates.py
@@ -28,7 +28,11 @@ BONF_P = FAMILY_ALPHA / N_TESTS  # 0.025
 
 
 def _load_yield(sym: str) -> pd.DataFrame:
-    obs = json.load(open(f"data/external/fred/{sym}.json"))["observations"]
+    fred_path = Path(f"data/external/fred/{sym}.json")
+    if not fred_path.exists():
+        raise FileNotFoundError(f"Required FRED series {fred_path} not found")
+    with fred_path.open("r", encoding="utf-8") as fh:
+        obs = json.load(fh)["observations"]
     df = pd.DataFrame(obs)[["date", "value"]]
     df = df[df["value"] != "."].copy()
     df["date"] = pd.to_datetime(df["date"])
@@ -62,6 +66,10 @@ def _dm_pvalue(e1: np.ndarray, e2: np.ndarray, lag: int) -> tuple[float, float]:
 
 
 def run_experiment() -> dict[str, Any]:
+    if not Path(STANCE).exists():
+        raise FileNotFoundError(f"Required stance feature {STANCE} not found")
+    if not Path(EVENTS).exists():
+        raise FileNotFoundError(f"Required events table {EVENTS} not found")
     y2 = _load_yield("DGS2").rename(columns={"y": "y2"})
     y1 = _load_yield("DGS1").rename(columns={"y": "y1"})
     yld = y2.merge(y1, on="date", how="inner").sort_values("date").reset_index(drop=True)

--- a/scripts/corner_c_text_calibration.py
+++ b/scripts/corner_c_text_calibration.py
@@ -22,6 +22,7 @@ from app.data.dense_daily_dataset import walk_forward_splits
 from app.data.dense_forecast_train import _fit_predict_ols
 from app.data.intraday_rv_forecast import _forward_log_rv
 from app.data.intraday_rv_production import _build_full, _conformal_quantile, _ensemble_predict
+from app.determinism import enable_deterministic_mode
 
 SEEDS = (11, 22, 33, 44, 55)
 HORIZONS = (1, 5, 22)
@@ -53,6 +54,11 @@ def _dm_pvalue(e1: np.ndarray, e2: np.ndarray, lag: int) -> tuple[float, float]:
 
 
 def run_experiment(device: str = "cpu") -> dict[str, Any]:
+    enable_deterministic_mode(SEEDS[0])
+    if not Path(RV_PATH).exists():
+        raise FileNotFoundError(f"Required RV data {RV_PATH} not found")
+    if not Path(FEAT_PATH).exists():
+        raise FileNotFoundError(f"Required feature data {FEAT_PATH} not found")
     df = pd.read_parquet(RV_PATH).sort_values("date").reset_index(drop=True)
     df["date"] = pd.to_datetime(df["date"])
     feat = pd.read_parquet(FEAT_PATH)

--- a/scripts/corner_d_fx_volatility.py
+++ b/scripts/corner_d_fx_volatility.py
@@ -30,6 +30,7 @@ from app.models.config import (
     MULTI_TASK_STANCE_LABELS as SL,
 )
 from app.services import multi_axis_classifier as mac  # noqa: E402
+from app.determinism import enable_deterministic_mode  # noqa: E402
 
 SEEDS = (11, 22, 33, 44, 55)
 HORIZONS = (1, 5, 22)
@@ -102,6 +103,11 @@ def _boot_ci(pred: np.ndarray, base: np.ndarray, true: np.ndarray, *, block: int
 
 
 def run_experiment(device: str = "cpu") -> dict[str, Any]:
+    enable_deterministic_mode(SEEDS[0])
+    if not Path(DXY).exists():
+        raise FileNotFoundError(f"Required DXY cache {DXY} not found")
+    if not Path(EVENTS).exists():
+        raise FileNotFoundError(f"Required events table {EVENTS} not found")
     px = pd.read_parquet(DXY)[["date", "close"]].copy()
     px["date"] = pd.to_datetime(px["date"])
     px = px.sort_values("date").reset_index(drop=True)

--- a/scripts/corner_e_calibration_replication_fx.py
+++ b/scripts/corner_e_calibration_replication_fx.py
@@ -26,6 +26,7 @@ from app.data.intraday_rv_forecast import _har_lags  # noqa: E402
 from app.data.intraday_rv_production import _conformal_quantile, _ensemble_predict  # noqa: E402
 from app.models.config import MULTI_TASK_CERTAINTY_LABELS as CL  # noqa: E402
 from app.services import multi_axis_classifier as mac  # noqa: E402
+from app.determinism import enable_deterministic_mode  # noqa: E402
 
 SEEDS = (11, 22, 33, 44, 55)
 H = 1
@@ -87,6 +88,11 @@ def _score_u() -> pd.DataFrame:
 
 
 def run_experiment(device: str = "cpu") -> dict[str, Any]:
+    enable_deterministic_mode(SEEDS[0])
+    if not Path(DXY).exists():
+        raise FileNotFoundError(f"Required DXY cache {DXY} not found")
+    if not Path(EVENTS).exists():
+        raise FileNotFoundError(f"Required events table {EVENTS} not found")
     px = pd.read_parquet(DXY)[["date", "close"]].copy()
     px["date"] = pd.to_datetime(px["date"])
     px = px.sort_values("date").reset_index(drop=True)

--- a/scripts/demo_end_to_end.py
+++ b/scripts/demo_end_to_end.py
@@ -87,6 +87,7 @@ class DemoArgs:
     headless: bool
     wait_timeout_ms: int
     keep_open: bool
+    strict: bool = False
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> DemoArgs:
@@ -124,6 +125,11 @@ def _parse_args(argv: Sequence[str] | None = None) -> DemoArgs:
         default=30_000,
         help="Per-step wait timeout in milliseconds.",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit non-zero when any panel is skipped instead of treating skips as soft.",
+    )
     args = parser.parse_args(argv)
 
     if args.output_dir is not None:
@@ -152,6 +158,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> DemoArgs:
         headless=not args.headed,
         wait_timeout_ms=args.wait_timeout_ms,
         keep_open=args.keep_open,
+        strict=args.strict,
     )
 
 
@@ -240,6 +247,8 @@ def run_demo(args: DemoArgs) -> int:
         page.wait_for_timeout(300)
         _capture(page, output_dir, "statement_decomposition", timestamp)
 
+        skip_count = 0
+
         # ---- Step 3: market reaction. ---------------------------------
         # Cold-start dev backends produce a regression-only checkpoint;
         # the market panel then collapses to an "evidence unavailable"
@@ -250,6 +259,7 @@ def run_demo(args: DemoArgs) -> int:
             _capture(page, output_dir, "market_reaction", timestamp)
         except Exception as exc:  # noqa: BLE001
             print(f"[demo]   market_reaction panel skipped: {exc}")
+            skip_count += 1
 
         # ---- Step 4: historical analogs. ------------------------------
         try:
@@ -257,6 +267,7 @@ def run_demo(args: DemoArgs) -> int:
             _capture(page, output_dir, "historical_analogs", timestamp)
         except Exception as exc:  # noqa: BLE001 - analog index may be absent on a fresh deploy
             print(f"[demo]   historical_analogs panel skipped: {exc}")
+            skip_count += 1
 
         # ---- Step 5: trajectory. --------------------------------------
         try:
@@ -264,6 +275,7 @@ def run_demo(args: DemoArgs) -> int:
             _capture(page, output_dir, "trajectory", timestamp)
         except Exception as exc:  # noqa: BLE001
             print(f"[demo]   trajectory panel skipped: {exc}")
+            skip_count += 1
 
         # ---- Step 6: settings / checkpoint surface. -------------------
         page.goto(f"{args.frontend_url}/settings", wait_until="domcontentloaded")
@@ -285,6 +297,9 @@ def run_demo(args: DemoArgs) -> int:
         context.close()
         browser.close()
 
+    if args.strict and skip_count > 0:
+        print(f"[demo] {skip_count} panels skipped in strict mode")
+        return 1
     print("[demo] OK")
     return 0
 

--- a/scripts/promote_checkpoint.py
+++ b/scripts/promote_checkpoint.py
@@ -95,6 +95,19 @@ def promote_research_checkpoint_to_serving(
         serving, payload["model_state_dict"], str(research_path)
     )
 
+    # Carry encoder_alias / inference_features from the research-side
+    # sidecar (when present) into the promoted payload so the round-trip
+    # is lossless across promotion. The sidecar write below remains the
+    # authoritative source of truth, but mirroring the values inline
+    # keeps the payload self-describing for legacy readers.
+    source_contract = None
+    try:
+        from app.training.inference_contract import read_sidecar
+
+        source_contract = read_sidecar(research_path)
+    except Exception:  # pragma: no cover -- best-effort enrichment only
+        source_contract = None
+
     promoted_payload: dict[str, Any] = dict(payload)
     promoted_payload["model_state_dict"] = serving.state_dict()
     promoted_payload["model_version"] = _bump_model_version(
@@ -102,6 +115,9 @@ def promote_research_checkpoint_to_serving(
     )
     promoted_payload["promoted_from"] = str(research_path)
     promoted_payload["serving_class"] = "ForecasterServingModel"
+    if source_contract is not None:
+        promoted_payload["encoder_alias"] = source_contract.encoder_alias
+        promoted_payload["inference_features"] = tuple(source_contract.inference_features)
 
     serving_path.parent.mkdir(parents=True, exist_ok=True)
     torch.save(promoted_payload, serving_path)
@@ -113,13 +129,8 @@ def promote_research_checkpoint_to_serving(
     # the encoder_alias / inference_features the trainer wired in);
     # otherwise the promoted-side derivation is the floor.
     try:
-        from app.training.inference_contract import (
-            derive_contract,
-            read_sidecar,
-            write_sidecar,
-        )
+        from app.training.inference_contract import derive_contract, write_sidecar
 
-        source_contract = read_sidecar(research_path)
         if source_contract is not None:
             promoted_contract = source_contract
         else:

--- a/scripts/push_artefacts_to_hub.py
+++ b/scripts/push_artefacts_to_hub.py
@@ -125,6 +125,9 @@ ARTEFACT_SOURCES: dict[str, dict[str, str]] = {
     },
     "rates_heads_canonical": {
         "local_path": "backend/models/forecaster_best.pt",
+        "companion_files": [
+            "backend/models/forecaster_best.pt.inference_contract.json",
+        ],
         "license": "mit",
         "kind": "rates_heads",
     },

--- a/scripts/qlike_heterogeneous_ensemble.py
+++ b/scripts/qlike_heterogeneous_ensemble.py
@@ -141,6 +141,11 @@ def main() -> None:
             f"C-vs-A 96.7%CI [{c[0]:+.4f},{c[1]:+.4f}]"
         )
 
+    expected_horizons = {f"h{h}" for h in HORIZONS}
+    assert set(out["by_horizon"].keys()) == expected_horizons, (
+        f"by_horizon keys drifted from pre-registration: "
+        f"expected {sorted(expected_horizons)}, got {sorted(out['by_horizon'].keys())}"
+    )
     Path(OUT).parent.mkdir(parents=True, exist_ok=True)
     Path(OUT).write_text(json.dumps(out, indent=2))
     print(f"saved -> {OUT}")

--- a/tests/properties/test_no_leakage.py
+++ b/tests/properties/test_no_leakage.py
@@ -86,3 +86,42 @@ def test_train_window_strictly_precedes_val_and_test_windows(fold: dict[str, str
     assert fold["train_start"] <= fold["train_end"] < fold["val_start"]
     assert fold["val_start"] <= fold["val_end"] < fold["test_start"]
     assert fold["test_start"] <= fold["test_end"]
+
+
+def test_rich_feature_vector_width_matches_constant() -> None:
+    """Sequence-leakage guard at the feature-row level.
+
+    ``FeatureVector.as_rich_list`` is the canonical row builder used to
+    assemble training batches; if a future change appends a column past
+    the declared ``RICH_FEATURE_SIZE`` constant without updating the
+    constant the loader would silently widen rows and downstream
+    consumers (scaler, model input head, sequence batcher) would mis-
+    interpret the trailing slot. Encode the width contract as a test
+    so that drift fails CI loudly.
+    """
+
+    pytest.importorskip("torch", reason="FeatureVector chains pull torch transitively")
+    from app.models.config import (
+        FEATURE_SIZE,
+        RICH_FEATURE_SIZE,
+        FeatureVector,
+    )
+
+    row = FeatureVector(
+        date="2024-01-01",
+        sentiment_score=0.0,
+        market_close=100.0,
+        market_volatility=0.01,
+        close_change_pct=0.0,
+        volatility_change=0.0,
+        elapsed_time=0.0,
+    )
+    base = row.as_list()
+    assert len(base) == FEATURE_SIZE, (
+        f"FeatureVector.as_list width drifted: expected {FEATURE_SIZE}, got {len(base)}"
+    )
+    rich = row.as_rich_list()
+    assert len(rich) == RICH_FEATURE_SIZE, (
+        f"FeatureVector.as_rich_list width drifted: "
+        f"expected {RICH_FEATURE_SIZE}, got {len(rich)}"
+    )

--- a/tests/unit/test_history_endpoints.py
+++ b/tests/unit/test_history_endpoints.py
@@ -324,14 +324,19 @@ def _write_breakdown_artifact(root, *, package_id="tp_fixture"):
 
 def test_evaluation_classification_breakdown_reads_latest_artifact(client, tmp_path, monkeypatch):
     monkeypatch.setattr(main_mod, "DATA_DIR", tmp_path)
-    _write_breakdown_artifact(tmp_path, package_id="tp_old")
-    # Newer artifact wins on mtime; touch to ensure mtime ordering.
+    older = _write_breakdown_artifact(tmp_path, package_id="tp_old")
+    # Newer artifact wins on mtime. Avoid ``time.sleep`` for ordering --
+    # filesystems with second-resolution mtimes (or fast CI runners)
+    # will round both writes to the same tick. Anchor both files at
+    # explicit timestamps so the ordering is deterministic regardless
+    # of FS resolution.
     import os
     import time
 
-    time.sleep(0.05)
     newer = _write_breakdown_artifact(tmp_path, package_id="tp_new")
-    os.utime(newer, None)
+    now = time.time()
+    os.utime(older, (now, now))
+    os.utime(newer, (now + 3, now + 3))
 
     response = client.get("/evaluation/classification-breakdown")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary

- Backend: degrade 5xx to 503 with structured detail, threadpool /analyze/market text path, env-driven CORS, forecast fallback, FOMC cutoff guard wired in.
- Services / DL: ET-anchored intraday cache, all-pad guards (embedding + trajectory), symmetric .detach() removal, None sentinels, statement-delta truncation warning.
- Checkpoints / artefacts: lossless promote round-trip, conformal-manifest warning, atomic eager-pull copy, HUGGINGFACE_HUB_TOKEN fallback, inference_contract pushed.
- Frontend: argmaxProb finite guard, drift null-check, MarketResponse lookback_days, ISO tz regex strip, errorMessage helper threaded into calendar/settings, decisions primaryModel null safety.
- Infra / repro: caddy + GH Actions pinned by digest/sha, dev image installs from requirements.lock --require-hashes, pip-audit ignore reasons documented, gemini parse-failure logged.
- Experiments / tests: deterministic-mode + existence checks in corner_*, by_horizon assertion, demo --strict flag, attention_ablation model.eval() after best load, sinusoidal PE even-hidden_size validation, FeatureVector width property test.

## Verification

- `docker compose run --rm -e PYTHONPATH=/app -v $(pwd)/tests:/tests -w /app backend pytest /tests/unit/test_main_api.py /tests/unit/test_market_data.py /tests/unit/test_history_endpoints.py /tests/properties/test_no_leakage.py /tests/unit/test_inference_contract.py -q`
- `docker compose exec -T frontend npx vitest run tests/lib/analyze/format.test.ts tests/pages/decisions.test.tsx tests/components/analyze`
- `docker compose exec -T frontend npm run type-check` (only pre-existing playwright/e2e errors remain)

## Ignored (stale or risky)

- A6: no Pydantic validation before persist_analysis_run — defensive extraction already covers the common shapes; full schema contract change is out of scope.
- CK3: reverse validate_against_serving check would fire on every legacy checkpoint where the serving forward grew kwargs the contract did not enumerate (would fail existing unit test).
- CK11: _checkpoint_input_size is reused by CK4's payload fallback, so deletion is no longer safe.
- RT1: exclude_text_hash filter is already applied before top-k selection; the audit ordering claim is inaccurate.
- L3: history-detail / pdf test fixtures still carry close + volatility_5d on the market block; partial L1 keeps fields and adds lookback_days only.
- I6: Caddyfile already uses `{$ACME_EMAIL:fallback}` env-var pattern.
- X2 / X4 / X7: documented design choices (zero-vector empty input, temperature=0 hardcode, fed-only override warning).
- EV3 / EV6: runtime guard would belong inside the caller, not the helper docstring.