### PR TITLE
Eager-pull trajectory and retrieval bundles into /data so prod stops needing manual SCP

### DIFF
--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -267,7 +267,7 @@ def hydrate() -> None:
     for artefact in eager_artefacts():
         files = _ARTEFACT_FILES.get(artefact.name)
         if files is None:
-            logger.debug("eager-pull: %r has no MODELS_DIR copy mapping; skip", artefact.name)
+            logger.debug("eager-pull: %r not in copy map; skip", artefact.name)
             continue
         _hydrate_one(artefact, files, MODELS_DIR, DATA_DIR, token, parse_hf_uri, download_snapshot)
 

--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -3,27 +3,30 @@
 Runs from the container entrypoint before uvicorn starts. For each
 eager artefact mapped in :data:`_ARTEFACT_FILES`, downloads the pinned
 revision via ``huggingface_hub.snapshot_download`` and copies the named
-files into ``MODELS_DIR`` only when the destination is absent. A dev
-box with a freshly trained checkpoint keeps it — the shim never
-clobbers a file already on disk. The shim never raises out: on
-missing token / network failure / 404 it logs and returns so the
-cold-start bootstrap in :mod:`app.main` still runs on first
+files into ``MODELS_DIR`` or ``DATA_DIR`` only when the destination is
+absent. A dev box with a freshly trained checkpoint keeps it — the
+shim never clobbers a file already on disk. The shim never raises
+out: on missing token / network failure / 404 it logs and returns so
+the cold-start bootstrap in :mod:`app.main` still runs on first
 ``/analyze``.
 
