### PR TITLE
Drop post-cutoff bars in offline RV builder + refresh stance preregistration

### DIFF
--- a/backend/app/data/intraday_realized.py
+++ b/backend/app/data/intraday_realized.py
@@ -78,10 +78,25 @@ def daily_realized_measures(
 
 
 def _measures_by_day(bars: list[Any]) -> dict[str, dict[str, float]]:
-    """Group AV intraday bars by ET date → daily realized measures."""
+    """Group AV intraday bars by ET date → daily realized measures.
+
+    On FOMC meeting days, bars stamped strictly after 14:00 ET are dropped
+    before the daily reduction. The 2pm statement release embeds the policy
+    decision into every later intraday return, so summing those into the
+    daily realized measure would back-door the announcement into the HAR
+    feature frame. The cutoff mirrors the serving path's
+    :func:`app.services.market_data._is_fomc_day_after_cutoff`.
+    """
+
+    from datetime import datetime as _datetime
+
+    from app.services.market_data import FOMC_ZONE, _is_fomc_day_after_cutoff
 
     by_date: dict[str, list[Any]] = {}
     for bar in bars:
+        ts_et = _datetime.fromisoformat(bar.timestamp_et).replace(tzinfo=FOMC_ZONE)
+        if _is_fomc_day_after_cutoff(ts_et):
+            continue
         by_date.setdefault(bar.timestamp_et[:10], []).append(bar)
     out: dict[str, dict[str, float]] = {}
     for date_iso, day in by_date.items():

--- a/docs/research/stance-instrument-validity-preregistration.md
+++ b/docs/research/stance-instrument-validity-preregistration.md
@@ -4,34 +4,34 @@
 
 ## Result (2026-06-02)
 
-n=130 meetings 2010–2026 (cut 9 / hold 101 / hike 20).
+n=122 meetings 2011-01-26..2026-04-29 (cut 9 / hold 93 / hike 20).
 
 | test | value | read |
 |---|---|---|
-| **PRIMARY** Spearman ρ(s, Δff) | **+0.283**, perm-p **0.0006**, CI95 **[0.081, 0.459]** | significant → **VALID**, but *weak* (0.2–0.4) |
-| (a) AUC hike-vs-cut | **0.800**, CI95 [0.62, 0.94] | **strong** discrimination at the extremes |
-| (b) ordinal ρ(s, {cut<hold<hike}) | +0.276 | monotone but weak |
-| (c) leading ρ(sₜ, Δff₊₁) | +0.212, p 0.008 | weak forward alignment (survives Bonferroni) |
-| diagnostic: within-holds ρ(sₜ, Δff₊₁) | +0.047 | **no** signalling inside the hold regime |
-| mean s by action | cut **−0.84** / hold **−0.82** / hike **+0.03** | the tell ↓ |
+| **PRIMARY** Spearman ρ(s, Δff) | **+0.357**, perm-p **0.0002**, CI95 **[0.142, 0.534]** | significant → **VALID**, low-moderate strength |
+| (a) AUC hike-vs-cut | **0.794**, CI95 [0.606, 0.933] | strong discrimination at the extremes |
+| (b) ordinal ρ(s, {cut<hold<hike}) | +0.350 | monotone, low-moderate |
+| (c) leading ρ(sₜ, Δff₊₁) | +0.272, perm-p 0.0007 | forward alignment survives Bonferroni |
+| diagnostic: within-holds ρ(sₜ, Δff₊₁) | +0.151 | weak signalling inside the hold regime |
+| mean s by action | cut **−0.287** / hold **−0.655** / hike **+0.385** | hike clears neutral; cut/hold ordering inverted |
 
 **Verdict: the stance instrument is a VALID measure of policy hawkishness
-(primary significant, both decision-rule conditions met) — but weak and
-asymmetric.** It is essentially a **hike detector**: it separates hikes from cuts
-well (AUC 0.80), but **cannot distinguish a hold from a cut** (mean s −0.82 vs
-−0.84, nearly identical) and is **dovish-skewed in absolute scale** (even hikes
-barely clear neutral). Its validity is carried by the hawkish extreme; the dovish
-end is undifferentiated, and it carries no forward guidance within the long hold
-regime (within-holds lead ≈ 0).
+(primary significant, both decision-rule conditions met) — but asymmetric.** It
+is essentially a **hike detector**: it separates hikes from cuts well (AUC
+0.794), and the hike end now clears neutral cleanly (mean s +0.385). The
+dovish-end ordering is **inverted**: cuts read more hawkish than holds (mean s
+−0.287 vs −0.655), so the instrument cannot be used as a fine-grained
+cut-vs-hold discriminator and the within-holds lead is weak (ρ +0.151).
 
 **What this sharpens (honest descriptive scope):** the dashboard's stance surface
 can credibly flag *hiking-hawkish* statements, but should NOT be read as a
 fine-grained hawk–dove thermometer on the dovish side, nor imply "more dovish
 than the last hold." Concrete instrument-improvement leads: (1) the dovish-end
-resolution (hold vs cut) is where the head is blind — a targeted re-label/training
-focus there would add the most; (2) the absolute scale is mis-centred (dovish
-bias) and would benefit from recalibration. Artifact:
-`data/artifacts/stance_instrument_validity/result.json`.
+resolution (cut vs hold) is where the head is blind — a targeted re-label /
+training focus there would add the most; (2) the inverted cut/hold ordering
+suggests the cut-associated statements carry hawkish framing that the classifier
+picks up, so re-labelling around concrete policy-direction cues would help.
+Artifact: `data/artifacts/stance_instrument_validity/result.json`.
 
 ## Motivation (adventure 1 — text as measurement)
 

--- a/tests/unit/test_intraday_realized.py
+++ b/tests/unit/test_intraday_realized.py
@@ -52,3 +52,40 @@ def test_measures_by_day_groups_dates() -> None:
     out = ir._measures_by_day(bars)
     assert set(out) == {"2020-01-02", "2020-01-03"}
     assert out["2020-01-02"]["rv"] > 0 and "rvol" in out["2020-01-02"]
+
+
+def test_measures_by_day_drops_post_cutoff_bars_on_fomc_days(monkeypatch) -> None:
+    """Bars strictly after 14:00 ET on an FOMC meeting day must not enter the
+    daily reduction. The 14:00 bar itself stays (the cutoff is strict), and a
+    non-FOMC day keeps every bar regardless of the time-of-day stamp."""
+
+    from datetime import date as _date
+
+    from app.services import market_data as _md
+
+    monkeypatch.setattr(_md, "_fomc_days", lambda: frozenset({_date(2020, 1, 2)}))
+
+    rng = np.random.default_rng(2)
+    bars = []
+    # 9:00 through 16:00 in 5-minute increments → 85 bars per day; well above
+    # MIN_RETURNS_PER_DAY so both days survive the per-day reduction.
+    for hh in range(9, 16):
+        for mm in range(0, 60, 5):
+            for d in ("2020-01-02", "2020-01-03"):
+                p = float(100 * np.exp(rng.normal(0, 0.001)))
+                bars.append(
+                    IntradayBar(f"{d} {hh:02d}:{mm:02d}:00", p, p * 1.001, p * 0.999, p, 1.0)
+                )
+    for d in ("2020-01-02", "2020-01-03"):
+        p = float(100 * np.exp(rng.normal(0, 0.001)))
+        bars.append(IntradayBar(f"{d} 16:00:00", p, p * 1.001, p * 0.999, p, 1.0))
+
+    out = ir._measures_by_day(bars)
+    # Both dates survive the reduction.
+    assert set(out) == {"2020-01-02", "2020-01-03"}
+    # Non-FOMC day keeps all 85 bars → 84 returns.
+    assert out["2020-01-03"]["n_ret"] == 84
+    # FOMC day keeps 9:00 through 14:00 inclusive (the 14:00 bar stays
+    # because the cutoff is strict-greater-than). That's 5 hours × 12 bars
+    # plus the 14:00 bar = 61 bars → 60 returns.
+    assert out["2020-01-02"]["n_ret"] == 60

--- a/tests/unit/test_intraday_realized.py
+++ b/tests/unit/test_intraday_realized.py
@@ -63,7 +63,11 @@ def test_measures_by_day_drops_post_cutoff_bars_on_fomc_days(monkeypatch) -> Non
 
     from app.services import market_data as _md
 
-    monkeypatch.setattr(_md, "_fomc_days", lambda: frozenset({_date(2020, 1, 2)}))
+    # Patch the un-cached predicate rather than ``_fomc_days``. The latter is
+    # decorated with ``@lru_cache`` and a name-level monkeypatch can leave the
+    # original wrapper holding a stale cached set for unrelated tests in the
+    # same session.
+    monkeypatch.setattr(_md, "is_fomc_day", lambda d: d == _date(2020, 1, 2))
 
     rng = np.random.default_rng(2)
     bars = []


### PR DESCRIPTION
## Summary
- backend/app/data/intraday_realized.py: filter FOMC-day bars stamped strictly after 14:00 ET before the daily reduction so HAR/HARQ training data cannot embed the 2pm policy decision through lagged RV
- tests/unit/test_intraday_realized.py: covers the FOMC vs non-FOMC bar count after filtering by patching the un-cached is_fomc_day predicate
- docs/research/stance-instrument-validity-preregistration.md: refresh the Result table to the current xbank-DAPT artifact in data/artifacts/stance_instrument_validity/result.json

## Test plan
- [ ] docker compose run --rm backend pytest tests/unit/test_intraday_realized.py