### PR TITLE
Cross-bank dashboard: side-by-side stance + vol-regime for Fed, ECB, BoE, BoC, BoJ, RBA

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2844,9 +2844,7 @@ async def cross_bank_snapshot() -> CrossBankSnapshotResponse:
         payload = await run_in_threadpool(build_snapshot)
     except Exception:  # pragma: no cover -- defensive
         logger.exception("cross_bank_snapshot_failed")
-        raise HTTPException(
-            status_code=503, detail="Cross-bank snapshot unavailable"
-        ) from None
+        raise HTTPException(status_code=503, detail="Cross-bank snapshot unavailable") from None
 
     cards = [CrossBankCard(**row) for row in payload.get("banks", [])]
     return CrossBankSnapshotResponse(

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,6 +86,8 @@ from app.schemas import (
     TrajectoryRequest,
     TrajectoryResponse,
     VolRegimeReactionCard,
+    CrossBankCard,
+    CrossBankSnapshotResponse,
 )
 from app.evaluation.xai import attribute_text, split_sentences, to_response as xai_to_response
 from app.services.document_parser import (
@@ -2815,4 +2817,40 @@ async def analyze_trajectory(payload: TrajectoryRequest) -> TrajectoryResponse:
         train_end=result.get("train_end"),
         as_of_date=str(result.get("as_of_date") or payload.as_of_date.isoformat()),
         warning=result.get("warning"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cross-bank dashboard panel (xbank-DAPT classifier surfaced across six banks)
+# ---------------------------------------------------------------------------
+@app.get("/cross-bank/snapshot", response_model=CrossBankSnapshotResponse)
+async def cross_bank_snapshot() -> CrossBankSnapshotResponse:
+    """Side-by-side stance + vol-regime read for Fed / ECB / BoE / BoC / BoJ / RBA.
+
+    Backed by ``app.services.cross_bank_snapshot.build_snapshot``. The
+    multi-axis classifier was continued-pretrained on the xbank-DAPT
+    substrate so it is valid across all six banks; the vol-regime tag
+    is a coarse 5d-realised-vol band against the bank's flagship
+    equity index. Results cache in-process for an hour.
+
+    Returns an explicit ``status`` per card so the frontend can render
+    a "Coming soon" placeholder for any bank where the corpus or
+    market lookup degraded, instead of a 500 across the whole panel.
+    """
+
+    from app.services.cross_bank_snapshot import build_snapshot
+
+    try:
+        payload = await run_in_threadpool(build_snapshot)
+    except Exception:  # pragma: no cover -- defensive
+        logger.exception("cross_bank_snapshot_failed")
+        raise HTTPException(
+            status_code=503, detail="Cross-bank snapshot unavailable"
+        ) from None
+
+    cards = [CrossBankCard(**row) for row in payload.get("banks", [])]
+    return CrossBankSnapshotResponse(
+        banks=cards,
+        generated_at=str(payload.get("generated_at") or ""),
+        cache_ttl_seconds=int(payload.get("cache_ttl_seconds") or 0),
     )

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1915,3 +1915,53 @@ class RvBacktestResponse(BaseModel):
     rows: list[RvBacktestRow]
     coverage: RvBacktestCoverage
     generated_at: str
+
+
+class CrossBankCard(BaseModel):
+    """One central-bank card on the cross-bank dashboard panel.
+
+    Mirrors the dict shape emitted by
+    :func:`app.services.cross_bank_snapshot.build_bank_card`. Heads
+    that could not be filled (corpus missing for a bank, classifier
+    checkpoint unavailable, market-data lookup failed) leave the
+    matching field as ``None`` and surface the reason in ``status`` /
+    ``vol_regime_status`` so the frontend renders an explicit
+    "Coming soon" placeholder rather than blank space.
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    bank: str
+    short_code: str
+    display_name: str
+    flag: str
+    symbol: str
+    latest_statement_date: str | None
+    stance: dict[str, float] | None
+    stance_label: str | None
+    stance_confidence: float | None
+    certainty_label: str | None
+    certainty_confidence: float | None
+    time_axis: str | None
+    vol_regime_label: str | None
+    vol_regime_confidence: float | None
+    vol_regime_as_of: str | None
+    vol_regime_status: str | None
+    sample_size: int
+    status: str
+
+
+class CrossBankSnapshotResponse(BaseModel):
+    """Response wire shape for ``GET /cross-bank/snapshot``.
+
+    Six-card side-by-side stance + vol-regime read across Fed, ECB,
+    BoE, BoC, BoJ, RBA. Cached in-process for an hour (statements do
+    not change minute-to-minute and the classifier cold-start is
+    expensive).
+    """
+
+    model_config = _FORBID_FROZEN_CONFIG
+
+    banks: list[CrossBankCard]
+    generated_at: str
+    cache_ttl_seconds: int

--- a/backend/app/services/cross_bank_snapshot.py
+++ b/backend/app/services/cross_bank_snapshot.py
@@ -399,6 +399,38 @@ def build_snapshot(
             if entry is not None and entry.expires_at > now:
                 return entry.payload
 
+    # Double-checked locking: hold the lock across the full rebuild so a
+    # post-TTL burst of concurrent requests does not fan out N parallel
+    # classifier runs. Waiters re-check the cache after acquiring the
+    # lock and return the freshly built payload instead of rebuilding.
+    # The rebuild itself takes ~6 s cold which is acceptable to serialise;
+    # subsequent hits in the same TTL window are O(ms).
+    if use_cache:
+        with _cache_lock:
+            entry = _cache.get(cache_key)
+            now = time.time()
+            if entry is not None and entry.expires_at > now:
+                return entry.payload
+            banks = [
+                build_bank_card(
+                    spec,
+                    score_text=score_text,
+                    market_lookup=market_lookup,
+                    registry_path=registry_path,
+                )
+                for spec in BANK_SPECS
+            ]
+            payload = {
+                "banks": banks,
+                "generated_at": datetime.now(timezone.utc).isoformat(),
+                "cache_ttl_seconds": _CACHE_TTL_SECONDS,
+            }
+            _cache[cache_key] = _CacheEntry(payload=payload, expires_at=now + _CACHE_TTL_SECONDS)
+            return payload
+
+    # Cache disabled path (tests, ad-hoc calls): build without touching
+    # the cache so a test that monkeypatches ``score_text`` cannot
+    # poison the production cache for the next non-mocked request.
     banks = [
         build_bank_card(
             spec,
@@ -408,16 +440,11 @@ def build_snapshot(
         )
         for spec in BANK_SPECS
     ]
-    payload = {
+    return {
         "banks": banks,
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "cache_ttl_seconds": _CACHE_TTL_SECONDS,
     }
-
-    if use_cache:
-        with _cache_lock:
-            _cache[cache_key] = _CacheEntry(payload=payload, expires_at=now + _CACHE_TTL_SECONDS)
-    return payload
 
 
 def reset_cache() -> None:

--- a/backend/app/services/cross_bank_snapshot.py
+++ b/backend/app/services/cross_bank_snapshot.py
@@ -1,0 +1,437 @@
+"""Cross-bank stance + vol-regime snapshot service.
+
+Backs ``GET /cross-bank/snapshot``. For each of the six central banks the
+xbank-DAPT multi-axis classifier was trained on (Fed, ECB, BoE, BoC, BoJ,
+RBA), this module:
+
+1. Pulls the most recent annotated sentences from the ingested
+   ``source_registry.jsonl`` (the gtfintechlab corpus is rev-pinned at
+   ingest time; event_date is year-rounded).
+2. Runs the multi-axis classifier (``score_text``) over a small sample and
+   averages the stance/certainty/time distributions to produce one card
+   per bank. The classifier weights are bank-aware because the xbank-DAPT
+   continued-pretraining substrate already saw all six banks' corpora.
+3. Looks up the bank's flagship equity index (^GSPC, ^STOXX50E, ^FTSE,
+   ^GSPTSE, ^N225, ^AXJO) and bins the trailing 5-day realised volatility
+   into ``calm`` / ``normal`` / ``high`` against a per-symbol band. This
+   is a coarse heuristic that does not depend on the Fed-trained
+   vol-regime classifier (which was calibrated on ^GSPC FOMC-day windows
+   and is not transferable cross-asset).
+
+Results are cached in-process for ``_CACHE_TTL_SECONDS`` (default 1h) — a
+Fed/ECB/BoE statement does not change minute to minute, and the
+classifier cold-start is the most expensive part of the path.
+
+When the corpus or the classifier checkpoint is missing for a bank, the
+card is still emitted with ``status="corpus_missing"`` /
+``status="classifier_unavailable"`` so the frontend can render a
+"Coming soon" placeholder instead of a 500.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from app.config import DATA_DIR
+from app.models.config import MULTI_TASK_STANCE_LABELS
+
+_logger = logging.getLogger(__name__)
+
+# Cache TTL: an hour balances "fresh enough for the dashboard" against
+# the cold-start cost of the multi-axis classifier checkpoint load.
+_CACHE_TTL_SECONDS = 3600
+
+# Sentence sample size per bank. The classifier is ~30 ms/sentence on
+# CPU after warm-up; 32 keeps the worst-case panel build under ~6 s
+# across all six banks while still smoothing per-sentence noise.
+_SAMPLE_SIZE = 32
+
+
+@dataclass(frozen=True)
+class BankSpec:
+    key: str
+    source: str
+    display_name: str
+    flag: str  # ISO country code; frontend maps to flag emoji
+    symbol: str
+    short_code: str  # FED / ECB / BOE / BOC / BOJ / RBA
+
+
+BANK_SPECS: tuple[BankSpec, ...] = (
+    BankSpec(
+        key="fed",
+        source="gtfintechlab_federal_reserve_system",
+        display_name="Federal Reserve",
+        flag="US",
+        symbol="^GSPC",
+        short_code="FED",
+    ),
+    BankSpec(
+        key="ecb",
+        source="gtfintechlab_european_central_bank",
+        display_name="European Central Bank",
+        flag="EU",
+        symbol="^STOXX50E",
+        short_code="ECB",
+    ),
+    BankSpec(
+        key="boe",
+        source="gtfintechlab_bank_of_england",
+        display_name="Bank of England",
+        flag="GB",
+        symbol="^FTSE",
+        short_code="BOE",
+    ),
+    BankSpec(
+        key="boc",
+        source="gtfintechlab_bank_of_canada",
+        display_name="Bank of Canada",
+        flag="CA",
+        symbol="^GSPTSE",
+        short_code="BOC",
+    ),
+    BankSpec(
+        key="boj",
+        source="gtfintechlab_bank_of_japan",
+        display_name="Bank of Japan",
+        flag="JP",
+        symbol="^N225",
+        short_code="BOJ",
+    ),
+    BankSpec(
+        key="rba",
+        source="gtfintechlab_reserve_bank_of_australia",
+        display_name="Reserve Bank of Australia",
+        flag="AU",
+        symbol="^AXJO",
+        short_code="RBA",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class _CacheEntry:
+    payload: dict[str, Any]
+    expires_at: float
+
+
+_cache: dict[str, _CacheEntry] = {}
+_cache_lock = threading.Lock()
+
+
+def _registry_path() -> Path:
+    return DATA_DIR / "raw" / "phase2" / "source_registry.jsonl"
+
+
+def _load_recent_sentences(
+    source: str,
+    *,
+    limit: int = _SAMPLE_SIZE,
+    registry_path: Path | None = None,
+) -> tuple[list[str], str | None]:
+    """Return ``(sentences, latest_event_date_iso)`` for the given bank.
+
+    Streams ``source_registry.jsonl`` so the full registry never sits
+    in memory (it tops 600 MB at full ingest). The gtfintechlab corpora
+    use a year-rounded ``event_date``; we still walk the file and pick
+    the rows with the maximum date, sampling up to ``limit`` from that
+    set. Returns an empty list + ``None`` when the registry or the
+    source is absent.
+    """
+
+    path = registry_path or _registry_path()
+    if not path.exists():
+        _logger.warning("cross_bank_snapshot_registry_missing path=%s", path)
+        return [], None
+
+    latest_date = ""
+    bucket: list[str] = []
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            for line in fh:
+                if not line.strip():
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if row.get("source") != source:
+                    continue
+                text = (row.get("text") or "").strip()
+                if not text:
+                    continue
+                event_date = row.get("event_date") or ""
+                if event_date > latest_date:
+                    latest_date = event_date
+                    bucket = [text]
+                elif event_date == latest_date:
+                    bucket.append(text)
+    except OSError as exc:
+        _logger.warning(
+            "cross_bank_snapshot_registry_read_failed source=%s err=%s",
+            source,
+            exc,
+        )
+        return [], None
+
+    if not bucket:
+        return [], None
+
+    # Deterministic sample: alphabetical sort + head ``limit`` so a
+    # cache rebuild on a fresh process produces the same card.
+    bucket.sort()
+    sample = bucket[:limit]
+    return sample, (latest_date or None)
+
+
+def _aggregate_distribution(
+    scores: list[dict[str, Any]],
+    block: str,
+    labels: tuple[str, ...],
+) -> dict[str, float] | None:
+    """Average the per-class softmax across the sentence scores.
+
+    Returns ``None`` when no usable score is present. Renormalises
+    after averaging to absorb floating-point drift.
+    """
+
+    sums: dict[str, float] = {label: 0.0 for label in labels}
+    n = 0
+    for score in scores:
+        if not score:
+            continue
+        dist = (score.get(block) or {}).get("distribution") or {}
+        if not dist:
+            continue
+        for label in labels:
+            sums[label] += float(dist.get(label, 0.0))
+        n += 1
+    if n == 0:
+        return None
+    averaged = {label: sums[label] / n for label in labels}
+    total = sum(averaged.values())
+    if total <= 0:
+        return None
+    return {label: value / total for label, value in averaged.items()}
+
+
+def _argmax_label(
+    dist: dict[str, float] | None,
+) -> tuple[str | None, float | None]:
+    if not dist:
+        return None, None
+    label = max(dist, key=lambda k: dist[k])
+    return label, float(dist[label])
+
+
+def _build_vol_regime(symbol: str) -> dict[str, Any]:
+    """Return ``{label, confidence, close, vol_5d_annualised, as_of, status}``.
+
+    Uses a coarse 5-day realised-vol band: annualised vol < 12% -> calm,
+    > 22% -> high, else normal. Cuts are intentionally the same across
+    all six indices — this surfaces a quick cross-bank read, not a
+    calibrated regime forecast.
+    """
+
+    try:
+        from app.services.market_data import fetch_market_snapshot
+    except Exception as exc:  # pragma: no cover -- import-time only
+        _logger.warning(
+            "cross_bank_snapshot_market_data_import_failed err=%s", exc
+        )
+        return {
+            "label": None,
+            "confidence": None,
+            "close": None,
+            "vol_5d_annualised": None,
+            "as_of": None,
+            "status": "market_data_unavailable",
+        }
+
+    today_iso = date.today().isoformat()
+    try:
+        snapshot = fetch_market_snapshot(
+            target_date=today_iso,
+            symbol=symbol,
+            lookback_days=14,
+            volatility_window=5,
+        )
+    except Exception as exc:  # noqa: BLE001 -- graceful degradation
+        _logger.warning(
+            "cross_bank_snapshot_market_fetch_failed symbol=%s err=%s",
+            symbol,
+            exc,
+        )
+        return {
+            "label": None,
+            "confidence": None,
+            "close": None,
+            "vol_5d_annualised": None,
+            "as_of": None,
+            "status": "market_data_unavailable",
+        }
+
+    vol_5d_raw = float(snapshot.get("volatility_5d") or 0.0)
+    annualised = vol_5d_raw * (252 ** 0.5)
+    if annualised < 0.12:
+        label = "calm"
+    elif annualised > 0.22:
+        label = "high"
+    else:
+        label = "normal"
+
+    # A crude "confidence": distance from the nearer band edge, clamped
+    # into [0.55, 0.95]. Rendered as a confidence chip on the card.
+    band_edges = (0.12, 0.22)
+    nearest_edge = min(band_edges, key=lambda edge: abs(annualised - edge))
+    distance = abs(annualised - nearest_edge)
+    confidence = max(0.55, min(0.95, 0.55 + 4.0 * distance))
+
+    return {
+        "label": label,
+        "confidence": float(round(confidence, 4)),
+        "close": float(snapshot.get("close") or 0.0),
+        "vol_5d_annualised": float(round(annualised, 6)),
+        "as_of": str(snapshot.get("date_used") or today_iso),
+        "status": "ok",
+    }
+
+
+def build_bank_card(
+    spec: BankSpec,
+    *,
+    score_text: Callable[[str], dict[str, Any] | None] | None = None,
+    market_lookup: Callable[[str], dict[str, Any]] | None = None,
+    registry_path: Path | None = None,
+) -> dict[str, Any]:
+    """Build one bank card. Pure function over its injected dependencies.
+
+    ``score_text`` defaults to the lazy singleton in
+    :mod:`app.services.multi_axis_classifier`; injecting a stub keeps
+    the unit test offline. ``market_lookup`` is a callable
+    ``symbol -> vol_regime_dict``; defaults to ``_build_vol_regime``.
+    """
+
+    if score_text is None:
+        from app.services.multi_axis_classifier import score_text as _score_text
+
+        score_text = _score_text
+    if market_lookup is None:
+        market_lookup = _build_vol_regime
+
+    sentences, latest = _load_recent_sentences(
+        spec.source, registry_path=registry_path
+    )
+    scores: list[dict[str, Any]] = []
+    if sentences:
+        for sentence in sentences:
+            try:
+                result = score_text(sentence)
+            except Exception as exc:  # noqa: BLE001 -- per-sentence guard
+                _logger.debug(
+                    "cross_bank_snapshot_score_failed bank=%s err=%s",
+                    spec.key,
+                    exc,
+                )
+                continue
+            if result:
+                scores.append(result)
+
+    stance_dist = _aggregate_distribution(
+        scores, "stance", MULTI_TASK_STANCE_LABELS
+    )
+    stance_label, stance_conf = _argmax_label(stance_dist)
+
+    certainty_dist = _aggregate_distribution(
+        scores, "certainty", ("certain", "uncertain", "neutral")
+    )
+    certainty_label, certainty_conf = _argmax_label(certainty_dist)
+
+    time_dist = _aggregate_distribution(
+        scores, "time", ("forward looking", "not forward looking")
+    )
+    time_label, _ = _argmax_label(time_dist)
+
+    vol_regime = market_lookup(spec.symbol)
+
+    if not sentences:
+        status = "corpus_missing"
+    elif stance_dist is None:
+        status = "classifier_unavailable"
+    else:
+        status = "ok"
+
+    return {
+        "bank": spec.key,
+        "short_code": spec.short_code,
+        "display_name": spec.display_name,
+        "flag": spec.flag,
+        "symbol": spec.symbol,
+        "latest_statement_date": latest,
+        "stance": stance_dist,
+        "stance_label": stance_label,
+        "stance_confidence": stance_conf,
+        "certainty_label": certainty_label,
+        "certainty_confidence": certainty_conf,
+        "time_axis": time_label,
+        "vol_regime_label": vol_regime.get("label"),
+        "vol_regime_confidence": vol_regime.get("confidence"),
+        "vol_regime_as_of": vol_regime.get("as_of"),
+        "vol_regime_status": vol_regime.get("status"),
+        "sample_size": len(scores),
+        "status": status,
+    }
+
+
+def build_snapshot(
+    *,
+    score_text: Callable[[str], dict[str, Any] | None] | None = None,
+    market_lookup: Callable[[str], dict[str, Any]] | None = None,
+    registry_path: Path | None = None,
+    use_cache: bool = True,
+) -> dict[str, Any]:
+    """Public entrypoint. Builds the six-bank panel with TTL caching."""
+
+    cache_key = "default"
+    now = time.time()
+    if use_cache:
+        with _cache_lock:
+            entry = _cache.get(cache_key)
+            if entry is not None and entry.expires_at > now:
+                return entry.payload
+
+    banks = [
+        build_bank_card(
+            spec,
+            score_text=score_text,
+            market_lookup=market_lookup,
+            registry_path=registry_path,
+        )
+        for spec in BANK_SPECS
+    ]
+    payload = {
+        "banks": banks,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "cache_ttl_seconds": _CACHE_TTL_SECONDS,
+    }
+
+    if use_cache:
+        with _cache_lock:
+            _cache[cache_key] = _CacheEntry(
+                payload=payload, expires_at=now + _CACHE_TTL_SECONDS
+            )
+    return payload
+
+
+def reset_cache() -> None:
+    """Drop the in-process snapshot cache (test hook)."""
+
+    with _cache_lock:
+        _cache.clear()

--- a/backend/app/services/cross_bank_snapshot.py
+++ b/backend/app/services/cross_bank_snapshot.py
@@ -130,7 +130,7 @@ def _registry_path() -> Path:
     return DATA_DIR / "raw" / "phase2" / "source_registry.jsonl"
 
 
-def _load_recent_sentences(
+def _load_recent_sentences(  # noqa: C901 - branching is per-line defensive parsing
     source: str,
     *,
     limit: int = _SAMPLE_SIZE,

--- a/backend/app/services/cross_bank_snapshot.py
+++ b/backend/app/services/cross_bank_snapshot.py
@@ -243,9 +243,7 @@ def _build_vol_regime(symbol: str) -> dict[str, Any]:
     try:
         from app.services.market_data import fetch_market_snapshot
     except Exception as exc:  # pragma: no cover -- import-time only
-        _logger.warning(
-            "cross_bank_snapshot_market_data_import_failed err=%s", exc
-        )
+        _logger.warning("cross_bank_snapshot_market_data_import_failed err=%s", exc)
         return {
             "label": None,
             "confidence": None,
@@ -279,7 +277,7 @@ def _build_vol_regime(symbol: str) -> dict[str, Any]:
         }
 
     vol_5d_raw = float(snapshot.get("volatility_5d") or 0.0)
-    annualised = vol_5d_raw * (252 ** 0.5)
+    annualised = vol_5d_raw * (252**0.5)
     if annualised < 0.12:
         label = "calm"
     elif annualised > 0.22:
@@ -326,9 +324,7 @@ def build_bank_card(
     if market_lookup is None:
         market_lookup = _build_vol_regime
 
-    sentences, latest = _load_recent_sentences(
-        spec.source, registry_path=registry_path
-    )
+    sentences, latest = _load_recent_sentences(spec.source, registry_path=registry_path)
     scores: list[dict[str, Any]] = []
     if sentences:
         for sentence in sentences:
@@ -344,9 +340,7 @@ def build_bank_card(
             if result:
                 scores.append(result)
 
-    stance_dist = _aggregate_distribution(
-        scores, "stance", MULTI_TASK_STANCE_LABELS
-    )
+    stance_dist = _aggregate_distribution(scores, "stance", MULTI_TASK_STANCE_LABELS)
     stance_label, stance_conf = _argmax_label(stance_dist)
 
     certainty_dist = _aggregate_distribution(
@@ -354,9 +348,7 @@ def build_bank_card(
     )
     certainty_label, certainty_conf = _argmax_label(certainty_dist)
 
-    time_dist = _aggregate_distribution(
-        scores, "time", ("forward looking", "not forward looking")
-    )
+    time_dist = _aggregate_distribution(scores, "time", ("forward looking", "not forward looking"))
     time_label, _ = _argmax_label(time_dist)
 
     vol_regime = market_lookup(spec.symbol)
@@ -424,9 +416,7 @@ def build_snapshot(
 
     if use_cache:
         with _cache_lock:
-            _cache[cache_key] = _CacheEntry(
-                payload=payload, expires_at=now + _CACHE_TTL_SECONDS
-            )
+            _cache[cache_key] = _CacheEntry(payload=payload, expires_at=now + _CACHE_TTL_SECONDS)
     return payload
 
 

--- a/frontend/components/shell/header.tsx
+++ b/frontend/components/shell/header.tsx
@@ -8,6 +8,7 @@ import {
   FlaskConical,
   Gavel,
   Github,
+  Globe,
   History as HistoryIcon,
   LineChart,
   Menu,
@@ -23,6 +24,7 @@ import { cn } from "@/lib/utils";
 const NAV_ITEMS: Array<{ href: string; label: string; icon: React.ComponentType<{ className?: string }> }> = [
   { href: "/", label: "Workspace", icon: Activity },
   { href: "/decisions", label: "Decisions", icon: Gavel },
+  { href: "/cross-bank", label: "Cross-bank", icon: Globe },
   { href: "/history", label: "History", icon: HistoryIcon },
   { href: "/calendar", label: "Calendar", icon: Calendar },
   { href: "/performance", label: "Performance", icon: LineChart },

--- a/frontend/lib/analyze/api.ts
+++ b/frontend/lib/analyze/api.ts
@@ -7,6 +7,7 @@ import type {
   BacktestPositionEntry,
   BacktestResponse,
   ClassificationBreakdownResponse,
+  CrossBankSnapshotResponse,
   DocumentDetailResponse,
   EvaluationCoverageResponse,
   ExpectedVolumeForecastResponse,
@@ -515,4 +516,12 @@ export async function postResearchBacktest(
 ): Promise<BacktestResponse> {
   const response = await axios.post(`${baseUrl}/research/backtest`, body);
   return response.data as BacktestResponse;
+}
+
+export async function fetchCrossBankSnapshot(
+  baseUrl: string,
+  signal?: AbortSignal,
+): Promise<CrossBankSnapshotResponse> {
+  const response = await axios.get(`${baseUrl}/cross-bank/snapshot`, { signal });
+  return response.data as CrossBankSnapshotResponse;
 }

--- a/frontend/lib/analyze/constants.ts
+++ b/frontend/lib/analyze/constants.ts
@@ -19,6 +19,15 @@ export const SYMBOL_OPTIONS: SymbolOption[] = [
   { value: "EURUSD=X", label: "EUR/USD (EURUSD=X)" },
   { value: "BTC-USD", label: "Bitcoin (BTC-USD)" },
   { value: "^TNX", label: "US 10Y Yield (^TNX)" },
+  // Cross-bank flagship indices. Available so the cross-bank page's
+  // "Open in Workspace" deep-link lands on a known symbol; the HAR-
+  // tercile + RV backtest panels gracefully degrade for tickers not
+  // in HAR_TERCILE_SUPPORTED_SYMBOLS below.
+  { value: "^STOXX50E", label: "Euro Stoxx 50 (^STOXX50E)" },
+  { value: "^FTSE", label: "FTSE 100 (^FTSE)" },
+  { value: "^GSPTSE", label: "S&P/TSX Composite (^GSPTSE)" },
+  { value: "^N225", label: "Nikkei 225 (^N225)" },
+  { value: "^AXJO", label: "ASX 200 (^AXJO)" },
 ];
 
 export const HORIZON_OPTIONS: Horizon[] = ["1d", "3d", "5d", "10d"];

--- a/frontend/lib/analyze/types.ts
+++ b/frontend/lib/analyze/types.ts
@@ -972,3 +972,30 @@ export interface SemanticDiffResponse {
   summary: string;
   status?: SemanticDiffStatus | null;
 }
+
+export interface CrossBankCard {
+  bank: string;
+  short_code: string;
+  display_name: string;
+  flag: string;
+  symbol: string;
+  latest_statement_date: string | null;
+  stance: Record<string, number> | null;
+  stance_label: string | null;
+  stance_confidence: number | null;
+  certainty_label: string | null;
+  certainty_confidence: number | null;
+  time_axis: string | null;
+  vol_regime_label: string | null;
+  vol_regime_confidence: number | null;
+  vol_regime_as_of: string | null;
+  vol_regime_status: string | null;
+  sample_size: number;
+  status: string;
+}
+
+export interface CrossBankSnapshotResponse {
+  banks: CrossBankCard[];
+  generated_at: string;
+  cache_ttl_seconds: number;
+}

--- a/frontend/pages/cross-bank.tsx
+++ b/frontend/pages/cross-bank.tsx
@@ -238,9 +238,18 @@ export default function CrossBankPage(): JSX.Element {
               Side-by-side stance and volatility-regime read across six major
               central banks, scored by the xbank-DAPT multi-axis classifier
               against the latest annotated sentences from each bank's
-              published communications. Vol regime is a coarse 5-day realised
-              volatility band on the bank's flagship equity index. Cards
-              refresh hourly.
+              published communications. Cards refresh hourly.
+            </p>
+            <p className="max-w-3xl text-xs text-muted-foreground">
+              Vol regime is a coarse 5-day annualised realised-vol band
+              (calm &lt; 12%, normal, high &gt; 22%) on each bank's flagship
+              equity index. The thresholds are deliberately uniform across
+              indices so cards are directly comparable on the same scale;
+              indices with a higher baseline vol (e.g. ^N225) will lean
+              toward "normal"/"high" and lower-vol indices (e.g. ^FTSE)
+              toward "calm"/"normal" by construction. Read the regime as
+              a within-card direction signal, not a cross-card severity
+              ranking.
             </p>
             {data?.generated_at ? (
               <p className="text-xs text-muted-foreground">

--- a/frontend/pages/cross-bank.tsx
+++ b/frontend/pages/cross-bank.tsx
@@ -1,0 +1,281 @@
+import * as React from "react";
+import Head from "next/head";
+import Link from "next/link";
+import { ArrowUpRight, Clock, Globe } from "lucide-react";
+import { toast } from "sonner";
+
+import { Header } from "@/components/shell/header";
+import { StatusBar } from "@/components/shell/status-bar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { fetchCrossBankSnapshot, resolveApiBaseUrl } from "@/lib/analyze/api";
+import { errorMessage } from "@/lib/analyze/errors";
+import type {
+  CrossBankCard,
+  CrossBankSnapshotResponse,
+} from "@/lib/analyze/types";
+
+// Convert an ISO-3166 alpha-2 country code (e.g. "GB") into the matching
+// regional indicator flag emoji. The xbank ECB card uses "EU", which is
+// not technically a country code but ships a flag glyph in modern fonts.
+function flagFromCode(code: string): string {
+  if (!code) return "";
+  if (code === "EU") return "\u{1F1EA}\u{1F1FA}";
+  const upper = code.toUpperCase();
+  if (upper.length !== 2) return "";
+  const base = 0x1f1e6;
+  const a = upper.charCodeAt(0) - 65;
+  const b = upper.charCodeAt(1) - 65;
+  if (a < 0 || a > 25 || b < 0 || b > 25) return "";
+  return String.fromCodePoint(base + a, base + b);
+}
+
+function stanceBadgeVariant(label: string | null): "hawkish" | "dovish" | "neutral" | "outline" {
+  if (label === "hawkish") return "hawkish";
+  if (label === "dovish") return "dovish";
+  if (label === "neutral") return "neutral";
+  return "outline";
+}
+
+function regimeBadgeVariant(label: string | null): "hawkish" | "dovish" | "neutral" | "outline" {
+  if (label === "high") return "hawkish";
+  if (label === "calm") return "dovish";
+  if (label === "normal") return "neutral";
+  return "outline";
+}
+
+function formatPercent(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return "—";
+  // gtfintechlab event_dates are year-rounded ("2024-01-01"); show just the
+  // year when the day is 01-01 so we don't imply day-level precision.
+  if (/-01-01$/.test(value)) return value.slice(0, 4);
+  return value;
+}
+
+function BankCardSkeleton(): JSX.Element {
+  return (
+    <Card>
+      <CardHeader className="space-y-2">
+        <Skeleton className="h-5 w-40" />
+        <Skeleton className="h-3 w-24" />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-full" />
+        <Skeleton className="h-8 w-2/3" />
+      </CardContent>
+    </Card>
+  );
+}
+
+function BankCardView({ card }: { card: CrossBankCard }): JSX.Element {
+  const flag = flagFromCode(card.flag);
+  const stanceVariant = stanceBadgeVariant(card.stance_label);
+  const regimeVariant = regimeBadgeVariant(card.vol_regime_label);
+  const workspaceHref = `/?symbol=${encodeURIComponent(card.symbol)}`;
+  const stanceUnavailable =
+    card.status === "corpus_missing" || card.status === "classifier_unavailable";
+  const stanceUnavailableMessage =
+    card.status === "corpus_missing"
+      ? "Corpus not ingested yet — coming soon."
+      : "Classifier checkpoint unavailable.";
+
+  return (
+    <Card className="flex h-full flex-col">
+      <CardHeader className="space-y-1">
+        <div className="flex items-start justify-between gap-2">
+          <div className="space-y-0.5">
+            <CardTitle className="flex items-center gap-2 text-lg">
+              <span aria-hidden="true" className="text-2xl leading-none">
+                {flag || <Globe className="h-5 w-5" />}
+              </span>
+              <span>{card.short_code}</span>
+            </CardTitle>
+            <CardDescription>{card.display_name}</CardDescription>
+          </div>
+          <Badge variant="outline" className="font-mono text-[10px] uppercase tracking-wider">
+            {card.symbol}
+          </Badge>
+        </div>
+        <p className="flex items-center gap-1 text-xs text-muted-foreground">
+          <Clock className="h-3 w-3" aria-hidden="true" />
+          Latest sample: {formatDate(card.latest_statement_date)}
+        </p>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col justify-between gap-4">
+        <section aria-label="Stance" className="space-y-2">
+          <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <span>Stance</span>
+            {card.sample_size > 0 ? <span>{card.sample_size} sentences</span> : null}
+          </div>
+          {stanceUnavailable ? (
+            <p className="text-sm text-muted-foreground">{stanceUnavailableMessage}</p>
+          ) : (
+            <>
+              <div className="flex items-center gap-2">
+                <Badge variant={stanceVariant} className="text-sm capitalize">
+                  {card.stance_label ?? "—"}
+                </Badge>
+                <span className="text-sm font-medium text-foreground">
+                  {formatPercent(card.stance_confidence)}
+                </span>
+              </div>
+              {card.stance ? (
+                <dl className="grid grid-cols-3 gap-1 text-xs text-muted-foreground">
+                  <div className="space-y-0.5">
+                    <dt className="uppercase tracking-wide">Hawk</dt>
+                    <dd className="font-mono text-foreground">{formatPercent(card.stance.hawkish ?? 0)}</dd>
+                  </div>
+                  <div className="space-y-0.5">
+                    <dt className="uppercase tracking-wide">Neutral</dt>
+                    <dd className="font-mono text-foreground">{formatPercent(card.stance.neutral ?? 0)}</dd>
+                  </div>
+                  <div className="space-y-0.5">
+                    <dt className="uppercase tracking-wide">Dove</dt>
+                    <dd className="font-mono text-foreground">{formatPercent(card.stance.dovish ?? 0)}</dd>
+                  </div>
+                </dl>
+              ) : null}
+              {card.time_axis ? (
+                <p className="text-xs text-muted-foreground">
+                  Time horizon: <span className="text-foreground">{card.time_axis}</span>
+                </p>
+              ) : null}
+            </>
+          )}
+        </section>
+
+        <section aria-label="Vol regime" className="space-y-2 border-t border-border pt-3">
+          <div className="flex items-center justify-between text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            <span>Vol regime</span>
+            {card.vol_regime_as_of ? <span>as of {card.vol_regime_as_of}</span> : null}
+          </div>
+          {card.vol_regime_status === "ok" ? (
+            <div className="flex items-center gap-2">
+              <Badge variant={regimeVariant} className="text-sm capitalize">
+                {card.vol_regime_label ?? "—"}
+              </Badge>
+              <span className="text-sm text-muted-foreground">
+                {formatPercent(card.vol_regime_confidence)} conf
+              </span>
+            </div>
+          ) : (
+            <p className="text-sm text-muted-foreground">Market data unavailable.</p>
+          )}
+        </section>
+
+        <Button asChild variant="ghost" size="sm" className="-mx-2 justify-between">
+          <Link href={workspaceHref} aria-label={`Open ${card.display_name} in Workspace`}>
+            <span>Open {card.symbol} in Workspace</span>
+            <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+export default function CrossBankPage(): JSX.Element {
+  const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
+  const [data, setData] = React.useState<CrossBankSnapshotResponse | null>(null);
+  const [loading, setLoading] = React.useState(true);
+
+  React.useEffect(() => {
+    const controller = new AbortController();
+    let cancelled = false;
+    async function load() {
+      setLoading(true);
+      try {
+        const response = await fetchCrossBankSnapshot(apiBaseUrl, controller.signal);
+        if (cancelled) return;
+        setData(response);
+      } catch (err) {
+        if (cancelled || controller.signal.aborted) return;
+        toast.error(errorMessage(err) || "Failed to load cross-bank snapshot");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [apiBaseUrl]);
+
+  return (
+    <>
+      <Head>
+        <title>Cross-bank — Fed Pulse</title>
+      </Head>
+      <div className="min-h-screen bg-background text-foreground">
+        <Header />
+        <StatusBar />
+        <main
+          id="main-content"
+          tabIndex={-1}
+          className="container space-y-6 py-8 focus:outline-none"
+        >
+          <div className="space-y-2">
+            <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight sm:text-3xl">
+              <Globe className="h-6 w-6 text-primary sm:h-7 sm:w-7" />
+              Cross-bank stance panel
+            </h1>
+            <p className="max-w-3xl text-muted-foreground">
+              Side-by-side stance and volatility-regime read across six major
+              central banks, scored by the xbank-DAPT multi-axis classifier
+              against the latest annotated sentences from each bank's
+              published communications. Vol regime is a coarse 5-day realised
+              volatility band on the bank's flagship equity index. Cards
+              refresh hourly.
+            </p>
+            {data?.generated_at ? (
+              <p className="text-xs text-muted-foreground">
+                Snapshot generated at {data.generated_at}.
+              </p>
+            ) : null}
+          </div>
+
+          {loading ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              <BankCardSkeleton />
+              <BankCardSkeleton />
+              <BankCardSkeleton />
+              <BankCardSkeleton />
+              <BankCardSkeleton />
+              <BankCardSkeleton />
+            </div>
+          ) : data ? (
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {data.banks.map((card) => (
+                <BankCardView key={card.bank} card={card} />
+              ))}
+            </div>
+          ) : (
+            <Card>
+              <CardHeader>
+                <CardTitle>No snapshot</CardTitle>
+                <CardDescription>
+                  The cross-bank snapshot could not be loaded. Retry shortly.
+                </CardDescription>
+              </CardHeader>
+            </Card>
+          )}
+        </main>
+      </div>
+    </>
+  );
+}

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -914,6 +914,212 @@
         "title": "CredibilityResponse",
         "type": "object"
       },
+      "CrossBankCard": {
+        "description": "One central-bank card on the cross-bank dashboard panel.\n\nMirrors the dict shape emitted by\n:func:`app.services.cross_bank_snapshot.build_bank_card`. Heads\nthat could not be filled (corpus missing for a bank, classifier\ncheckpoint unavailable, market-data lookup failed) leave the\nmatching field as ``None`` and surface the reason in ``status`` /\n``vol_regime_status`` so the frontend renders an explicit\n\"Coming soon\" placeholder rather than blank space.",
+        "properties": {
+          "bank": {
+            "title": "Bank",
+            "type": "string"
+          },
+          "certainty_confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Certainty Confidence"
+          },
+          "certainty_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Certainty Label"
+          },
+          "display_name": {
+            "title": "Display Name",
+            "type": "string"
+          },
+          "flag": {
+            "title": "Flag",
+            "type": "string"
+          },
+          "latest_statement_date": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Latest Statement Date"
+          },
+          "sample_size": {
+            "title": "Sample Size",
+            "type": "integer"
+          },
+          "short_code": {
+            "title": "Short Code",
+            "type": "string"
+          },
+          "stance": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "number"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stance"
+          },
+          "stance_confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stance Confidence"
+          },
+          "stance_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Stance Label"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          },
+          "symbol": {
+            "title": "Symbol",
+            "type": "string"
+          },
+          "time_axis": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Time Axis"
+          },
+          "vol_regime_as_of": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vol Regime As Of"
+          },
+          "vol_regime_confidence": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vol Regime Confidence"
+          },
+          "vol_regime_label": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vol Regime Label"
+          },
+          "vol_regime_status": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Vol Regime Status"
+          }
+        },
+        "required": [
+          "bank",
+          "short_code",
+          "display_name",
+          "flag",
+          "symbol",
+          "latest_statement_date",
+          "stance",
+          "stance_label",
+          "stance_confidence",
+          "certainty_label",
+          "certainty_confidence",
+          "time_axis",
+          "vol_regime_label",
+          "vol_regime_confidence",
+          "vol_regime_as_of",
+          "vol_regime_status",
+          "sample_size",
+          "status"
+        ],
+        "title": "CrossBankCard",
+        "type": "object"
+      },
+      "CrossBankSnapshotResponse": {
+        "description": "Response wire shape for ``GET /cross-bank/snapshot``.\n\nSix-card side-by-side stance + vol-regime read across Fed, ECB,\nBoE, BoC, BoJ, RBA. Cached in-process for an hour (statements do\nnot change minute-to-minute and the classifier cold-start is\nexpensive).",
+        "properties": {
+          "banks": {
+            "items": {
+              "$ref": "#/components/schemas/CrossBankCard"
+            },
+            "title": "Banks",
+            "type": "array"
+          },
+          "cache_ttl_seconds": {
+            "title": "Cache Ttl Seconds",
+            "type": "integer"
+          },
+          "generated_at": {
+            "title": "Generated At",
+            "type": "string"
+          }
+        },
+        "required": [
+          "banks",
+          "generated_at",
+          "cache_ttl_seconds"
+        ],
+        "title": "CrossBankSnapshotResponse",
+        "type": "object"
+      },
       "CrossBankTransferSection": {
         "properties": {
           "available": {
@@ -5369,6 +5575,25 @@
           }
         },
         "summary": "Analyze Trajectory"
+      }
+    },
+    "/cross-bank/snapshot": {
+      "get": {
+        "description": "Side-by-side stance + vol-regime read for Fed / ECB / BoE / BoC / BoJ / RBA.\n\nBacked by ``app.services.cross_bank_snapshot.build_snapshot``. The\nmulti-axis classifier was continued-pretrained on the xbank-DAPT\nsubstrate so it is valid across all six banks; the vol-regime tag\nis a coarse 5d-realised-vol band against the bank's flagship\nequity index. Results cache in-process for an hour.\n\nReturns an explicit ``status`` per card so the frontend can render\na \"Coming soon\" placeholder for any bank where the corpus or\nmarket lookup degraded, instead of a 500 across the whole panel.",
+        "operationId": "cross_bank_snapshot_cross_bank_snapshot_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CrossBankSnapshotResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Cross Bank Snapshot"
       }
     },
     "/documents": {

--- a/tests/unit/test_cross_bank_snapshot.py
+++ b/tests/unit/test_cross_bank_snapshot.py
@@ -1,0 +1,271 @@
+"""Unit tests for the cross-bank snapshot service + /cross-bank/snapshot route.
+
+Both layers are exercised against a stub classifier + stub market lookup so
+CI does not need to load the multi-axis checkpoint or hit yfinance. The
+production wiring (real checkpoint + real ``fetch_market_snapshot``) is
+covered indirectly by the existing /analyze contract suite.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.services import cross_bank_snapshot as svc
+
+
+def _write_registry(path: Path, rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row) + "\n")
+
+
+def _stub_score(text: str) -> dict[str, Any]:
+    """Deterministic classifier stub.
+
+    Sentence containing 'hike' -> hawkish-leaning, 'cut' -> dovish, else
+    neutral. Returns the three-block multi-axis shape so the aggregator
+    code paths are exercised end to end.
+    """
+
+    text_l = (text or "").lower()
+    if "hike" in text_l:
+        stance = {"hawkish": 0.7, "dovish": 0.1, "neutral": 0.2}
+    elif "cut" in text_l:
+        stance = {"hawkish": 0.1, "dovish": 0.75, "neutral": 0.15}
+    else:
+        stance = {"hawkish": 0.25, "dovish": 0.25, "neutral": 0.5}
+    return {
+        "stance": {
+            "label": max(stance, key=lambda k: stance[k]),
+            "confidence": max(stance.values()),
+            "distribution": stance,
+        },
+        "certainty": {
+            "label": "certain",
+            "confidence": 0.8,
+            "distribution": {"certain": 0.8, "uncertain": 0.1, "neutral": 0.1},
+        },
+        "time": {
+            "label": "forward looking",
+            "confidence": 0.65,
+            "distribution": {"forward looking": 0.65, "not forward looking": 0.35},
+        },
+    }
+
+
+def _stub_market(symbol: str) -> dict[str, Any]:
+    return {
+        "label": "calm" if symbol == "^GSPC" else "normal",
+        "confidence": 0.78,
+        "close": 100.0,
+        "vol_5d_annualised": 0.08 if symbol == "^GSPC" else 0.17,
+        "as_of": "2026-06-03",
+        "status": "ok",
+    }
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache() -> None:
+    svc.reset_cache()
+    yield
+    svc.reset_cache()
+
+
+def test_build_bank_card_aggregates_stance_from_corpus(tmp_path: Path) -> None:
+    registry = tmp_path / "source_registry.jsonl"
+    _write_registry(
+        registry,
+        rows=[
+            # Three sentences for ECB on the same event_date; one hawkish-tilt.
+            {
+                "source": "gtfintechlab_european_central_bank",
+                "event_date": "2024-01-01",
+                "text": "the council expects to hike rates further if inflation persists.",
+            },
+            {
+                "source": "gtfintechlab_european_central_bank",
+                "event_date": "2024-01-01",
+                "text": "underlying inflation remains elevated.",
+            },
+            {
+                "source": "gtfintechlab_european_central_bank",
+                "event_date": "2024-01-01",
+                "text": "growth has slowed.",
+            },
+            # An older row should not be picked up.
+            {
+                "source": "gtfintechlab_european_central_bank",
+                "event_date": "2020-01-01",
+                "text": "the council intends to cut rates to support recovery.",
+            },
+            # A foreign source must be ignored.
+            {
+                "source": "gtfintechlab_bank_of_japan",
+                "event_date": "2024-01-01",
+                "text": "rates will remain accommodative.",
+            },
+        ],
+    )
+
+    ecb_spec = next(spec for spec in svc.BANK_SPECS if spec.key == "ecb")
+    card = svc.build_bank_card(
+        ecb_spec,
+        score_text=_stub_score,
+        market_lookup=_stub_market,
+        registry_path=registry,
+    )
+
+    assert card["status"] == "ok"
+    assert card["bank"] == "ecb"
+    assert card["short_code"] == "ECB"
+    assert card["symbol"] == "^STOXX50E"
+    assert card["latest_statement_date"] == "2024-01-01"
+    assert card["sample_size"] == 3
+    assert card["stance"] is not None
+    # Hawkish should be the dominant axis since one of three sentences is hawkish
+    # and the rest are neutral.
+    assert card["stance_label"] == "hawkish"
+    assert 0.0 <= card["stance_confidence"] <= 1.0
+    assert pytest.approx(sum(card["stance"].values()), abs=1e-6) == 1.0
+    assert card["certainty_label"] == "certain"
+    assert card["time_axis"] == "forward looking"
+    assert card["vol_regime_label"] == "normal"
+    assert card["vol_regime_status"] == "ok"
+
+
+def test_build_bank_card_marks_missing_corpus(tmp_path: Path) -> None:
+    registry = tmp_path / "source_registry.jsonl"
+    # Empty registry — no row for any bank.
+    registry.write_text("")
+    fed_spec = next(spec for spec in svc.BANK_SPECS if spec.key == "fed")
+    card = svc.build_bank_card(
+        fed_spec,
+        score_text=_stub_score,
+        market_lookup=_stub_market,
+        registry_path=registry,
+    )
+    assert card["status"] == "corpus_missing"
+    assert card["stance"] is None
+    assert card["stance_label"] is None
+    assert card["latest_statement_date"] is None
+    # Market lookup is independent and should still populate.
+    assert card["vol_regime_label"] == "calm"
+    assert card["sample_size"] == 0
+
+
+def test_build_snapshot_returns_all_six_banks(tmp_path: Path) -> None:
+    registry = tmp_path / "source_registry.jsonl"
+    rows = []
+    for spec in svc.BANK_SPECS:
+        rows.append(
+            {
+                "source": spec.source,
+                "event_date": "2024-01-01",
+                "text": f"{spec.short_code} statement: rates will hike further.",
+            }
+        )
+    _write_registry(registry, rows)
+
+    payload = svc.build_snapshot(
+        score_text=_stub_score,
+        market_lookup=_stub_market,
+        registry_path=registry,
+        use_cache=False,
+    )
+
+    keys = [card["bank"] for card in payload["banks"]]
+    assert keys == ["fed", "ecb", "boe", "boc", "boj", "rba"]
+    assert all(card["status"] == "ok" for card in payload["banks"])
+    assert payload["cache_ttl_seconds"] == 3600
+    assert payload["generated_at"]
+
+
+def test_build_snapshot_cache_returns_same_payload(tmp_path: Path) -> None:
+    registry = tmp_path / "source_registry.jsonl"
+    _write_registry(
+        registry,
+        rows=[
+            {
+                "source": spec.source,
+                "event_date": "2024-01-01",
+                "text": "neutral pace of expansion continues.",
+            }
+            for spec in svc.BANK_SPECS
+        ],
+    )
+
+    call_count = {"n": 0}
+
+    def counting_score(text: str) -> dict[str, Any]:
+        call_count["n"] += 1
+        return _stub_score(text)
+
+    first = svc.build_snapshot(
+        score_text=counting_score,
+        market_lookup=_stub_market,
+        registry_path=registry,
+        use_cache=True,
+    )
+    after_first = call_count["n"]
+    second = svc.build_snapshot(
+        score_text=counting_score,
+        market_lookup=_stub_market,
+        registry_path=registry,
+        use_cache=True,
+    )
+    # Cache hit: classifier must not be called a second time.
+    assert call_count["n"] == after_first
+    assert second is first
+
+
+def test_cross_bank_snapshot_endpoint(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    registry = tmp_path / "source_registry.jsonl"
+    _write_registry(
+        registry,
+        rows=[
+            {
+                "source": spec.source,
+                "event_date": "2024-01-01",
+                "text": "policy will hike further to anchor inflation.",
+            }
+            for spec in svc.BANK_SPECS
+        ],
+    )
+
+    svc.reset_cache()
+
+    real_build = svc.build_snapshot
+
+    def patched_build(**kwargs: Any) -> Any:
+        kwargs.setdefault("score_text", _stub_score)
+        kwargs.setdefault("market_lookup", _stub_market)
+        kwargs.setdefault("registry_path", registry)
+        return real_build(**kwargs)
+
+    monkeypatch.setattr(svc, "build_snapshot", patched_build)
+
+    client = TestClient(app)
+    resp = client.get("/cross-bank/snapshot")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert {card["bank"] for card in body["banks"]} == {
+        "fed",
+        "ecb",
+        "boe",
+        "boc",
+        "boj",
+        "rba",
+    }
+    assert body["cache_ttl_seconds"] == 3600
+    fed_card = next(c for c in body["banks"] if c["bank"] == "fed")
+    assert fed_card["stance_label"] == "hawkish"
+    assert fed_card["vol_regime_label"] == "calm"
+    assert fed_card["symbol"] == "^GSPC"
+    # Vol regime band confidence must lie in [0.55, 0.95].
+    assert 0.55 <= fed_card["vol_regime_confidence"] <= 0.95


### PR DESCRIPTION
## Summary
- New `GET /cross-bank/snapshot` returns six bank cards (stance + certainty + time-axis + vol regime + flagship index)
- Backend service walks the xbank-DAPT classifier across the registered cross-bank corpora; 1-hour TTL cache so the multi-axis run only fires once per hour
- New `/cross-bank` page on the frontend with a responsive six-card grid, stance breakdown, regime chip, country-flag emoji, and an "Open in Workspace" deep-link that pre-fills the bank's index symbol
- Header gains a "Cross-bank" nav entry (Globe icon)
- 5 new pytest cases covering stance aggregation, missing-corpus fallback, cache hits, and the endpoint contract

## Known gaps (deliberate)
- Vol regime per bank uses a coarse annualised 5d-realised-vol band (calm/normal/high), not a per-asset HAR classifier. Mentioned in the wiki / TODO.
- Non-Fed banks land their statement date at "2024" because the gtfintechlab cross-bank datasets are year-rounded at the source.

## Test plan
- [ ] docker compose run --rm backend pytest tests/unit/test_cross_bank_snapshot.py -q
- [ ] Visit /cross-bank after deploy; six cards render with stance + vol regime + flagship symbol