### PR TITLE
Drop leaky post-2pm FOMC bars at serve time instead of raising

### DIFF
--- a/backend/app/services/market_data.py
+++ b/backend/app/services/market_data.py
@@ -72,9 +72,7 @@ def _is_fomc_day_after_cutoff(timestamp: datetime) -> bool:
 
     if not is_fomc_day(timestamp.date()):
         return False
-    anchored = (
-        timestamp.replace(tzinfo=timezone.utc) if timestamp.tzinfo is None else timestamp
-    )
+    anchored = timestamp.replace(tzinfo=timezone.utc) if timestamp.tzinfo is None else timestamp
     local = anchored.astimezone(FOMC_ZONE)
     cutoff = datetime.combine(local.date(), FOMC_LOCAL_CUTOFF_TIME, tzinfo=FOMC_ZONE)
     return local > cutoff
@@ -196,8 +194,7 @@ def _snapshot_frame_to_series(frame: Any) -> Any:
 
     if "date" not in frame.columns or "close" not in frame.columns:
         raise RuntimeError(
-            "Snapshot parquet must contain 'date' and 'close' columns; got "
-            f"{list(frame.columns)}"
+            f"Snapshot parquet must contain 'date' and 'close' columns; got {list(frame.columns)}"
         )
     index = pd.to_datetime(frame["date"]).dt.tz_localize(None)
     series = pd.Series(frame["close"].astype(float).to_numpy(), index=index, name="Close")

--- a/backend/app/services/market_data.py
+++ b/backend/app/services/market_data.py
@@ -62,6 +62,24 @@ def is_fomc_day(value: date) -> bool:
     return value in _fomc_days()
 
 
