### PR TITLE
UAT 2: meta-tensor safety, navbar rework, favicon

### DIFF
--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -326,12 +326,33 @@ def _get_model() -> ForecasterServingModel:
                 )
             raw_config = payload.get("model_config") if isinstance(payload, dict) else None
             resolved = _coerce_model_config(raw_config)
-            model = build_serving_forecaster(resolved).to(device)
-            if payload is not None:
-                _load_state_dict_loose(model, payload["model_state_dict"], str(BEST_MODEL_PATH))
-            model.eval()  # set inference mode
+            # Build inside an explicit torch.device context so any lazy-init
+            # third-party layers (e.g. HF transformers under
+            # ``init_empty_weights``) materialise their tensors on the real
+            # device instead of staying on ``meta``. A subsequent ``.to(device)``
+            # on a model that holds meta tensors raises the NotImplementedError
+            # "Cannot copy out of meta tensor; no data!" which used to leave the
+            # singleton in a half-built state and break every later /analyze
+            # request until backend restart.
+            try:
+                with torch.device(device):
+                    model = build_serving_forecaster(resolved)
+                model = model.to(device)
+                if payload is not None:
+                    _load_state_dict_loose(
+                        model, payload["model_state_dict"], str(BEST_MODEL_PATH)
+                    )
+                model.eval()  # set inference mode
+            except Exception:
+                # Never publish a half-built model into the singleton; the
+                # next request must be free to rebuild from scratch.
+                _model = None
+                _model_artifact_metadata = None
+                raise
             _model = model
-            _model_artifact_metadata = _checkpoint_metadata(payload, BEST_MODEL_PATH, model=model)
+            _model_artifact_metadata = _checkpoint_metadata(
+                payload, BEST_MODEL_PATH, model=model
+            )
     return _model
 
 

--- a/backend/app/services/forecaster.py
+++ b/backend/app/services/forecaster.py
@@ -339,9 +339,7 @@ def _get_model() -> ForecasterServingModel:
                     model = build_serving_forecaster(resolved)
                 model = model.to(device)
                 if payload is not None:
-                    _load_state_dict_loose(
-                        model, payload["model_state_dict"], str(BEST_MODEL_PATH)
-                    )
+                    _load_state_dict_loose(model, payload["model_state_dict"], str(BEST_MODEL_PATH))
                 model.eval()  # set inference mode
             except Exception:
                 # Never publish a half-built model into the singleton; the
@@ -350,9 +348,7 @@ def _get_model() -> ForecasterServingModel:
                 _model_artifact_metadata = None
                 raise
             _model = model
-            _model_artifact_metadata = _checkpoint_metadata(
-                payload, BEST_MODEL_PATH, model=model
-            )
+            _model_artifact_metadata = _checkpoint_metadata(payload, BEST_MODEL_PATH, model=model)
     return _model
 
 