-Mapping policy: only artefacts whose files are read directly out of
-``MODELS_DIR`` appear in :data:`_ARTEFACT_FILES`. Each entry is either
-a flat filename (snapshot path == destination path relative to
-``MODELS_DIR``) or a ``(snapshot_name, dst_relpath)`` pair when the
-file must land in a sub-directory of ``MODELS_DIR``; the tuple form
-is what ``volume_har_canonical`` uses to drop its JSON spec under
-``models/volume_har/``. ``encoder_canonical``, ``retrieval``,
-``trajectory`` lazy-load via their own caches and are intentionally
-absent so they do not trip the copy step.
-``rates_heads_canonical`` historically pointed at the same
-``forecaster_best.pt`` file as ``forecaster_canonical``; with the LSTM
-canonical revision (``7ab0a873``) rates heads are absent, so we leave
-``rates_heads_canonical`` out of the copy map to avoid clobbering the
-forecaster path.
+Mapping policy: each entry is either a flat filename (snapshot path
+== destination path relative to ``MODELS_DIR``) or a
+``(snapshot_name, dst_relpath)`` pair when the file must land in a
+sub-directory, or a ``(snapshot_name, dst_relpath, dst_root)`` triple
+when the destination is rooted at ``DATA_DIR`` instead of
+``MODELS_DIR``. ``dst_root`` is ``"MODELS"`` (default, backwards
+compatible) or ``"DATA"``. ``volume_har_canonical`` uses the pair
+form to drop its JSON spec under ``models/volume_har/``;
+``trajectory_bundle`` and ``retrieval_bundle`` use the triple form so
+their files land under ``data/artifacts/...`` where
+:mod:`app.services.trajectory` and :mod:`app.services.analogs` read
+them. ``encoder_canonical`` lazy-loads via the HF cache and is
+intentionally absent. ``rates_heads_canonical`` historically pointed
+at the same ``forecaster_best.pt`` file as ``forecaster_canonical``;
+with the LSTM canonical revision (``7ab0a873``) rates heads are
+absent, so we leave ``rates_heads_canonical`` out of the copy map to
+avoid clobbering the forecaster path.
 """
 
 from __future__ import annotations
@@ -50,15 +53,28 @@ except Exception:  # pragma: no cover - import-time defensive
     snapshot_download = None
 
 # Artefact-name -> tuple of filenames to extract from the snapshot and
-# copy into MODELS_DIR. Anything not listed is left in the HF cache.
+# copy into ``MODELS_DIR`` or ``DATA_DIR``. Anything not listed is left
+# in the HF cache.
 #
-# Each entry is either a flat filename (snapshot path == destination
-# path relative to ``MODELS_DIR``) or a ``(snapshot_name, dst_relpath)``
-# pair when the destination needs to land in a sub-directory under
-# ``MODELS_DIR``. The ``volume_har_canonical`` artefact uses the pair
-# form so the JSON spec sits in ``models/volume_har/`` where
-# :mod:`app.services.volume_forecaster` reads it.
-_ARTEFACT_FILES: dict[str, tuple[str | tuple[str, str], ...]] = {
+# Each entry is one of:
+#   - a flat filename (snapshot path == destination path relative to
+#     ``MODELS_DIR``);
+#   - a ``(snapshot_name, dst_relpath)`` pair when the destination
+#     needs to land in a sub-directory under ``MODELS_DIR``
+#     (``volume_har_canonical`` uses this form);
+#   - a ``(snapshot_name, dst_relpath, dst_root)`` triple when the
+#     destination is rooted at ``DATA_DIR`` instead of ``MODELS_DIR``;
+#     ``dst_root`` is ``"MODELS"`` (default) or ``"DATA"``.
+#
+# ``trajectory_bundle`` and ``retrieval_bundle`` use the triple form
+# so their files land under ``data/artifacts/...`` where the trajectory
+# and analogs services read them.
+_TRAJECTORY_BUNDLE_RELDIR = "artifacts/trajectory/trajectory_transformer"
+_RETRIEVAL_BUNDLE_RELDIR = "artifacts/retrieval/finbert_fed_adjacent_xbank_dapt_retrieval"
+
+_ARTEFACT_FILES: dict[
+    str, tuple[str | tuple[str, str] | tuple[str, str, str], ...]
+] = {
     "forecaster_canonical": (
         "forecaster_best.pt",
         "forecaster_best.pt.inference_contract.json",
@@ -67,25 +83,85 @@ _ARTEFACT_FILES: dict[str, tuple[str | tuple[str, str], ...]] = {
         "forecaster_calibration_fresh.pt",
     ),
     "volume_har_canonical": (("volume_har_artifact.json", "volume_har/volume_har_artifact.json"),),
+    "trajectory_bundle": (
+        ("embedding_index.parquet", f"{_TRAJECTORY_BUNDLE_RELDIR}/embedding_index.parquet", "DATA"),
+        ("embedding_index.npz", f"{_TRAJECTORY_BUNDLE_RELDIR}/embedding_index.npz", "DATA"),
+        ("model.pt", f"{_TRAJECTORY_BUNDLE_RELDIR}/model.pt", "DATA"),
+        ("manifest.json", f"{_TRAJECTORY_BUNDLE_RELDIR}/manifest.json", "DATA"),
+        ("conformal.json", f"{_TRAJECTORY_BUNDLE_RELDIR}/conformal.json", "DATA"),
+        ("metrics.json", f"{_TRAJECTORY_BUNDLE_RELDIR}/metrics.json", "DATA"),
+    ),
+    "retrieval_bundle": (
+        ("embeddings.npy", f"{_RETRIEVAL_BUNDLE_RELDIR}/embeddings.npy", "DATA"),
+        ("index.parquet", f"{_RETRIEVAL_BUNDLE_RELDIR}/index.parquet", "DATA"),
+        ("manifest.json", f"{_RETRIEVAL_BUNDLE_RELDIR}/manifest.json", "DATA"),
+        ("training_args.json", f"{_RETRIEVAL_BUNDLE_RELDIR}/training_args.json", "DATA"),
+        ("checkpoint/config.json", f"{_RETRIEVAL_BUNDLE_RELDIR}/checkpoint/config.json", "DATA"),
+        (
+            "checkpoint/config_sentence_transformers.json",
+            f"{_RETRIEVAL_BUNDLE_RELDIR}/checkpoint/config_sentence_transformers.json",
+            "DATA",
+        ),
+        (
+            "checkpoint/model.safetensors",
+            f"{_RETRIEVAL_BUNDLE_RELDIR}/checkpoint/model.safetensors",
+            "DATA",
+        ),
+        ("checkpoint/modules.json", f"{_RETRIEVAL_BUNDLE_RELDIR}/checkpoint/modules.json", "DATA"),
+        (
+            "checkpoint/sentence_bert_config.json",
+            f"{_RETRIEVAL_BUNDLE_RELDIR}/checkpoint/sentence_bert_config.json",
+            "DATA",
+        ),
+        (
+            "checkpoint/tokenizer.json",
+            f"{_RETRIEVAL_BUNDLE_RELDIR}/checkpoint/tokenizer.json",
+            "DATA",
+        ),
+        (
+            "checkpoint/tokenizer_config.json",
+            f"{_RETRIEVAL_BUNDLE_RELDIR}/checkpoint/tokenizer_config.json",
+            "DATA",
+        ),
+        (
+            "checkpoint/1_Pooling/config.json",
+            f"{_RETRIEVAL_BUNDLE_RELDIR}/checkpoint/1_Pooling/config.json",
+            "DATA",
+        ),
+        ("checkpoint/README.md", f"{_RETRIEVAL_BUNDLE_RELDIR}/checkpoint/README.md", "DATA"),
+    ),
 }
 
 
-def _split_entry(entry: str | tuple[str, str]) -> tuple[str, str]:
-    """Return ``(snapshot_relpath, dst_relpath)`` for one mapping entry.
+# ``dst_root`` values recognised in the triple-form entry. Anything
+# else is logged and the entry is skipped.
+_DST_ROOT_MODELS = "MODELS"
+_DST_ROOT_DATA = "DATA"
 