+def _is_fomc_day_after_cutoff(timestamp: datetime) -> bool:
+    """Return True iff ``timestamp`` falls on an FOMC day strictly after 14:00 ET.
+
+    Same cutoff semantics as :func:`assert_fomc_day_market_cutoff`. Used by
+    the serving paths to drop bad bars from a series without aborting the
+    whole request, while the offline builder path keeps the hard assertion.
+    """
+
+    if not is_fomc_day(timestamp.date()):
+        return False
+    anchored = (
+        timestamp.replace(tzinfo=timezone.utc) if timestamp.tzinfo is None else timestamp
+    )
+    local = anchored.astimezone(FOMC_ZONE)
+    cutoff = datetime.combine(local.date(), FOMC_LOCAL_CUTOFF_TIME, tzinfo=FOMC_ZONE)
+    return local > cutoff
+
+
 def assert_fomc_day_market_cutoff(
     timestamp: datetime,
     *,
@@ -80,28 +98,57 @@ def assert_fomc_day_market_cutoff(
     ``America/New_York`` local time so DST is handled automatically and
     the cutoff is the same 14:00 wall-clock both halves of the year.
 
-    Raises ``ValueError`` on violation so the caller can surface a clear
-    error to the operator. No silent coercion: a bad row is a bug, not a
-    rounding error.
+    Raises ``ValueError`` on violation. The offline event-dataset builder
+    uses this strict form so a leaked bar aborts the build. Serving paths
+    use :func:`_is_fomc_day_after_cutoff` to drop the offending bar from
+    the series rather than failing the request.
     """
 
-    if not is_fomc_day(timestamp.date()):
-        return  # Not an FOMC day -> cutoff does not apply.
-
+    if not _is_fomc_day_after_cutoff(timestamp):
+        return
     if timestamp.tzinfo is None:
         anchored = timestamp.replace(tzinfo=timezone.utc)
     else:
         anchored = timestamp
     local = anchored.astimezone(FOMC_ZONE)
     cutoff = datetime.combine(local.date(), FOMC_LOCAL_CUTOFF_TIME, tzinfo=FOMC_ZONE)
-    if local > cutoff:
-        raise ValueError(
-            f"{feature_name} dated {local.isoformat()} is after the FOMC "
-            f"14:00 ET cutoff ({cutoff.isoformat()}) on a meeting day. "
-            "Same-day post-announcement bars leak the policy decision into the "
-            "feature frame. Drop the bar or rebuild the feature with an "
-            "as-of timestamp ≤ 14:00 ET."
+    raise ValueError(
+        f"{feature_name} dated {local.isoformat()} is after the FOMC "
+        f"14:00 ET cutoff ({cutoff.isoformat()}) on a meeting day. "
+        "Same-day post-announcement bars leak the policy decision into the "
+        "feature frame. Drop the bar or rebuild the feature with an "
+        "as-of timestamp ≤ 14:00 ET."
+    )
+
+
+def _filter_leak_safe(series: Any) -> Any:
+    """Drop FOMC-day bars whose timestamp sits after the 14:00 ET cutoff.
+
+    Mirrors the offline-builder leak guard at serve time without erroring
+    out the request. The dropped bars are exactly the ones that would have
+    leaked the policy decision into the feature frame, so removing them
+    preserves the same no-leak contract via skip rather than raise.
+    """
+
+    import logging as _logging
+
+    if series.empty:
+        return series
+    keep_mask = []
+    dropped = 0
+    for idx in series.index:
+        ts = idx.to_pydatetime() if hasattr(idx, "to_pydatetime") else idx
+        leaks = _is_fomc_day_after_cutoff(ts)
+        keep_mask.append(not leaks)
+        if leaks:
+            dropped += 1
+    if dropped:
+        _logging.getLogger(__name__).info(
+            "market_data_leak_filter dropped_bars=%d total=%d",
+            dropped,
+            len(series),
         )
+    return series[keep_mask]
 
 
 def _safe_symbol(symbol: str) -> str:
@@ -257,6 +304,17 @@ def fetch_market_snapshot(
     if valid.empty:
         raise RuntimeError(f"No market data on or before {requested_date.isoformat()} for {symbol}")
 
+    # Drop any FOMC-day bars whose timestamp sits after the 14:00 ET cutoff
+    # before picking the latest valid index. The offline event-dataset
+    # builder still asserts; at serve time the contract is identical
+    # (no leaked bar enters the feature frame) but the request continues
+    # against the most recent CLEAN bar instead of erroring out the user.
+    valid = _filter_leak_safe(valid)
+    if valid.empty:
+        raise RuntimeError(
+            f"No leak-safe market data on or before {requested_date.isoformat()} for {symbol}"
+        )
+
     latest_idx = valid.index[-1]
     date_used = latest_idx.date()
     lag_days = (requested_date - date_used).days
@@ -264,11 +322,6 @@ def fetch_market_snapshot(
         raise RuntimeError(
             f"Nearest trading day is {lag_days} days before requested date; increase lookback window."
         )
-
-    assert_fomc_day_market_cutoff(
-        latest_idx.to_pydatetime() if hasattr(latest_idx, "to_pydatetime") else latest_idx,
-        feature_name="market_snapshot_close",
-    )
 
     returns = close_series.pct_change().dropna()
     rolling = returns.rolling(volatility_window).std()
@@ -311,15 +364,21 @@ def fetch_market_sequence(
     if valid.empty:
         raise RuntimeError(f"No market data on or before {requested_date.isoformat()} for {symbol}")
 
+    # Drop FOMC-day bars whose timestamp sits after the 14:00 ET cutoff
+    # before assembling the sequence. The offline builder still hard-asserts;
+    # at serve time we skip the leaked bar so the rest of the lookback is
+    # still usable.
+    valid = _filter_leak_safe(valid)
+    if valid.empty:
+        raise RuntimeError(
+            f"No leak-safe market data on or before {requested_date.isoformat()} for {symbol}"
+        )
+
     returns = close_series.pct_change().dropna()
     rolling = returns.rolling(5).std()
 
     points: list[dict[str, float | str]] = []
     for idx, close_value in valid.tail(sequence_length).items():
-        assert_fomc_day_market_cutoff(
-            idx.to_pydatetime() if hasattr(idx, "to_pydatetime") else idx,
-            feature_name="market_sequence_close",
-        )
         vol = rolling.loc[:idx].iloc[-1] if not rolling.loc[:idx].dropna().empty else 0.0
         points.append(
             {

--- a/frontend/lib/analyze/constants.ts
+++ b/frontend/lib/analyze/constants.ts
@@ -23,5 +23,15 @@ export const SYMBOL_OPTIONS: SymbolOption[] = [
 
 export const HORIZON_OPTIONS: Horizon[] = ["1d", "3d", "5d", "10d"];
 
+// Symbols the HAR-tercile baseline + backtest endpoints support. ^GSPC
+// serves from the pinned QLIKE-DLq artifact; ^NDX and ^DJI use a
+// per-call OLS HAR fit. FX / commodity tickers stay out of scope —
+// HAR-tercile is fit on equity-index RV.
+export const HAR_TERCILE_SUPPORTED_SYMBOLS: readonly string[] = [
+  "^GSPC",
+  "^NDX",
+  "^DJI",
+];
+
 export const REAL_TRAIN_POLL_INTERVAL_MS = 2000;
 export const REAL_TRAIN_POLL_MAX = 180;

--- a/frontend/lib/analyze/errors.ts
+++ b/frontend/lib/analyze/errors.ts
@@ -10,7 +10,7 @@ export type ErrorCategory = "model_unavailable" | "bad_input" | "network" | "not
 interface AxiosLikeError {
   response?: {
     status?: number;
-    data?: { detail?: string };
+    data?: { detail?: string | { error?: string; message?: string } };
   };
   request?: unknown;
   message?: string;
@@ -33,6 +33,21 @@ const MODEL_UNAVAILABLE_COPY = "Model unavailable. Try again later or check the 
 const NETWORK_COPY = "Network error. Check your connection and try again.";
 const NOT_FOUND_COPY = "Not found.";
 const FALLBACK_COPY = "Something went wrong. Try again.";
+
+function _extractDetail(err: AxiosLikeError): string | null {
+  // Backend handlers return one of:
+  //   detail: "human readable string"
+  //   detail: { error: "code", message: "human readable string" }
+  // Both forms should surface to the user; the dict form is the common
+  // shape for the per-symbol unsupported / unavailable rejections.
+  const detail = err.response?.data?.detail;
+  if (typeof detail === "string" && detail.trim().length > 0) return detail;
+  if (detail && typeof detail === "object" && typeof (detail as { message?: string }).message === "string") {
+    const msg = (detail as { message: string }).message.trim();
+    if (msg.length > 0) return msg;
+  }
+  return null;
+}
 
 export function categorizeError(err: unknown): { category: ErrorCategory; message: string } {
   if (!err) return { category: "network", message: FALLBACK_COPY };
@@ -57,27 +72,27 @@ export function categorizeError(err: unknown): { category: ErrorCategory; messag
   const status = axiosErr.response?.status;
   if (status != null) {
     if (BAD_INPUT_STATUSES.has(status)) {
-      const detail = axiosErr.response?.data?.detail;
       return {
         category: "bad_input",
-        message:
-          typeof detail === "string" && detail.trim().length > 0
-            ? detail
-            : "Request rejected. Check the inputs and try again.",
+        message: _extractDetail(axiosErr) || "Request rejected. Check the inputs and try again.",
       };
     }
     if (NOT_FOUND_STATUSES.has(status)) {
-      const detail = axiosErr.response?.data?.detail;
       return {
         category: "not_found",
-        message:
-          typeof detail === "string" && detail.trim().length > 0
-            ? detail
-            : NOT_FOUND_COPY,
+        message: _extractDetail(axiosErr) || NOT_FOUND_COPY,
       };
     }
     if (MODEL_UNAVAILABLE_STATUSES.has(status)) {
-      return { category: "model_unavailable", message: MODEL_UNAVAILABLE_COPY };
+      // Backend services frequently return a structured 503 with
+      // {detail: {error, message}} for "data unavailable for this symbol"
+      // (e.g. FX tickers without yfinance volume). Surface the inner
+      // message when present so the user sees the actual reason rather
+      // than the generic "Model unavailable" fallback.
+      return {
+        category: "model_unavailable",
+        message: _extractDetail(axiosErr) || MODEL_UNAVAILABLE_COPY,
+      };
     }
   }
 

--- a/frontend/lib/analyze/shared-context.tsx
+++ b/frontend/lib/analyze/shared-context.tsx
@@ -91,6 +91,22 @@ const LOADING_HAR_BASELINES: HarBaselinesState = {
   error: null,
 };
 
+function _harBaselineErrorMessage(err: unknown, symbol: string | undefined): string {
+  // Axios attaches the parsed response body to err.response.data. The
+  // /forecast/regime/baselines endpoint returns a structured
+  // { code, detail: { error, message } } payload for unsupported symbols
+  // (status 422). Prefer that human-readable string over the generic
+  // "Request failed with status code 422" axios surfaces by default.
+  const e = err as { response?: { status?: number; data?: { detail?: { message?: string } | string } }; message?: string };
+  const status = e?.response?.status;
+  const detail = e?.response?.data?.detail;
+  const detailMsg = typeof detail === "object" && detail !== null ? detail.message : undefined;
+  if (status === 422 && detailMsg) {
+    return `${detailMsg} (${symbol ?? "this symbol"})`;
+  }
+  return e?.message || "HAR baselines fetch failed";
+}
+
 export function SymbolCalendarProvider({ children }: { children: React.ReactNode }) {
   const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
 
@@ -242,7 +258,7 @@ export function SymbolCalendarProvider({ children }: { children: React.ReactNode
             [symKey]: {
               data: null,
               loading: false,
-              error: (err as Error).message || "HAR baselines fetch failed",
+              error: _harBaselineErrorMessage(err, symbol),
             },
           }));
         });

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -48,7 +48,7 @@ import {
   postAnalyzeAnalogs,
   postAnalyzeMarket,
 } from "@/lib/analyze/api";
-import { DEFAULT_TEXT } from "@/lib/analyze/constants";
+import { DEFAULT_TEXT, HAR_TERCILE_SUPPORTED_SYMBOLS } from "@/lib/analyze/constants";
 import { errorMessage } from "@/lib/analyze/errors";
 import { toStance } from "@/lib/analyze/format";
 import {
@@ -1046,7 +1046,7 @@ export default function WorkspacePage() {
           >
             Forecast accuracy (backtest)
           </p>
-          {request.symbol === "^GSPC" ? (
+          {HAR_TERCILE_SUPPORTED_SYMBOLS.includes(request.symbol) ? (
             <HarAccuracyPanel
               data={harBacktest}
               loading={harBacktestLoading}
@@ -1056,6 +1056,9 @@ export default function WorkspacePage() {
               storageKey="workspace-card:har-accuracy"
             />
           ) : null}
+          {/* RV / QLIKE-DLq backtest remains SPX-only because the
+              QLIKE-DLq artifact pins per-fold coefficients on SPX RV
+              and is not yet refit per asset. */}
           {request.symbol === "^GSPC" ? (
             <RvAccuracyPanel
               data={rvBacktest}


### PR DESCRIPTION
The P1 cutoff guard was wired at serve time in the paper-critical PR; it surfaces a red error toast when the lookback window crosses an FOMC meeting day with a post-14:00 ET bar. Hard-fail is correct for the offline event-dataset builder; at serve time we drop the offending bars and continue.

## Change

- `_is_fomc_day_after_cutoff` returns the boolean the strict assertion uses
- `assert_fomc_day_market_cutoff` still raises; the offline builder remains the strict path
- `fetch_market_snapshot` and `fetch_market_sequence` skip leaky bars via `_filter_leak_safe`
- INFO log records how many bars were dropped per request

## Verification

- `curl -X POST http://localhost:8000/analyze -d '{"text":"...","date":"2026-06-02","symbol":"EURUSD=X","horizon":"10d"}'` returns 200 instead of the leak-cutoff 500