--- a/frontend/components/shell/command-palette.tsx
+++ b/frontend/components/shell/command-palette.tsx
@@ -58,7 +58,7 @@ const PAGE_ENTRIES = [
   { id: "page-compare", label: "Compare", hint: "/compare", icon: GitCompare, href: "/compare" },
   { id: "page-calendar", label: "Calendar", hint: "/calendar", icon: Calendar, href: "/calendar" },
   { id: "page-performance", label: "Performance", hint: "/performance", icon: LineChart, href: "/performance" },
-  { id: "page-research", label: "Research", hint: "/research", icon: FlaskConical, href: "/research" },
+  { id: "page-research", label: "Labs", hint: "/research", icon: FlaskConical, href: "/research" },
 ];
 
 function toggleTheme() {

--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -7,7 +7,6 @@ import {
   Calendar,
   FlaskConical,
   Gavel,
-  GitCompare,
   Github,
   History as HistoryIcon,
   LineChart,
@@ -25,10 +24,9 @@ const NAV_ITEMS: Array<{ href: string; label: string; icon: React.ComponentType<
   { href: "/", label: "Workspace", icon: Activity },
   { href: "/decisions", label: "Decisions", icon: Gavel },
   { href: "/history", label: "History", icon: HistoryIcon },
-  { href: "/compare", label: "Compare", icon: GitCompare },
   { href: "/calendar", label: "Calendar", icon: Calendar },
   { href: "/performance", label: "Performance", icon: LineChart },
-  { href: "/research", label: "Research", icon: FlaskConical },
+  { href: "/research", label: "Labs", icon: FlaskConical },
 ];
 
 function isActive(currentPath: string, href: string): boolean {

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -3,7 +3,9 @@ import { Html, Head, Main, NextScript } from "next/document";
 export default function Document() {
   return (
     <Html lang="en">
-      <Head />
+      <Head>
+        <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+      </Head>
       <body className="bg-background text-foreground">
         <Main />
         <NextScript />

--- a/frontend/pages/history/index.tsx
+++ b/frontend/pages/history/index.tsx
@@ -296,13 +296,16 @@ export default function HistoryPage() {
     [apiBaseUrl, reload],
   );
 
-  // Collect the available variant / symbol options from the loaded rows.
-  // Symbols also include the static universe so filters work pre-load.
-  const symbolOptions = React.useMemo(() => {
-    const set = new Set<string>(symbolUniverse.map((s) => s.symbol));
-    for (const row of items) set.add(row.symbol);
-    return [...set].sort();
-  }, [items, symbolUniverse]);
+  // Symbol filter mirrors whatever the live ``/symbols`` endpoint
+  // returns so the picker matches the Workspace asset selector. Older
+  // history rows whose symbol no longer appears on /symbols (e.g. a
+  // legacy ticker that was dropped from the universe) are reachable via
+  // search; surfacing them as filter chips would silently widen the
+  // supported set on this page only.
+  const symbolOptions = React.useMemo(
+    () => symbolUniverse.map((s) => s.symbol).sort(),
+    [symbolUniverse],
+  );
 
   const variantOptions = React.useMemo(() => {
     const set = new Set<string>();

--- a/frontend/pages/research.tsx
+++ b/frontend/pages/research.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import Head from "next/head";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { FlaskConical } from "lucide-react";
 import {
@@ -658,21 +659,28 @@ export default function ResearchPage() {
   return (
     <>
       <Head>
-        <title>Research — Fed Pulse</title>
+        <title>Labs — Fed Pulse</title>
       </Head>
       <div className="min-h-screen bg-background text-foreground">
         <Header />
         <StatusBar />
         <main id="main-content" tabIndex={-1} className="container space-y-5 py-6 focus:outline-none">
-          <div className="space-y-1">
+          <div className="space-y-2">
             <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
               <FlaskConical className="h-6 w-6 text-primary" />
-              Research console
+              Labs
             </h1>
             <p className="max-w-2xl text-sm text-muted-foreground">
               Research artefacts the model is built on. The Bake-off compares text encoders.
               The Transfer matrix shows how a model trained on one central bank&apos;s statements
               performs on another&apos;s. Files lists the raw artefact JSONs you can download.
+            </p>
+            <p className="text-sm text-muted-foreground">
+              Diff two analyses side-by-side in{" "}
+              <Link href="/compare" className="font-medium text-primary underline-offset-2 hover:underline">
+                Compare runs
+              </Link>
+              .
             </p>
           </div>
 

--- a/frontend/public/favicon.svg
+++ b/frontend/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#0f172a"/>
+  <path d="M5 17 L11 17 L13 11 L16 22 L19 13 L21 17 L27 17"
+        fill="none"
+        stroke="#0ea5e9"
+        stroke-width="2.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
Six UAT items from the second pass through the dashboard.

## Changes

- **Meta-tensor singleton safety** (`backend/app/services/forecaster.py`)
  - `build_serving_forecaster(...)` now runs inside a `torch.device(device)` context so lazy-init layers materialise on the real device instead of `meta`
  - Any exception during build clears the singleton so the next request can rebuild from scratch instead of inheriting a half-built model
  - Closes the "Analyze pipeline failed: serving runtime error" toast that surfaced after a transient model-build hiccup

- **History asset filter alignment** (`frontend/pages/history/index.tsx`)
  - Filter chips follow the live `/symbols` universe instead of unioning historical-only tickers; matches the Workspace asset picker

- **Navbar rework**
  - Drop `Compare` from the main nav (the diff is rarely surfaced and crowded the bar)
  - Rename `Research` → `Labs` (header + command palette + page title)
  - Surface Compare as a small link inside the Labs landing copy so it stays reachable

- **Favicon** (`frontend/public/favicon.svg` + `_document.tsx` Head wiring)
  - SVG line-chart pulse on slate-900 background

## Out of scope (in answer text, not code)

- `text_embedding_missing` listed under MODEL INPUT CHECK on Settings is **normal** — the LSTM forecaster requires both `text_embedding` (the 768-d pooled vector) and `text_embedding_missing` (the 0/1 gating flag). The contract surface lists both because both are honoured by the model's forward signature.