### PR TITLE
Route prod API calls through /api so the frontend stops 404ing

### DIFF
--- a/compose.prod.yml
+++ b/compose.prod.yml
@@ -21,7 +21,7 @@ services:
       context: .
       dockerfile: Dockerfile.prod
       args:
-        NEXT_PUBLIC_API_URL: https://fedpulse.yusufizzetmurat.com
+        NEXT_PUBLIC_API_URL: https://fedpulse.yusufizzetmurat.com/api
     container_name: fed-pulse-backend
     restart: always
     env_file:
@@ -49,7 +49,7 @@ services:
       context: .
       dockerfile: Dockerfile.prod
       args:
-        NEXT_PUBLIC_API_URL: https://fedpulse.yusufizzetmurat.com
+        NEXT_PUBLIC_API_URL: https://fedpulse.yusufizzetmurat.com/api
     container_name: fed-pulse-frontend
     restart: always
     # The FE entrypoint never touches HF Hub (FED_PULSE_SKIP_EAGER_PULL=1)
@@ -62,7 +62,7 @@ services:
       - NODE_ENV=production
       - FED_PULSE_SVC_MASK=frontend
       - FED_PULSE_SKIP_EAGER_PULL=1
-      - NEXT_PUBLIC_API_URL=https://fedpulse.yusufizzetmurat.com
+      - NEXT_PUBLIC_API_URL=https://fedpulse.yusufizzetmurat.com/api
       - HF_HOME=/home/fedpulse/.cache/huggingface
       - HUGGINGFACE_HUB_CACHE=/home/fedpulse/.cache/huggingface
     volumes:

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -64,10 +64,13 @@ fedpulse.yusufizzetmurat.com {
     # include the /api prefix on ``NEXT_PUBLIC_API_URL`` used to
     # surface as "no model files on disk" because every API call
     # fell through to the Next.js 404 page. These prefixes mirror
-    # the backend route surface (see ``backend/app/main.py``) so a
-    # bare-domain call still reaches the backend instead of 404ing
-    # at the frontend. New backend routes need to be listed here.
-    @backend_routes path /analyze* /symbols /settings/* /forecast/* /forecasts/* /history* /fomc/* /research/* /evaluation/* /trajectory* /documents/*
+    # the backend route surface (see ``backend/app/main.py``), MINUS
+    # any prefix that doubles as a Next.js page route — /history and
+    # /documents/* are browser-navigable pages, so forwarding them
+    # here would return JSON to a user clicking the nav link. New
+    # backend routes only get listed here when the frontend has no
+    # page at the same prefix.
+    @backend_routes path /analyze* /symbols /settings/* /forecast/* /forecasts/* /fomc/* /research/* /evaluation/* /trajectory*
     handle @backend_routes {
         reverse_proxy backend:8000 {
             transport http {

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -60,6 +60,23 @@ fedpulse.yusufizzetmurat.com {
         }
     }
 
+    # Defence-in-depth allowlist: a frontend build that forgets to
+    # include the /api prefix on ``NEXT_PUBLIC_API_URL`` used to
+    # surface as "no model files on disk" because every API call
+    # fell through to the Next.js 404 page. These prefixes mirror
+    # the backend route surface (see ``backend/app/main.py``) so a
+    # bare-domain call still reaches the backend instead of 404ing
+    # at the frontend. New backend routes need to be listed here.
+    @backend_routes path /analyze* /symbols /settings/* /forecast/* /forecasts/* /history* /fomc/* /research/* /evaluation/* /trajectory* /documents/*
+    handle @backend_routes {
+        reverse_proxy backend:8000 {
+            transport http {
+                read_timeout 120s
+                write_timeout 120s
+            }
+        }
+    }
+
     # Everything else is the Next.js standalone server.
     handle {
         reverse_proxy frontend:3000


### PR DESCRIPTION
## Summary
- compose.prod.yml: bake /api into NEXT_PUBLIC_API_URL across both build args and the runtime env so axios calls hit the Caddy-proxied path
- deploy/Caddyfile: allowlist backend route prefixes that have no Next.js page collision as defence-in-depth against a future build dropping the /api suffix

## Why
Production was showing "no model files on disk" and most data tabs were blank even though /api/health reported the backend was warm with forecaster_best.pt + xbank-DAPT loaded. The frontend image was built with NEXT_PUBLIC_API_URL set to the bare apex, so every call landed on Next.js and 404'd.

## Test plan
- [ ] curl https://fedpulse.yusufizzetmurat.com/api/health returns 200 (already does)
- [ ] After deploy: open / and confirm symbol list + analyze flow load
- [ ] After deploy: open /settings and confirm model files + checkpoints render