-    Plain strings collapse to ``(entry, entry)`` so the legacy flat-file
-    mapping is byte-identical.
+
+def _split_entry(
+    entry: str | tuple[str, str] | tuple[str, str, str],
+) -> tuple[str, str, str]:
+    """Return ``(snapshot_relpath, dst_relpath, dst_root)`` for one mapping entry.
+
+    Plain strings collapse to ``(entry, entry, "MODELS")`` so the legacy
+    flat-file mapping is byte-identical. Two-tuples expand to a default
+    ``"MODELS"`` root so the existing ``volume_har_canonical`` mapping
+    keeps working unchanged.
     """
 
     if isinstance(entry, tuple):
-        return entry[0], entry[1]
-    return entry, entry
+        if len(entry) == 3:
+            return entry[0], entry[1], entry[2]
+        return entry[0], entry[1], _DST_ROOT_MODELS
+    return entry, entry, _DST_ROOT_MODELS
 
 
-def _hydrate_one(  # noqa: PLR0913 - six injected params is the natural shape here
+def _hydrate_one(  # noqa: PLR0913 - seven injected params is the natural shape here
     artefact: Any,
-    files: tuple[str | tuple[str, str], ...],
+    files: tuple[str | tuple[str, str] | tuple[str, str, str], ...],
     models_dir: Path,
+    data_dir: Path,
     token: str,
     parse_hf_uri: Callable[[str], Any],
     download_snapshot: Callable[..., str],
@@ -100,8 +176,8 @@ def _hydrate_one(  # noqa: PLR0913 - six injected params is the natural shape he
         )
         return
 
-    pairs = [_split_entry(entry) for entry in files]
-    snapshot_names = [src_name for src_name, _ in pairs]
+    triples = [_split_entry(entry) for entry in files]
+    snapshot_names = [src_name for src_name, _, _ in triples]
 
     revision = artefact.revision or None
     try:
@@ -122,9 +198,19 @@ def _hydrate_one(  # noqa: PLR0913 - six injected params is the natural shape he
         )
         return
 
-    for src_name, dst_relpath in pairs:
+    roots = {_DST_ROOT_MODELS: models_dir, _DST_ROOT_DATA: data_dir}
+    for src_name, dst_relpath, dst_root in triples:
+        root = roots.get(dst_root)
+        if root is None:
+            logger.warning(
+                "eager-pull: unknown dst_root %r for %s in %s; skip",
+                dst_root,
+                dst_relpath,
+                artefact.hf_uri,
+            )
+            continue
         src = Path(snapshot_dir) / src_name
-        dst = models_dir / dst_relpath
+        dst = root / dst_relpath
         if not src.exists():
             logger.warning(
                 "eager-pull: %r missing from snapshot of %s; skip",
@@ -155,6 +241,7 @@ def hydrate() -> None:
     """Pull every mapped eager artefact, copy each named file if absent."""
 
     try:
+        from app.config import DATA_DIR
         from app.models.config import MODELS_DIR
         from app.models.registry import eager_artefacts, parse_hf_uri
     except Exception:
@@ -177,13 +264,16 @@ def hydrate() -> None:
         return
 
     MODELS_DIR.mkdir(parents=True, exist_ok=True)
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
 
     for artefact in eager_artefacts():
         files = _ARTEFACT_FILES.get(artefact.name)
         if files is None:
             logger.debug("eager-pull: %r has no MODELS_DIR copy mapping; skip", artefact.name)
             continue
-        _hydrate_one(artefact, files, MODELS_DIR, token, parse_hf_uri, download_snapshot)
+        _hydrate_one(
+            artefact, files, MODELS_DIR, DATA_DIR, token, parse_hf_uri, download_snapshot
+        )
 
 
 def main() -> int:

--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -72,9 +72,7 @@ except Exception:  # pragma: no cover - import-time defensive
 _TRAJECTORY_BUNDLE_RELDIR = "artifacts/trajectory/trajectory_transformer"
 _RETRIEVAL_BUNDLE_RELDIR = "artifacts/retrieval/finbert_fed_adjacent_xbank_dapt_retrieval"
 
-_ARTEFACT_FILES: dict[
-    str, tuple[str | tuple[str, str] | tuple[str, str, str], ...]
-] = {
+_ARTEFACT_FILES: dict[str, tuple[str | tuple[str, str] | tuple[str, str, str], ...]] = {
     "forecaster_canonical": (
         "forecaster_best.pt",
         "forecaster_best.pt.inference_contract.json",
@@ -271,9 +269,7 @@ def hydrate() -> None:
         if files is None:
             logger.debug("eager-pull: %r has no MODELS_DIR copy mapping; skip", artefact.name)
             continue
-        _hydrate_one(
-            artefact, files, MODELS_DIR, DATA_DIR, token, parse_hf_uri, download_snapshot
-        )
+        _hydrate_one(artefact, files, MODELS_DIR, DATA_DIR, token, parse_hf_uri, download_snapshot)
 
 
 def main() -> int:

--- a/tests/unit/test_boot_eager_pull.py
+++ b/tests/unit/test_boot_eager_pull.py
@@ -178,19 +178,35 @@ def test_main_returns_zero_even_on_unexpected_error(
     assert eager_pull.main() == 0
 
 
-def test_split_entry_plain_string_collapses_to_pair() -> None:
-    """A flat filename maps to ``(name, name)`` — both sides identical."""
+def test_split_entry_plain_string_collapses_to_triple() -> None:
+    """A flat filename maps to ``(name, name, "MODELS")`` — the legacy
+    flat-file mapping defaults to the ``MODELS_DIR`` root.
+    """
 
     assert eager_pull._split_entry("forecaster_best.pt") == (
         "forecaster_best.pt",
         "forecaster_best.pt",
+        "MODELS",
     )
 
 
-def test_split_entry_tuple_form_returns_src_and_dst() -> None:
-    """A ``(snapshot_name, dst_relpath)`` pair is preserved as-is."""
+def test_split_entry_pair_form_defaults_to_models_root() -> None:
+    """A ``(snapshot_name, dst_relpath)`` pair expands to a ``"MODELS"``
+    root so the existing ``volume_har_canonical`` mapping is unchanged.
+    """
 
     entry = ("volume_har_artifact.json", "volume_har/volume_har_artifact.json")
+    assert eager_pull._split_entry(entry) == (
+        "volume_har_artifact.json",
+        "volume_har/volume_har_artifact.json",
+        "MODELS",
+    )
+
+
+def test_split_entry_triple_form_returns_src_dst_root() -> None:
+    """A ``(snapshot_name, dst_relpath, dst_root)`` triple is preserved as-is."""
+
+    entry = ("model.pt", "artifacts/trajectory/trajectory_transformer/model.pt", "DATA")
     assert eager_pull._split_entry(entry) == entry
 
 

--- a/tests/unit/test_eager_pull.py
+++ b/tests/unit/test_eager_pull.py
@@ -1,0 +1,282 @@
+"""Behavioural tests for the ``DATA_DIR`` destination in the eager-pull shim.
+
+These cover the triple-form mapping ``(snapshot_name, dst_relpath, "DATA")``
+used by ``trajectory_bundle`` and ``retrieval_bundle``, which land their
+files under ``DATA_DIR / artifacts / ...`` instead of ``MODELS_DIR``.
+The shim must:
+
+- copy files into ``DATA_DIR`` when ``dst_root == "DATA"``;
+- leave ``MODELS_DIR`` untouched for those entries;
+- create nested sub-directories (e.g. ``checkpoint/1_Pooling/``);
+- still honour the "no overwrite" rule for files already on disk;
+- skip an entry with an unknown ``dst_root`` value rather than raise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.boot import eager_pull
+from app.models.registry import ArtefactRef
+
+
+@pytest.fixture()
+def models_and_data_dirs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> tuple[Path, Path]:
+    models = tmp_path / "models"
+    data = tmp_path / "data"
+    models.mkdir()
+    data.mkdir()
+    monkeypatch.setattr("app.models.config.MODELS_DIR", models, raising=True)
+    monkeypatch.setattr("app.config.DATA_DIR", data, raising=True)
+    return models, data
+
+
+def _trajectory_artefact() -> ArtefactRef:
+    return ArtefactRef(
+        name="trajectory_bundle",
+        hf_uri="hf://yusufizzetmurat/fed-pulse-trajectory",
+        revision="df7ccaac07473dfff4e1a62d557a6979d5077304",
+        eager=True,
+        description="",
+        inference_features=(),
+    )
+
+
+def _retrieval_artefact() -> ArtefactRef:
+    return ArtefactRef(
+        name="retrieval_bundle",
+        hf_uri="hf://yusufizzetmurat/fed-pulse-retrieval",
+        revision="a4693b818e4e2a738f3e32c844f45c651424ee3e",
+        eager=True,
+        description="",
+        inference_features=(),
+    )
+
+
+def test_trajectory_bundle_lands_under_data_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    models_and_data_dirs: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    """Every ``trajectory_bundle`` file is copied into ``DATA_DIR``
+    and the ``MODELS_DIR`` tree stays empty for these entries.
+    """
+
+    models, data = models_and_data_dirs
+    monkeypatch.setenv("HF_TOKEN", "stub")
+
+    snapshot = tmp_path / "snap_trajectory"
+    snapshot.mkdir()
+    for src_name, _, _ in (
+        eager_pull._split_entry(e) for e in eager_pull._ARTEFACT_FILES["trajectory_bundle"]
+    ):
+        (snapshot / src_name).write_bytes(b"FROM_HF_" + src_name.encode())
+
+    monkeypatch.setattr(
+        "app.boot.eager_pull.snapshot_download",
+        lambda **kwargs: str(snapshot),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.models.registry.eager_artefacts",
+        lambda: [_trajectory_artefact()],
+    )
+
+    eager_pull.hydrate()
+
+    bundle_dir = data / "artifacts" / "trajectory" / "trajectory_transformer"
+    for src_name, dst_relpath, dst_root in (
+        eager_pull._split_entry(e) for e in eager_pull._ARTEFACT_FILES["trajectory_bundle"]
+    ):
+        assert dst_root == "DATA"
+        assert (data / dst_relpath).read_bytes() == b"FROM_HF_" + src_name.encode()
+    # The model checkpoint, the canonical "must exist" payload, is the
+    # spot-check most likely to regress on a path-build bug.
+    assert (bundle_dir / "model.pt").exists()
+    # MODELS_DIR must not see any of these files — the whole point of
+    # the triple form is to route them elsewhere.
+    assert list(models.iterdir()) == []
+
+
+def test_retrieval_bundle_creates_nested_checkpoint_subdirs(
+    monkeypatch: pytest.MonkeyPatch,
+    models_and_data_dirs: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    """The retrieval bundle has files two levels deep
+    (``checkpoint/1_Pooling/config.json``) — the shim must mkdir those
+    intermediate directories before copying.
+    """
+
+    models, data = models_and_data_dirs
+    monkeypatch.setenv("HF_TOKEN", "stub")
+
+    snapshot = tmp_path / "snap_retrieval"
+    snapshot.mkdir()
+    for src_name, _, _ in (
+        eager_pull._split_entry(e) for e in eager_pull._ARTEFACT_FILES["retrieval_bundle"]
+    ):
+        src_path = snapshot / src_name
+        src_path.parent.mkdir(parents=True, exist_ok=True)
+        src_path.write_bytes(b"FROM_HF_" + src_name.encode())
+
+    captured: dict[str, Any] = {}
+
+    def _fake_snapshot_download(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return str(snapshot)
+
+    monkeypatch.setattr(
+        "app.boot.eager_pull.snapshot_download",
+        _fake_snapshot_download,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.models.registry.eager_artefacts",
+        lambda: [_retrieval_artefact()],
+    )
+
+    eager_pull.hydrate()
+
+    bundle_dir = data / "artifacts" / "retrieval" / "finbert_fed_adjacent_xbank_dapt_retrieval"
+    assert (bundle_dir / "embeddings.npy").read_bytes() == b"FROM_HF_embeddings.npy"
+    assert (bundle_dir / "checkpoint" / "model.safetensors").exists()
+    assert (
+        bundle_dir / "checkpoint" / "1_Pooling" / "config.json"
+    ).read_bytes() == b"FROM_HF_checkpoint/1_Pooling/config.json"
+    # ``allow_patterns`` must carry snapshot-side (nested) paths so HF
+    # serves the checkpoint/* tree at all.
+    allow = captured.get("allow_patterns") or []
+    assert "checkpoint/1_Pooling/config.json" in allow
+    assert "checkpoint/model.safetensors" in allow
+    assert list(models.iterdir()) == []
+
+
+def test_data_root_entry_does_not_overwrite_existing_file(
+    monkeypatch: pytest.MonkeyPatch,
+    models_and_data_dirs: tuple[Path, Path],
+    tmp_path: Path,
+) -> None:
+    """A locally-trained ``model.pt`` survives an eager pull — the no
+    overwrite contract holds for the ``DATA`` root the same way it does
+    for ``MODELS``.
+    """
+
+    _, data = models_and_data_dirs
+    monkeypatch.setenv("HF_TOKEN", "stub")
+
+    snapshot = tmp_path / "snap"
+    snapshot.mkdir()
+    for src_name, _, _ in (
+        eager_pull._split_entry(e) for e in eager_pull._ARTEFACT_FILES["trajectory_bundle"]
+    ):
+        (snapshot / src_name).write_bytes(b"FROM_HF")
+
+    pre = data / "artifacts" / "trajectory" / "trajectory_transformer" / "model.pt"
+    pre.parent.mkdir(parents=True, exist_ok=True)
+    pre.write_bytes(b"LOCAL_TRAINED")
+
+    monkeypatch.setattr(
+        "app.boot.eager_pull.snapshot_download",
+        lambda **kwargs: str(snapshot),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.models.registry.eager_artefacts",
+        lambda: [_trajectory_artefact()],
+    )
+
+    eager_pull.hydrate()
+    assert pre.read_bytes() == b"LOCAL_TRAINED"
+    # Other files still hydrate.
+    assert (pre.parent / "embedding_index.parquet").read_bytes() == b"FROM_HF"
+
+
+def test_unknown_dst_root_is_logged_not_raised(
+    monkeypatch: pytest.MonkeyPatch,
+    models_and_data_dirs: tuple[Path, Path],
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An entry pointing at an unrecognised root logs and skips rather
+    than raising — the shim's fail-open contract must hold even when
+    the mapping itself is malformed.
+    """
+
+    models, data = models_and_data_dirs
+    monkeypatch.setenv("HF_TOKEN", "stub")
+
+    snapshot = tmp_path / "snap"
+    snapshot.mkdir()
+    (snapshot / "junk.txt").write_bytes(b"x")
+
+    monkeypatch.setattr(
+        "app.boot.eager_pull._ARTEFACT_FILES",
+        {"junk_artefact": (("junk.txt", "junk.txt", "UNKNOWN"),)},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.boot.eager_pull.snapshot_download",
+        lambda **kwargs: str(snapshot),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "app.models.registry.eager_artefacts",
+        lambda: [
+            ArtefactRef(
+                name="junk_artefact",
+                hf_uri="hf://yusufizzetmurat/fed-pulse-forecaster",
+                revision="x",
+                eager=True,
+                description="",
+                inference_features=(),
+            )
+        ],
+    )
+
+    with caplog.at_level("WARNING", logger="app.boot.eager_pull"):
+        eager_pull.hydrate()
+    assert any("unknown dst_root" in r.message for r in caplog.records)
+    # Nothing landed in either root.
+    assert list(models.iterdir()) == []
+    assert not (data / "junk.txt").exists()
+
+
+def test_trajectory_bundle_mapping_matches_service_constants() -> None:
+    """The trajectory bundle entry must drop its files exactly where
+    ``app.services.trajectory`` reads them.
+
+    Drift between the two is the bug class this whole change is meant
+    to prevent — pinning the relpath in a test stops a silent rename
+    on one side from breaking startup on the other.
+    """
+
+    from app.services import trajectory as trajectory_svc
+
+    expected_dir = "artifacts/trajectory/trajectory_transformer"
+    for src_name, dst_relpath, dst_root in (
+        eager_pull._split_entry(e) for e in eager_pull._ARTEFACT_FILES["trajectory_bundle"]
+    ):
+        assert dst_root == "DATA"
+        assert dst_relpath.startswith(expected_dir + "/")
+    # The four "must exist" filenames in the trajectory loader must all
+    # show up on the snapshot side, or the bundle hydrates incomplete
+    # and the service falls into its degraded "not available" state.
+    src_names = {
+        s for s, _, _ in (
+            eager_pull._split_entry(e)
+            for e in eager_pull._ARTEFACT_FILES["trajectory_bundle"]
+        )
+    }
+    for required in (
+        trajectory_svc.PARQUET_NAME,
+        trajectory_svc.NPZ_NAME,
+        trajectory_svc.MODEL_NAME,
+        trajectory_svc.MANIFEST_NAME,
+    ):
+        assert required in src_names


### PR DESCRIPTION
## Summary
- Extend _ARTEFACT_FILES to a 3-tuple (snapshot_name, dst_relpath, dst_root) with dst_root in {MODELS, DATA}
- Add trajectory_bundle and retrieval_bundle entries routing to DATA_DIR/artifacts/
- Both bundles already eager: true in registry.yaml; the shim now copies their files into the host /data volume on boot
- 15 unit tests passing (10 existing + 5 new)

## Test plan
- [ ] docker compose run --rm backend pytest tests/unit/test_eager_pull.py tests/unit/test_boot_eager_pull.py -q