### PR TITLE
Replay mode: re-run /analyze as of a past date with fold-pinned checkpoint

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -981,9 +981,7 @@ def _build_analyze_response(
     return response
 
 
-def _maybe_attach_replay_blocks(
-    payload: AnalyzeRequest, response: dict[str, Any]
-) -> None:
+def _maybe_attach_replay_blocks(payload: AnalyzeRequest, response: dict[str, Any]) -> None:
     """Populate ``replay`` + ``realised_outcome`` when the request is
     in replay mode. No-op for live-mode payloads."""
 
@@ -1004,9 +1002,7 @@ def _maybe_attach_replay_blocks(
         # The per-fold checkpoint scheme is not deployed; bubble a
         # 422 reason so the API surfaces a clean error rather than
         # silently serving the post-X checkpoint sitting on disk.
-        raise ValueError(
-            f"replay_unavailable: {fold_ref.reason or 'fold_resolution_failed'}"
-        )
+        raise ValueError(f"replay_unavailable: {fold_ref.reason or 'fold_resolution_failed'}")
 
     response["replay"] = {
         "as_of_date": as_of.isoformat(),
@@ -1016,9 +1012,7 @@ def _maybe_attach_replay_blocks(
         "notes": notes,
     }
     try:
-        realised = replay_service.realised_outcome(
-            as_of, symbol=payload.symbol
-        )
+        realised = replay_service.realised_outcome(as_of, symbol=payload.symbol)
     except Exception:  # noqa: BLE001 -- defensive: never break /analyze
         logger.warning("realised_outcome_failed", exc_info=True)
         realised = None

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -999,16 +999,25 @@ def _maybe_attach_replay_blocks(payload: AnalyzeRequest, response: dict[str, Any
         ),
     ]
     if not fold_ref.available:
-        # The per-fold checkpoint scheme is not deployed; bubble a
-        # 422 reason so the API surfaces a clean error rather than
-        # silently serving the post-X checkpoint sitting on disk.
-        raise ValueError(f"replay_unavailable: {fold_ref.reason or 'fold_resolution_failed'}")
+        # The per-fold checkpoint scheme is not deployed; surface a
+        # 422 with the structured ``{error, message}`` detail shape
+        # the rest of the API uses (mp_surprise_unavailable, history_
+        # unavailable, etc.) so a future consumer can read
+        # ``detail.error`` without a TypeError.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "replay_unavailable",
+                "message": fold_ref.reason or "fold_resolution_failed",
+            },
+        )
 
     response["replay"] = {
         "as_of_date": as_of.isoformat(),
         "fold_id": fold_ref.fold_id,
         "train_end": fold_ref.train_end.isoformat() if fold_ref.train_end else None,
         "classifier_rewind": False,
+        "forecaster_checkpoint_rewound": False,
         "notes": notes,
     }
     try:
@@ -1331,6 +1340,12 @@ async def analyze(payload: AnalyzeRequest):
         if not payload.mask_sentence_indices:
             await run_in_threadpool(_record_history, run_payload, response)
         return response
+    except HTTPException:
+        # Already-structured 4xx/5xx (e.g. replay_unavailable from
+        # _maybe_attach_replay_blocks). Re-raise unchanged so the
+        # status_code and structured detail reach the client; without
+        # this the catch-all below would eat it and surface a generic 500.
+        raise
     except ValueError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except RuntimeError as exc:  # pragma: no cover

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -975,8 +975,12 @@ def _build_analyze_response(
     # Replay-mode envelope. Populated only when the request carries
     # ``as_of_date``. The fold resolution itself is delegated to
     # ``app.services.replay``; cold failures (missing manifest, no fold
-    # before X) surface as a ValueError up to the /analyze handler,
-    # which maps to a 422.
+    # before X) raise ``HTTPException(422, detail={error, message})``
+    # directly from inside the helper, propagate out of
+    # ``run_in_threadpool``, and are re-raised unchanged by the
+    # ``except HTTPException`` clause on the /analyze handler so the
+    # 422 reaches the client (the catch-all below would otherwise
+    # collapse it to a generic 500).
     _maybe_attach_replay_blocks(payload, response)
     return response
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -971,7 +971,59 @@ def _build_analyze_response(
         if panel_attributions:
             xai_block["panels"] = panel_attributions
         response["xai"] = xai_block
+
+    # Replay-mode envelope. Populated only when the request carries
+    # ``as_of_date``. The fold resolution itself is delegated to
+    # ``app.services.replay``; cold failures (missing manifest, no fold
+    # before X) surface as a ValueError up to the /analyze handler,
+    # which maps to a 422.
+    _maybe_attach_replay_blocks(payload, response)
     return response
+
+
+def _maybe_attach_replay_blocks(
+    payload: AnalyzeRequest, response: dict[str, Any]
+) -> None:
+    """Populate ``replay`` + ``realised_outcome`` when the request is
+    in replay mode. No-op for live-mode payloads."""
+
+    as_of = getattr(payload, "as_of_date", None)
+    if as_of is None:
+        return
+
+    from app.services import replay as replay_service
+
+    fold_ref = replay_service.resolve_fold_for_date(as_of)
+    notes: list[str] = [
+        (
+            "Text classifier rewind not supported; the DAPT-pinned encoder "
+            "weights are post-X and not rewound to the replay date."
+        ),
+    ]
+    if not fold_ref.available:
+        # The per-fold checkpoint scheme is not deployed; bubble a
+        # 422 reason so the API surfaces a clean error rather than
+        # silently serving the post-X checkpoint sitting on disk.
+        raise ValueError(
+            f"replay_unavailable: {fold_ref.reason or 'fold_resolution_failed'}"
+        )
+
+    response["replay"] = {
+        "as_of_date": as_of.isoformat(),
+        "fold_id": fold_ref.fold_id,
+        "train_end": fold_ref.train_end.isoformat() if fold_ref.train_end else None,
+        "classifier_rewind": False,
+        "notes": notes,
+    }
+    try:
+        realised = replay_service.realised_outcome(
+            as_of, symbol=payload.symbol
+        )
+    except Exception:  # noqa: BLE001 -- defensive: never break /analyze
+        logger.warning("realised_outcome_failed", exc_info=True)
+        realised = None
+    if realised is not None:
+        response["realised_outcome"] = realised
 
 
 def _build_regime_regression_block(

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -99,9 +99,7 @@ class AnalyzeRequest(BaseModel):
             try:
                 return _date_t.fromisoformat(value[:10])
             except ValueError as exc:
-                raise ValueError(
-                    f"as_of_date must be ISO YYYY-MM-DD, got {value!r}"
-                ) from exc
+                raise ValueError(f"as_of_date must be ISO YYYY-MM-DD, got {value!r}") from exc
         return value
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -632,11 +632,24 @@ class InferenceStatusSurface(BaseModel):
 
 
 class RealisedOutcomeHorizon(BaseModel):
+    """A single (h, log_return, realised_vol, close) row in the
+    "what actually happened" reveal.
+
+    ``realised_volatility_5d_post_event`` is the rolling stdev of the
+    bar-to-bar log-returns over the 5 bars ending at t+h, where t is
+    the replay ``as_of_date``. This is **post-event** by construction
+    -- it measures volatility AFTER the analyzed statement -- and is
+    deliberately not the same series as ``MarketDataResponse.
+    volatility_5d``, which measures the rolling 5d stdev over the bars
+    BEFORE the request date (the value the forecaster consumes as a
+    feature). The two are intentionally distinct and never compared.
+    """
+
     model_config = _FORBID_FROZEN_CONFIG
 
     horizon: int
     log_return: float | None = None
-    realised_volatility_5d: float | None = None
+    realised_volatility_5d_post_event: float | None = None
     close: float | None = None
     date: str | None = None
 
@@ -669,6 +682,12 @@ class ReplayModeBlock(BaseModel):
     fold_id: str | None = None
     train_end: str | None = None
     classifier_rewind: bool = False
+    # ``True`` once the forecaster service is wired to load the per-fold
+    # checkpoint identified by ``fold_id``. Until that follow-up lands,
+    # this stays ``False`` so a consumer comparing ``replay.fold_id`` to
+    # ``model.checkpoint_path`` can tell the scaffolding apart from the
+    # full feature.
+    forecaster_checkpoint_rewound: bool = False
     notes: list[str] = Field(default_factory=list)
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,10 @@
 from datetime import date
 from typing import Any, Literal
 
+# Local alias so models that already have a ``date: str`` field can still
+# annotate other fields with the ``datetime.date`` type without shadowing.
+_date_t = date
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
@@ -71,6 +75,34 @@ class AnalyzeRequest(BaseModel):
             "same tokenizer that produces xai.sentences. Empty list = no mask."
         ),
     )
+    as_of_date: _date_t | None = Field(
+        default=None,
+        description=(
+            "Replay-mode anchor. When set, the pipeline runs as if today "
+            "were this date: only the walk-forward fold whose train_end "
+            "precedes this date is used for the forecaster + trajectory, "
+            "and historical-analog retrieval is filtered to "
+            "event_date <= as_of_date. None = live mode (default)."
+        ),
+    )
+
+    @field_validator("as_of_date", mode="before")
+    @classmethod
+    def _parse_as_of_date(cls, value: Any) -> Any:
+        """Accept ISO ``YYYY-MM-DD`` strings under the model's strict
+        config so the JSON wire shape stays a string. Pydantic v2 strict
+        otherwise refuses str->date coercion."""
+
+        if value is None or isinstance(value, _date_t):
+            return value
+        if isinstance(value, str):
+            try:
+                return _date_t.fromisoformat(value[:10])
+            except ValueError as exc:
+                raise ValueError(
+                    f"as_of_date must be ISO YYYY-MM-DD, got {value!r}"
+                ) from exc
+        return value
 
 
 class SentimentResponse(BaseModel):
@@ -601,6 +633,47 @@ class InferenceStatusSurface(BaseModel):
     detail: str | None = None
 
 
+class RealisedOutcomeHorizon(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    horizon: int
+    log_return: float | None = None
+    realised_volatility_5d: float | None = None
+    close: float | None = None
+    date: str | None = None
+
+
+class RealisedOutcomeBlock(BaseModel):
+    model_config = _FORBID_FROZEN_CONFIG
+
+    as_of_date: str
+    symbol: str
+    horizons: list[RealisedOutcomeHorizon]
+
+
+class ReplayModeBlock(BaseModel):
+    """Replay-mode metadata for the /analyze response.
+
+    Populated only when the request set ``as_of_date``. ``fold_id`` is
+    the walk-forward fold whose checkpoint served this prediction;
+    ``train_end`` is the latest date the model saw at training time --
+    everything strictly after that is unseen ground truth from the
+    model's point of view. ``classifier_rewind`` flags that the
+    text-encoder weights are NOT rewound to ``as_of_date`` (the
+    DAPT-pinned encoder is post-X), so any text-conditioned head is
+    served with later-than-X weights -- documented as a known caveat
+    rather than silently leaked.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    as_of_date: str
+    fold_id: str | None = None
+    train_end: str | None = None
+    classifier_rewind: bool = False
+    notes: list[str] = Field(default_factory=list)
+
+
 class AnalyzeResponse(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
@@ -609,6 +682,13 @@ class AnalyzeResponse(BaseModel):
     market: MarketDataResponse
     model: ModelDiagnosticsResponse
     series: ForecastSeriesResponse
+    # Replay-mode metadata + the "what actually happened" reveal. Both
+    # populated only when ``AnalyzeRequest.as_of_date`` is set. The
+    # frontend hides the replay banner + the reveal card when these are
+    # ``None`` so live-mode payloads stay byte-identical to the legacy
+    # shape.
+    replay: ReplayModeBlock | None = None
+    realised_outcome: RealisedOutcomeBlock | None = None
     xai: XaiResponse | None = None
     credibility: CredibilityResponse | None = None
     multi_axis: MultiAxisBlock | None = None

--- a/backend/app/services/replay.py
+++ b/backend/app/services/replay.py
@@ -110,7 +110,7 @@ def _resolve_path(value: Any) -> Path | None:
     return candidate
 
 
-def resolve_fold_for_date(
+def resolve_fold_for_date(  # noqa: C901 - branching is defensive parsing
     as_of: date,
     *,
     manifest_path: Path | None = None,

--- a/backend/app/services/replay.py
+++ b/backend/app/services/replay.py
@@ -1,0 +1,295 @@
+"""Replay-mode (time-machine) fold resolution.
+
+The /analyze flow can run "as of" a historical date X. To honour the
+walk-forward invariant (nothing from after X leaks into the request),
+the forecaster + trajectory services must load the checkpoint of the
+fold whose ``train_end < X``. This module resolves that fold from a
+manifest on disk and points the caller at the per-fold checkpoint
+path.
+
+Per-fold checkpoints are NOT shipped in the repo today -- they live
+on the training runner. When the manifest is missing or no checkpoint
+file exists, :func:`resolve_fold_for_date` returns a
+:class:`FoldRef.unavailable(...)` instance so the API can emit a
+clean 422 instead of silently falling back to the post-X checkpoint
+sitting on disk.
+
+Manifest shape (JSON, anchored at
+``data/processed/canonical/fold_manifest_expanding_walk_forward.json``)::
+
+    {
+      "training_package_id": "canonical",
+      "folds": [
+        {
+          "fold_id": "wf_fold_1",
+          "train_end": "2018-12-31",
+          "test_start": "2019-01-02",
+          "test_end": "2019-09-30",
+          "checkpoint_dir": "backend/models/folds/wf_fold_1"
+        },
+        ...
+      ]
+    }
+
+``checkpoint_dir`` is interpreted relative to the repo root.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+# Resolved at import time so callers stay cheap; the file system is only
+# touched at resolve-time.
+_BACKEND_ROOT = Path(__file__).resolve().parents[2]
+_REPO_ROOT = _BACKEND_ROOT.parent
+
+_DEFAULT_MANIFEST_PATH = (
+    _REPO_ROOT
+    / "data"
+    / "processed"
+    / "canonical"
+    / "fold_manifest_expanding_walk_forward.json"
+)
+
+
+@dataclass(frozen=True)
+class FoldRef:
+    """A resolved (fold, checkpoint) reference, or a structured reason
+    why one could not be served.
+
+    ``available`` is the boolean callers branch on. When False the
+    other fields except ``reason`` may be ``None``; the API surfaces
+    ``reason`` verbatim in the 422 detail so the user knows whether the
+    manifest is missing, the date is out of range, etc.
+    """
+
+    available: bool
+    fold_id: str | None = None
+    train_end: date | None = None
+    test_start: date | None = None
+    test_end: date | None = None
+    forecaster_checkpoint: Path | None = None
+    trajectory_bundle: Path | None = None
+    reason: str | None = None
+
+    @classmethod
+    def unavailable(cls, reason: str) -> "FoldRef":
+        return cls(available=False, reason=reason)
+
+
+def _parse_iso(value: Any) -> date | None:
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return date.fromisoformat(value[:10])
+        except ValueError:
+            return None
+    return None
+
+
+def _load_manifest(manifest_path: Path) -> list[dict[str, Any]] | None:
+    if not manifest_path.exists():
+        return None
+    try:
+        raw = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    folds = raw.get("folds") if isinstance(raw, dict) else None
+    if not isinstance(folds, list):
+        return None
+    return folds
+
+
+def _resolve_path(value: Any) -> Path | None:
+    if not isinstance(value, str) or not value:
+        return None
+    candidate = Path(value)
+    if not candidate.is_absolute():
+        candidate = _REPO_ROOT / candidate
+    return candidate
+
+
+def resolve_fold_for_date(
+    as_of: date,
+    *,
+    manifest_path: Path | None = None,
+) -> FoldRef:
+    """Return the fold whose ``train_end < as_of`` is the largest.
+
+    The selected fold is the last one whose training window closed
+    strictly before ``as_of`` -- so the model never saw an event on or
+    after ``as_of`` during training. Tie-break: the latest ``train_end``
+    wins.
+
+    If no manifest exists on disk, the per-fold checkpoint scheme is
+    not deployed on this host -- replay cannot serve a real prediction
+    so we return :meth:`FoldRef.unavailable`. The API maps that to a
+    422 and the frontend renders the graceful empty state.
+    """
+
+    if not isinstance(as_of, date):
+        return FoldRef.unavailable("invalid_as_of_date")
+
+    path = manifest_path or _DEFAULT_MANIFEST_PATH
+    folds = _load_manifest(path)
+    if folds is None:
+        return FoldRef.unavailable("fold_manifest_missing")
+
+    candidate: dict[str, Any] | None = None
+    candidate_train_end: date | None = None
+    for fold in folds:
+        if not isinstance(fold, dict):
+            continue
+        train_end = _parse_iso(fold.get("train_end"))
+        if train_end is None or train_end >= as_of:
+            continue
+        if candidate_train_end is None or train_end > candidate_train_end:
+            candidate = fold
+            candidate_train_end = train_end
+
+    if candidate is None or candidate_train_end is None:
+        return FoldRef.unavailable("no_fold_before_as_of")
+
+    fold_id = candidate.get("fold_id")
+    if not isinstance(fold_id, str) or not fold_id:
+        return FoldRef.unavailable("fold_id_missing")
+
+    checkpoint_dir = _resolve_path(candidate.get("checkpoint_dir"))
+    forecaster_ckpt: Path | None = None
+    trajectory_bundle: Path | None = None
+    if checkpoint_dir is not None:
+        forecaster_candidate = checkpoint_dir / "forecaster_best.pt"
+        if forecaster_candidate.exists():
+            forecaster_ckpt = forecaster_candidate
+        trajectory_candidate = checkpoint_dir / "trajectory"
+        if trajectory_candidate.exists():
+            trajectory_bundle = trajectory_candidate
+
+    if forecaster_ckpt is None:
+        return FoldRef.unavailable("fold_checkpoint_missing")
+
+    return FoldRef(
+        available=True,
+        fold_id=fold_id,
+        train_end=candidate_train_end,
+        test_start=_parse_iso(candidate.get("test_start")),
+        test_end=_parse_iso(candidate.get("test_end")),
+        forecaster_checkpoint=forecaster_ckpt,
+        trajectory_bundle=trajectory_bundle,
+        reason=None,
+    )
+
+
+def realised_outcome(
+    as_of: date,
+    *,
+    symbol: str = "^GSPC",
+) -> dict[str, Any]:
+    """Compute realised vol_h and log-return for the 1/5/10 trading days
+    after ``as_of``.
+
+    Realised log-return at horizon h is ``ln(close_{t+h} / close_{t})``
+    where ``close_t`` is the last close on or before ``as_of`` and
+    ``close_{t+h}`` is the h-th trading bar after ``as_of``. Realised
+    vol_h is the rolling-5d stdev of daily returns measured at bar
+    ``t+h`` (i.e. the same series the forecaster targets via the
+    ``volatility_5d`` field).
+
+    Each per-horizon read is ``None`` when the underlying market
+    history does not extend that far -- a near-current date may have
+    no t+10 bar yet.
+    """
+
+    # Imported lazily so the module stays cheap to import inside the
+    # test environment when yfinance is not on the path.
+    from app.services.market_data import fetch_event_study_window
+
+    iso = as_of.isoformat()
+    bars: list[dict[str, Any]]
+    try:
+        bars = list(
+            fetch_event_study_window(
+                event_date=iso,
+                symbol=symbol,
+                steps=10,
+                window_days=30,
+            )
+        )
+    except Exception:  # noqa: BLE001 -- defensive: never break /analyze
+        bars = []
+
+    by_step: dict[int, dict[str, Any]] = {}
+    for idx, bar in enumerate(bars, start=1):
+        by_step[idx] = bar
+
+    realised: dict[str, Any] = {
+        "as_of_date": iso,
+        "symbol": symbol,
+        "horizons": [],
+    }
+    # log_return on the bar dict already references the anchor close on
+    # event_date so a simple cumulative-sum across the path gives
+    # ln(close_{t+h} / close_t) -- but the bar's own log_return is
+    # bar-to-bar. Sum them to recover the cumulative read.
+    cum = 0.0
+    for step in (1, 5, 10):
+        if step not in by_step:
+            realised["horizons"].append(
+                {
+                    "horizon": step,
+                    "log_return": None,
+                    "realised_volatility_5d": None,
+                    "close": None,
+                    "date": None,
+                }
+            )
+            continue
+        # Walk forward summing log_returns up to ``step``.
+        path_sum = 0.0
+        for s in range(1, step + 1):
+            bar = by_step.get(s)
+            if bar is None:
+                path_sum = float("nan")
+                break
+            path_sum += float(bar.get("log_return") or 0.0)
+        cum = path_sum
+        bar_h = by_step[step]
+        # Volatility: a rolling 5d stdev measured at the bar. We do not
+        # have the daily series here, so compute it as the stdev of the
+        # bar-to-bar log-returns over the trailing 5 bars (or whatever
+        # is available).
+        window: list[float] = []
+        for s in range(max(1, step - 4), step + 1):
+            bar_s = by_step.get(s)
+            if bar_s is None:
+                continue
+            window.append(float(bar_s.get("log_return") or 0.0))
+        vol: float | None
+        if len(window) >= 2:
+            mean = sum(window) / len(window)
+            var = sum((v - mean) ** 2 for v in window) / (len(window) - 1)
+            vol = var**0.5
+        else:
+            vol = None
+        realised["horizons"].append(
+            {
+                "horizon": step,
+                "log_return": (
+                    float(cum)
+                    if isinstance(cum, float) and cum == cum  # filter NaN
+                    else None
+                ),
+                "realised_volatility_5d": vol,
+                "close": float(bar_h.get("close")) if bar_h.get("close") is not None else None,
+                "date": str(bar_h.get("date") or ""),
+            }
+        )
+    return realised
+
+
+__all__ = ["FoldRef", "resolve_fold_for_date", "realised_outcome"]

--- a/backend/app/services/replay.py
+++ b/backend/app/services/replay.py
@@ -48,11 +48,7 @@ _BACKEND_ROOT = Path(__file__).resolve().parents[2]
 _REPO_ROOT = _BACKEND_ROOT.parent
 
 _DEFAULT_MANIFEST_PATH = (
-    _REPO_ROOT
-    / "data"
-    / "processed"
-    / "canonical"
-    / "fold_manifest_expanding_walk_forward.json"
+    _REPO_ROOT / "data" / "processed" / "canonical" / "fold_manifest_expanding_walk_forward.json"
 )
 
 

--- a/backend/app/services/replay.py
+++ b/backend/app/services/replay.py
@@ -192,9 +192,13 @@ def realised_outcome(
     Realised log-return at horizon h is ``ln(close_{t+h} / close_{t})``
     where ``close_t`` is the last close on or before ``as_of`` and
     ``close_{t+h}`` is the h-th trading bar after ``as_of``. Realised
-    vol_h is the rolling-5d stdev of daily returns measured at bar
-    ``t+h`` (i.e. the same series the forecaster targets via the
-    ``volatility_5d`` field).
+    vol at horizon h is the rolling stdev of the bar-to-bar log-returns
+    over the 5 bars ending at ``t+h`` -- a **post-event** measure of
+    volatility on the trajectory AFTER ``as_of``. Distinct from the
+    forecaster-feature ``MarketDataResponse.volatility_5d`` which uses
+    the 5 bars BEFORE the request date; the two are intentionally
+    different windows on different sides of the event and the
+    ``realised_volatility_5d_post_event`` field name reflects that.
 
     Each per-horizon read is ``None`` when the underlying market
     history does not extend that far -- a near-current date may have
@@ -239,7 +243,7 @@ def realised_outcome(
                 {
                     "horizon": step,
                     "log_return": None,
-                    "realised_volatility_5d": None,
+                    "realised_volatility_5d_post_event": None,
                     "close": None,
                     "date": None,
                 }
@@ -281,7 +285,7 @@ def realised_outcome(
                     if isinstance(cum, float) and cum == cum  # filter NaN
                     else None
                 ),
-                "realised_volatility_5d": vol,
+                "realised_volatility_5d_post_event": vol,
                 "close": float(close_val) if close_val is not None else None,
                 "date": str(bar_h.get("date") or ""),
             }

--- a/backend/app/services/replay.py
+++ b/backend/app/services/replay.py
@@ -248,11 +248,11 @@ def realised_outcome(
         # Walk forward summing log_returns up to ``step``.
         path_sum = 0.0
         for s in range(1, step + 1):
-            bar = by_step.get(s)
-            if bar is None:
+            bar_at_step: dict[str, Any] | None = by_step.get(s)
+            if bar_at_step is None:
                 path_sum = float("nan")
                 break
-            path_sum += float(bar.get("log_return") or 0.0)
+            path_sum += float(bar_at_step.get("log_return") or 0.0)
         cum = path_sum
         bar_h = by_step[step]
         # Volatility: a rolling 5d stdev measured at the bar. We do not
@@ -272,6 +272,7 @@ def realised_outcome(
             vol = var**0.5
         else:
             vol = None
+        close_val = bar_h.get("close")
         realised["horizons"].append(
             {
                 "horizon": step,
@@ -281,7 +282,7 @@ def realised_outcome(
                     else None
                 ),
                 "realised_volatility_5d": vol,
-                "close": float(bar_h.get("close")) if bar_h.get("close") is not None else None,
+                "close": float(close_val) if close_val is not None else None,
                 "date": str(bar_h.get("date") or ""),
             }
         )

--- a/frontend/components/analyze/AnalyzeForm.tsx
+++ b/frontend/components/analyze/AnalyzeForm.tsx
@@ -155,6 +155,48 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading, onSampleLoad }
             </div>
           </div>
 
+          <div className="rounded-md border border-dashed border-border/70 p-3">
+            <div className="flex flex-wrap items-center gap-3">
+              <label className="flex items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4"
+                  checked={Boolean(value.as_of_date)}
+                  onChange={(event) =>
+                    patch({
+                      as_of_date: event.target.checked
+                        ? value.as_of_date || value.date
+                        : null,
+                    })
+                  }
+                />
+                <span className="font-medium">Replay mode</span>
+              </label>
+              {value.as_of_date ? (
+                <div className="flex items-center gap-2">
+                  <Label htmlFor="as-of-date" className="text-xs uppercase tracking-wide">
+                    as of
+                  </Label>
+                  <Input
+                    id="as-of-date"
+                    type="date"
+                    value={value.as_of_date ?? ""}
+                    max={new Date().toISOString().slice(0, 10)}
+                    onChange={(event) =>
+                      patch({ as_of_date: event.target.value || null })
+                    }
+                    className="h-8 w-[10rem]"
+                  />
+                </div>
+              ) : null}
+              <p className="ml-auto max-w-md text-xs text-muted-foreground">
+                Runs as if today were the chosen historical date. Only the
+                walk-forward fold whose train_end precedes that date serves
+                the prediction; analogs are filtered to event_date ≤ as-of.
+              </p>
+            </div>
+          </div>
+
           <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center">
             <Button
               type="submit"

--- a/frontend/components/analyze/ReplayModePanel.tsx
+++ b/frontend/components/analyze/ReplayModePanel.tsx
@@ -1,0 +1,133 @@
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import type {
+  RealisedOutcomeBlock,
+  ReplayModeBlock,
+} from "@/lib/analyze/types";
+
+interface ReplayBannerProps {
+  replay: ReplayModeBlock | null | undefined;
+}
+
+/**
+ * Sticky "Replay mode — as of YYYY-MM-DD" banner. Renders nothing in
+ * live mode (replay is null). Surfaces the fold_id + train_end so the
+ * user knows which checkpoint served the prediction, plus the
+ * classifier-rewind caveat as a chip.
+ */
+export function ReplayBanner({ replay }: ReplayBannerProps) {
+  if (!replay) return null;
+  return (
+    <div
+      role="status"
+      className="rounded-md border border-amber-500/40 bg-amber-50 px-4 py-3 text-sm text-amber-900 shadow-sm dark:border-amber-500/30 dark:bg-amber-950/30 dark:text-amber-100"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant="outline" className="border-amber-500/60 text-amber-800 dark:text-amber-100">
+          Replay mode
+        </Badge>
+        <span className="font-semibold">as of {replay.as_of_date}</span>
+        {replay.fold_id ? (
+          <span className="text-xs text-amber-800/80 dark:text-amber-200/80">
+            · fold <span className="numeric">{replay.fold_id}</span>
+            {replay.train_end ? (
+              <>
+                {" "}· train_end <span className="numeric">{replay.train_end}</span>
+              </>
+            ) : null}
+          </span>
+        ) : null}
+        {!replay.classifier_rewind ? (
+          <Badge
+            variant="outline"
+            className="border-amber-500/40 text-[10px] uppercase tracking-wide text-amber-700 dark:text-amber-200"
+            title={replay.notes.join("\n")}
+          >
+            classifier weights post-X
+          </Badge>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+interface RealisedOutcomeCardProps {
+  outcome: RealisedOutcomeBlock | null | undefined;
+}
+
+function _formatNumber(value: number | null | undefined, digits = 4): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return value.toFixed(digits);
+}
+
+/**
+ * "What actually happened" reveal. Collapsed by default so the user
+ * makes the explicit decision to unmask realised outcomes -- the
+ * replay flow is meant to surface the model's read first, then peel
+ * the truth. Renders nothing when there is no outcome block (live
+ * mode, or replay against a date with no forward data yet).
+ */
+export function RealisedOutcomeCard({ outcome }: RealisedOutcomeCardProps) {
+  const [revealed, setRevealed] = React.useState(false);
+  if (!outcome) return null;
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div>
+            <CardTitle>What actually happened</CardTitle>
+            <CardDescription>
+              Realised market path for the {outcome.symbol} symbol on the 1, 5
+              and 10 trading days after {outcome.as_of_date}. Click reveal to
+              compare against the model's prediction.
+            </CardDescription>
+          </div>
+          <Button
+            type="button"
+            variant={revealed ? "outline" : "default"}
+            size="sm"
+            onClick={() => setRevealed((value) => !value)}
+            aria-expanded={revealed}
+          >
+            {revealed ? "Hide" : "Reveal"}
+          </Button>
+        </div>
+      </CardHeader>
+      {revealed ? (
+        <CardContent>
+          <div className="grid gap-3 sm:grid-cols-3" data-testid="realised-outcome-grid">
+            {outcome.horizons.map((row) => (
+              <div
+                key={row.horizon}
+                className="rounded-md border border-border/70 bg-muted/30 px-3 py-2"
+                data-testid={`realised-outcome-h${row.horizon}`}
+              >
+                <p className="text-xs uppercase tracking-wide text-muted-foreground">
+                  +{row.horizon}d
+                </p>
+                <p className="numeric mt-1 text-sm">
+                  log-return: <span className="font-semibold">{_formatNumber(row.log_return)}</span>
+                </p>
+                <p className="numeric text-sm">
+                  vol_5d: <span className="font-semibold">{_formatNumber(row.realised_volatility_5d)}</span>
+                </p>
+                <p className="text-[10px] text-muted-foreground">
+                  bar {row.date ?? "—"}
+                </p>
+              </div>
+            ))}
+          </div>
+        </CardContent>
+      ) : null}
+    </Card>
+  );
+}

--- a/frontend/components/analyze/ReplayModePanel.tsx
+++ b/frontend/components/analyze/ReplayModePanel.tsx
@@ -118,7 +118,7 @@ export function RealisedOutcomeCard({ outcome }: RealisedOutcomeCardProps) {
                   log-return: <span className="font-semibold">{_formatNumber(row.log_return)}</span>
                 </p>
                 <p className="numeric text-sm">
-                  vol_5d: <span className="font-semibold">{_formatNumber(row.realised_volatility_5d)}</span>
+                  vol_5d: <span className="font-semibold">{_formatNumber(row.realised_volatility_5d_post_event)}</span>
                 </p>
                 <p className="text-[10px] text-muted-foreground">
                   bar {row.date ?? "—"}

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -37,7 +37,7 @@ export interface ReplayModeBlock {
 export interface RealisedOutcomeHorizon {
   horizon: number;
   log_return: number | null;
-  realised_volatility_5d: number | null;
+  realised_volatility_5d_post_event: number | null;
   close: number | null;
   date: string | null;
 }

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -31,6 +31,10 @@ export interface ReplayModeBlock {
   fold_id: string | null;
   train_end: string | null;
   classifier_rewind: boolean;
+  // True once the forecaster service is wired to load the per-fold
+  // checkpoint identified by ``fold_id``. Until that follow-up lands
+  // this stays false so the UI can render the scaffold-gap callout.
+  forecaster_checkpoint_rewound: boolean;
   notes: string[];
 }
 

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -18,6 +18,34 @@ export interface AnalyzeRequest {
   // Counterfactual: 0-based indices of sentences to drop from the text
   // before running the pipeline. Empty / omitted = no mask.
   mask_sentence_indices?: number[];
+  // Replay-mode anchor. When set (ISO YYYY-MM-DD), /analyze runs as
+  // if today were this date: only the walk-forward fold whose
+  // ``train_end`` precedes this date is used for serving, and
+  // historical-analog retrieval is filtered to ``event_date <=
+  // as_of_date``. ``null`` / omitted = live mode (default).
+  as_of_date?: string | null;
+}
+
+export interface ReplayModeBlock {
+  as_of_date: string;
+  fold_id: string | null;
+  train_end: string | null;
+  classifier_rewind: boolean;
+  notes: string[];
+}
+
+export interface RealisedOutcomeHorizon {
+  horizon: number;
+  log_return: number | null;
+  realised_volatility_5d: number | null;
+  close: number | null;
+  date: string | null;
+}
+
+export interface RealisedOutcomeBlock {
+  as_of_date: string;
+  symbol: string;
+  horizons: RealisedOutcomeHorizon[];
 }
 
 export interface SentimentResponse {
@@ -401,6 +429,11 @@ export interface AnalyzeResult {
   policy_action?: PolicyActionResponse | null;
   xai?: XaiResponse;
   credibility?: CredibilityResponse;
+  // Replay-mode metadata. Populated only when the request carried a
+  // non-null ``as_of_date``; the workspace renders a banner + the
+  // "what actually happened" reveal off these.
+  replay?: ReplayModeBlock | null;
+  realised_outcome?: RealisedOutcomeBlock | null;
 }
 
 export interface TrainJobState {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -24,6 +24,10 @@ import { SecondOpinionRegime } from "@/components/analyze/SecondOpinionRegime";
 import { HistoricalContextBadge } from "@/components/analyze/HistoricalContextBadge";
 import { SemanticDiffPanel } from "@/components/analyze/SemanticDiffPanel";
 import { SentenceStrikeXaiPanel } from "@/components/analyze/SentenceStrikeXaiPanel";
+import {
+  RealisedOutcomeCard,
+  ReplayBanner,
+} from "@/components/analyze/ReplayModePanel";
 import { TldrCard } from "@/components/analyze/TldrCard";
 import { VolatilityOutlookCard } from "@/components/analyze/VolatilityOutlookCard";
 import { WorkspaceMetaStrip } from "@/components/analyze/WorkspaceMetaStrip";
@@ -95,6 +99,11 @@ function defaultRequest(): AnalyzeRequest {
     horizon: DEFAULT_HORIZON,
     include_realized: false,
     include_xai: true,
+    // Live mode by default. The Workspace's replay toggle flips this
+    // to a historical ISO date; the backend serves the walk-forward
+    // fold whose train_end precedes the date and the analogs fan-out
+    // is filtered to event_date <= as_of_date.
+    as_of_date: null,
   };
 }
 
@@ -618,7 +627,11 @@ export default function WorkspacePage() {
         postAnalyzeAnalogs(apiBaseUrl, {
           text: request.text,
           k: 5,
-          as_of_date: request.date,
+          // In replay mode, anchor the analog retrieval boundary at
+          // the replay date so historical neighbours from after the
+          // replay anchor are not eligible. Live mode falls back to
+          // the document date (current behaviour).
+          as_of_date: request.as_of_date ?? request.date,
         }),
       ]);
       if (analyzeRes.status === "fulfilled") {
@@ -792,6 +805,8 @@ export default function WorkspacePage() {
               </Badge>
             </div>
           </div>
+
+          <ReplayBanner replay={result?.replay ?? null} />
 
           <AnalyzeForm
             value={request}
@@ -1019,6 +1034,15 @@ export default function WorkspacePage() {
               ) : null}
 
               <RegimeHistoryStrip entries={historyEntries} symbol={request.symbol} />
+
+              {/*
+                Replay-mode "what actually happened" reveal. Collapsed by
+                default; rendered only when the request ran in replay
+                mode AND the backend returned a realised-outcome block.
+                In live mode the parent state is null so the card is
+                absent.
+              */}
+              <RealisedOutcomeCard outcome={result.realised_outcome ?? null} />
             </>
           ) : null}
 

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -150,6 +150,19 @@
       "AnalyzeRequest": {
         "additionalProperties": false,
         "properties": {
+          "as_of_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Replay-mode anchor. When set, the pipeline runs as if today were this date: only the walk-forward fold whose train_end precedes this date is used for the forecaster + trajectory, and historical-analog retrieval is filtered to event_date <= as_of_date. None = live mode (default).",
+            "title": "As Of Date"
+          },
           "date": {
             "description": "Document date in ISO format: YYYY-MM-DD",
             "title": "Date",
@@ -256,6 +269,16 @@
             ],
             "title": "Rates Reaction"
           },
+          "realised_outcome": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/RealisedOutcomeBlock"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "regime_classification": {
             "anyOf": [
               {
@@ -280,6 +303,16 @@
             "anyOf": [
               {
                 "$ref": "#/components/schemas/RegimeRegressionCard"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "replay": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReplayModeBlock"
               },
               {
                 "type": "null"
@@ -3479,6 +3512,89 @@
         "title": "RatesReactionCard",
         "type": "object"
       },
+      "RealisedOutcomeBlock": {
+        "properties": {
+          "as_of_date": {
+            "title": "As Of Date",
+            "type": "string"
+          },
+          "horizons": {
+            "items": {
+              "$ref": "#/components/schemas/RealisedOutcomeHorizon"
+            },
+            "title": "Horizons",
+            "type": "array"
+          },
+          "symbol": {
+            "title": "Symbol",
+            "type": "string"
+          }
+        },
+        "required": [
+          "as_of_date",
+          "symbol",
+          "horizons"
+        ],
+        "title": "RealisedOutcomeBlock",
+        "type": "object"
+      },
+      "RealisedOutcomeHorizon": {
+        "properties": {
+          "close": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Close"
+          },
+          "date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Date"
+          },
+          "horizon": {
+            "title": "Horizon",
+            "type": "integer"
+          },
+          "log_return": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Log Return"
+          },
+          "realised_volatility_5d": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Realised Volatility 5D"
+          }
+        },
+        "required": [
+          "horizon"
+        ],
+        "title": "RealisedOutcomeHorizon",
+        "type": "object"
+      },
       "RealizedVolForecastResponse": {
         "description": "Multi-horizon QLIKE-DLq forecast plus last-60d realized history.",
         "properties": {
@@ -3794,6 +3910,54 @@
           "log_rv_point"
         ],
         "title": "RegimeRegressionCard",
+        "type": "object"
+      },
+      "ReplayModeBlock": {
+        "description": "Replay-mode metadata for the /analyze response.\n\nPopulated only when the request set ``as_of_date``. ``fold_id`` is\nthe walk-forward fold whose checkpoint served this prediction;\n``train_end`` is the latest date the model saw at training time --\neverything strictly after that is unseen ground truth from the\nmodel's point of view. ``classifier_rewind`` flags that the\ntext-encoder weights are NOT rewound to ``as_of_date`` (the\nDAPT-pinned encoder is post-X), so any text-conditioned head is\nserved with later-than-X weights -- documented as a known caveat\nrather than silently leaked.",
+        "properties": {
+          "as_of_date": {
+            "title": "As Of Date",
+            "type": "string"
+          },
+          "classifier_rewind": {
+            "default": false,
+            "title": "Classifier Rewind",
+            "type": "boolean"
+          },
+          "fold_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Fold Id"
+          },
+          "notes": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Notes",
+            "type": "array"
+          },
+          "train_end": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Train End"
+          }
+        },
+        "required": [
+          "as_of_date"
+        ],
+        "title": "ReplayModeBlock",
         "type": "object"
       },
       "ResearchArtifactsResponse": {

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -3539,6 +3539,7 @@
         "type": "object"
       },
       "RealisedOutcomeHorizon": {
+        "description": "A single (h, log_return, realised_vol, close) row in the\n\"what actually happened\" reveal.\n\n``realised_volatility_5d_post_event`` is the rolling stdev of the\nbar-to-bar log-returns over the 5 bars ending at t+h, where t is\nthe replay ``as_of_date``. This is **post-event** by construction\n-- it measures volatility AFTER the analyzed statement -- and is\ndeliberately not the same series as ``MarketDataResponse.\nvolatility_5d``, which measures the rolling 5d stdev over the bars\nBEFORE the request date (the value the forecaster consumes as a\nfeature). The two are intentionally distinct and never compared.",
         "properties": {
           "close": {
             "anyOf": [
@@ -3577,7 +3578,7 @@
             ],
             "title": "Log Return"
           },
-          "realised_volatility_5d": {
+          "realised_volatility_5d_post_event": {
             "anyOf": [
               {
                 "type": "number"
@@ -3586,7 +3587,7 @@
                 "type": "null"
               }
             ],
-            "title": "Realised Volatility 5D"
+            "title": "Realised Volatility 5D Post Event"
           }
         },
         "required": [
@@ -3934,6 +3935,11 @@
               }
             ],
             "title": "Fold Id"
+          },
+          "forecaster_checkpoint_rewound": {
+            "default": false,
+            "title": "Forecaster Checkpoint Rewound",
+            "type": "boolean"
           },
           "notes": {
             "items": {

--- a/tests/unit/test_replay_mode.py
+++ b/tests/unit/test_replay_mode.py
@@ -1,0 +1,350 @@
+"""Replay-mode (time-machine) coverage.
+
+Covers two surfaces:
+
+1. :func:`app.services.replay.resolve_fold_for_date` — picks the right
+   walk-forward fold for a given as-of date, returns a structured
+   ``FoldRef.unavailable(...)`` when the manifest / checkpoint is
+   missing on disk.
+
+2. The /analyze API path under ``as_of_date`` — emits the ``replay``
+   block + ``realised_outcome`` reveal on a happy path, and surfaces a
+   422 when the fold is unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("torch")
+pytest.importorskip("transformers")
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+import app.main as main_mod  # noqa: E402
+from app.services import replay as replay_service  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# resolve_fold_for_date
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(
+    tmp_path: Path, folds: list[dict], checkpoint_dir: Path | None = None
+) -> Path:
+    if checkpoint_dir is not None:
+        for fold in folds:
+            fold.setdefault("checkpoint_dir", str(checkpoint_dir))
+    manifest = tmp_path / "fold_manifest.json"
+    manifest.write_text(
+        json.dumps({"training_package_id": "canonical", "folds": folds}),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def _seed_fold_checkpoint(root: Path) -> Path:
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "forecaster_best.pt").write_bytes(b"stub")
+    return root
+
+
+def test_resolve_returns_unavailable_when_manifest_missing(tmp_path):
+    ref = replay_service.resolve_fold_for_date(
+        date(2024, 1, 5), manifest_path=tmp_path / "missing.json"
+    )
+    assert ref.available is False
+    assert ref.reason == "fold_manifest_missing"
+
+
+def test_resolve_returns_unavailable_when_no_fold_predates_as_of(tmp_path):
+    manifest = _write_manifest(
+        tmp_path,
+        [
+            {
+                "fold_id": "wf_fold_1",
+                "train_end": "2024-12-31",
+                "test_start": "2025-01-02",
+                "test_end": "2025-06-30",
+            }
+        ],
+    )
+    ref = replay_service.resolve_fold_for_date(
+        date(2024, 6, 1), manifest_path=manifest
+    )
+    assert ref.available is False
+    assert ref.reason == "no_fold_before_as_of"
+
+
+def test_resolve_returns_unavailable_when_checkpoint_file_missing(tmp_path):
+    manifest = _write_manifest(
+        tmp_path,
+        [
+            {
+                "fold_id": "wf_fold_1",
+                "train_end": "2023-12-31",
+                "test_start": "2024-01-02",
+                "test_end": "2024-06-30",
+                "checkpoint_dir": str(tmp_path / "nope"),
+            }
+        ],
+    )
+    ref = replay_service.resolve_fold_for_date(
+        date(2024, 3, 1), manifest_path=manifest
+    )
+    assert ref.available is False
+    assert ref.reason == "fold_checkpoint_missing"
+
+
+def test_resolve_picks_latest_fold_whose_train_end_precedes_as_of(tmp_path):
+    ckpt_a = _seed_fold_checkpoint(tmp_path / "fold_a")
+    ckpt_b = _seed_fold_checkpoint(tmp_path / "fold_b")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "training_package_id": "canonical",
+                "folds": [
+                    {
+                        "fold_id": "wf_fold_1",
+                        "train_end": "2022-12-31",
+                        "test_start": "2023-01-02",
+                        "test_end": "2023-06-30",
+                        "checkpoint_dir": str(ckpt_a),
+                    },
+                    {
+                        "fold_id": "wf_fold_2",
+                        "train_end": "2023-06-30",
+                        "test_start": "2023-07-03",
+                        "test_end": "2023-12-31",
+                        "checkpoint_dir": str(ckpt_b),
+                    },
+                    {
+                        "fold_id": "wf_fold_3",
+                        "train_end": "2024-06-30",
+                        "test_start": "2024-07-01",
+                        "test_end": "2024-12-31",
+                        "checkpoint_dir": str(tmp_path / "no_ckpt"),
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # ``as_of`` = 2024-01-15 sits inside wf_fold_2's test window; the
+    # right serving fold has train_end < 2024-01-15, which is wf_fold_2
+    # itself (train_end 2023-06-30, strictly before 2024-01-15).
+    ref = replay_service.resolve_fold_for_date(
+        date(2024, 1, 15), manifest_path=manifest
+    )
+    assert ref.available is True
+    assert ref.fold_id == "wf_fold_2"
+    assert ref.train_end == date(2023, 6, 30)
+    assert ref.forecaster_checkpoint == ckpt_b / "forecaster_best.pt"
+
+
+# ---------------------------------------------------------------------------
+# /analyze API path
+# ---------------------------------------------------------------------------
+
+
+def _stub_market_path(monkeypatch):
+    monkeypatch.setattr(
+        main_mod,
+        "analyze_text",
+        lambda _: {
+            "label": "HAWKISH",
+            "score": 0.62,
+            "raw": [{"label": "HAWKISH", "score": 0.62}],
+        },
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_market_snapshot",
+        lambda **_: {
+            "symbol": "^GSPC",
+            "requested_date": "2024-03-15",
+            "date_used": "2024-03-15",
+            "lookback_days": 5,
+            "close": 5000.0,
+            "volatility_5d": 0.01,
+        },
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_market_history",
+        lambda **_: [
+            {"date": "2024-03-12", "close": 4980.0, "volatility_5d": 0.011},
+            {"date": "2024-03-13", "close": 5000.0, "volatility_5d": 0.010},
+        ],
+    )
+    monkeypatch.setattr(main_mod, "parse_horizon_steps", lambda _: 3)
+    monkeypatch.setattr(
+        main_mod,
+        "fetch_forward_trading_dates",
+        lambda **_: ["2024-03-18", "2024-03-19", "2024-03-20"],
+    )
+    monkeypatch.setattr(
+        main_mod,
+        "forecast_quantitative_series",
+        lambda **_: {
+            "prediction": {"close": 5050.0, "volatility": 0.012, "horizon": "3d"},
+            "model": {
+                "checkpoint_path": "backend/models/forecaster_best.pt",
+                "checkpoint_exists": True,
+                "checkpoint_loaded": True,
+                "runtime_mode": "fast",
+                "hidden_size": 64,
+                "num_layers": 2,
+                "dropout": 0.15,
+                "head_hidden_size": 32,
+                "close_scale": 10000.0,
+                "sequence_length": 5,
+            },
+            "series": {
+                "timestamps": ["2024-03-12", "2024-03-13"],
+                "history_close": [4980.0, 5000.0],
+                "history_volatility": [0.011, 0.01],
+                "forecast_timestamps": ["2024-03-18", "2024-03-19", "2024-03-20"],
+                "forecast_close": [5020.0, 5040.0, 5050.0],
+                "forecast_close_lower": [5000.0, 5015.0, 5020.0],
+                "forecast_close_upper": [5040.0, 5060.0, 5080.0],
+                "forecast_volatility": [0.011, 0.012, 0.012],
+                "forecast_volatility_lower": [0.009, 0.010, 0.010],
+                "forecast_volatility_upper": [0.013, 0.014, 0.015],
+                "forecast_confidence_level": 0.8,
+                "volatility_scale": {"suggested_ymin": 0.0, "suggested_ymax": 0.02},
+            },
+        },
+    )
+    monkeypatch.setattr(main_mod, "checkpoint_exists", lambda: True)
+
+
+def test_replay_mode_returns_422_when_per_fold_checkpoints_missing(monkeypatch):
+    _stub_market_path(monkeypatch)
+    client = TestClient(main_mod.app)
+
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "Recent indicators…",
+            "date": "2024-03-15",
+            "symbol": "^GSPC",
+            "horizon": "3d",
+            "include_realized": False,
+            "as_of_date": "2024-03-15",
+        },
+    )
+    assert response.status_code == 422
+    assert "replay_unavailable" in response.json()["detail"]
+
+
+def test_replay_mode_emits_replay_and_realised_blocks_when_fold_resolves(
+    monkeypatch, tmp_path
+):
+    _stub_market_path(monkeypatch)
+    ckpt = tmp_path / "fold"
+    ckpt.mkdir(parents=True)
+    (ckpt / "forecaster_best.pt").write_bytes(b"stub")
+    manifest = tmp_path / "manifest.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "training_package_id": "canonical",
+                "folds": [
+                    {
+                        "fold_id": "wf_fold_2",
+                        "train_end": "2023-12-31",
+                        "test_start": "2024-01-02",
+                        "test_end": "2024-06-30",
+                        "checkpoint_dir": str(ckpt),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(replay_service, "_DEFAULT_MANIFEST_PATH", manifest)
+    monkeypatch.setattr(
+        replay_service,
+        "realised_outcome",
+        lambda as_of, symbol="^GSPC": {
+            "as_of_date": as_of.isoformat(),
+            "symbol": symbol,
+            "horizons": [
+                {
+                    "horizon": 1,
+                    "log_return": 0.01,
+                    "realised_volatility_5d": 0.005,
+                    "close": 5050.0,
+                    "date": "2024-03-18",
+                },
+                {
+                    "horizon": 5,
+                    "log_return": 0.02,
+                    "realised_volatility_5d": 0.007,
+                    "close": 5100.0,
+                    "date": "2024-03-22",
+                },
+                {
+                    "horizon": 10,
+                    "log_return": None,
+                    "realised_volatility_5d": None,
+                    "close": None,
+                    "date": None,
+                },
+            ],
+        },
+    )
+
+    client = TestClient(main_mod.app)
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "Recent indicators…",
+            "date": "2024-03-15",
+            "symbol": "^GSPC",
+            "horizon": "3d",
+            "include_realized": False,
+            "as_of_date": "2024-03-15",
+        },
+    )
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["replay"] is not None
+    assert body["replay"]["as_of_date"] == "2024-03-15"
+    assert body["replay"]["fold_id"] == "wf_fold_2"
+    assert body["replay"]["train_end"] == "2023-12-31"
+    assert body["replay"]["classifier_rewind"] is False
+    assert any("classifier rewind" in note.lower() for note in body["replay"]["notes"])
+    assert body["realised_outcome"] is not None
+    horizons = {h["horizon"]: h for h in body["realised_outcome"]["horizons"]}
+    assert horizons[1]["log_return"] == pytest.approx(0.01)
+    assert horizons[10]["log_return"] is None
+
+
+def test_live_mode_payload_is_unchanged_when_as_of_date_omitted(monkeypatch):
+    _stub_market_path(monkeypatch)
+    client = TestClient(main_mod.app)
+    response = client.post(
+        "/analyze",
+        json={
+            "text": "Recent indicators…",
+            "date": "2026-03-15",
+            "symbol": "^GSPC",
+            "horizon": "3d",
+            "include_realized": False,
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("replay") is None
+    assert body.get("realised_outcome") is None

--- a/tests/unit/test_replay_mode.py
+++ b/tests/unit/test_replay_mode.py
@@ -244,7 +244,10 @@ def test_replay_mode_returns_422_when_per_fold_checkpoints_missing(monkeypatch):
         },
     )
     assert response.status_code == 422
-    assert "replay_unavailable" in response.json()["detail"]
+    detail = response.json()["detail"]
+    assert isinstance(detail, dict), detail
+    assert detail["error"] == "replay_unavailable"
+    assert detail["message"]
 
 
 def test_replay_mode_emits_replay_and_realised_blocks_when_fold_resolves(
@@ -283,21 +286,21 @@ def test_replay_mode_emits_replay_and_realised_blocks_when_fold_resolves(
                 {
                     "horizon": 1,
                     "log_return": 0.01,
-                    "realised_volatility_5d": 0.005,
+                    "realised_volatility_5d_post_event": 0.005,
                     "close": 5050.0,
                     "date": "2024-03-18",
                 },
                 {
                     "horizon": 5,
                     "log_return": 0.02,
-                    "realised_volatility_5d": 0.007,
+                    "realised_volatility_5d_post_event": 0.007,
                     "close": 5100.0,
                     "date": "2024-03-22",
                 },
                 {
                     "horizon": 10,
                     "log_return": None,
-                    "realised_volatility_5d": None,
+                    "realised_volatility_5d_post_event": None,
                     "close": None,
                     "date": None,
                 },


### PR DESCRIPTION
## Summary
- Optional `as_of_date` on AnalyzeRequest; when set, the request runs in replay mode
- New `backend/app/services/replay.py` resolves date -> fold via a `fold_manifest_expanding_walk_forward.json` contract documented in the module docstring
- Response gains `replay` (fold id, train_end, classifier_rewind=false, notes) and `realised_outcome` (h=1/5/10 realised vol and log-return) blocks
- Frontend: replay toggle + as-of date picker in AnalyzeForm, banner above the Workspace, collapsible "what actually happened" reveal card
- Analogs threading respects `as_of_date <= date` to keep retrieval strictly backward in replay mode
- 7 new pytest cases in tests/unit/test_replay_mode.py covering fold resolution + API contracts

## Known gaps (deliberate)
- Per-fold forecaster checkpoints are not yet deployed. While they're absent, every replay request returns 422 with `replay_unavailable: fold_manifest_missing`. The hookup is one small follow-up once the runner drops the manifest + per-fold .pt files.
- Text classifier weights are NOT rewound (DAPT pin is post-X); the banner surfaces this honestly via the `classifier_rewind=false` flag.

## Test plan
- [ ] docker compose run --rm backend pytest tests/unit/test_replay_mode.py -q