### PR TITLE
Friendly replay toast + asset-gating stubs on the workspace

### DIFF
--- a/frontend/lib/analyze/errors.ts
+++ b/frontend/lib/analyze/errors.ts
@@ -34,17 +34,56 @@ const NETWORK_COPY = "Network error. Check your connection and try again.";
 const NOT_FOUND_COPY = "Not found.";
 const FALLBACK_COPY = "Something went wrong. Try again.";
 
+// Translation of backend error slugs into friendlier user copy.
+// Lives next to the extractor so the dictionary stays close to the
+// detail shape it consumes; add a row here whenever a new structured
+// ``{error, message}`` rejection is wired and the raw slug would
+// otherwise surface as the toast (``replay_unavailable``: ``fold_checkpoint_
+// missing`` is the canonical example).
+const _FRIENDLY_ERROR_COPY: Record<string, Record<string, string>> = {
+  replay_unavailable: {
+    fold_manifest_missing:
+      "Replay is unavailable: the per-fold checkpoint manifest is not deployed on this host.",
+    fold_manifest_unreadable:
+      "Replay is unavailable: the per-fold checkpoint manifest could not be parsed.",
+    fold_checkpoint_missing:
+      "Replay for this date is not available yet: the matching walk-forward fold has no trained checkpoint on disk.",
+    fold_checkpoint_invalid:
+      "Replay for this date is not available: the matching fold's checkpoint failed its inference-contract check.",
+    no_fold_before_as_of:
+      "Replay date is too early: no walk-forward fold's training window closed before that date.",
+    fold_id_missing:
+      "Replay is unavailable: the matching fold entry has no fold id.",
+    invalid_as_of_date: "Replay date is not a valid calendar date.",
+  },
+};
+
+function _translateError(error: string | undefined, message: string | undefined): string | null {
+  if (!error || !message) return null;
+  const codeMap = _FRIENDLY_ERROR_COPY[error];
+  if (codeMap && codeMap[message]) return codeMap[message];
+  return null;
+}
+
 function _extractDetail(err: AxiosLikeError): string | null {
   // Backend handlers return one of:
   //   detail: "human readable string"
   //   detail: { error: "code", message: "human readable string" }
   // Both forms should surface to the user; the dict form is the common
-  // shape for the per-symbol unsupported / unavailable rejections.
+  // shape for the per-symbol unsupported / unavailable rejections. The
+  // structured form runs through ``_translateError`` so the raw slug
+  // (``fold_checkpoint_missing``) becomes a sentence the user can act
+  // on instead of leaking dev jargon into the toast.
   const detail = err.response?.data?.detail;
   if (typeof detail === "string" && detail.trim().length > 0) return detail;
-  if (detail && typeof detail === "object" && typeof (detail as { message?: string }).message === "string") {
-    const msg = (detail as { message: string }).message.trim();
-    if (msg.length > 0) return msg;
+  if (detail && typeof detail === "object") {
+    const obj = detail as { error?: string; message?: string };
+    const friendly = _translateError(obj.error, obj.message);
+    if (friendly) return friendly;
+    if (typeof obj.message === "string") {
+      const msg = obj.message.trim();
+      if (msg.length > 0) return msg;
+    }
   }
   return null;
 }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1079,7 +1079,25 @@ export default function WorkspacePage() {
               collapsible
               storageKey="workspace-card:har-accuracy"
             />
-          ) : null}
+          ) : (
+            // Stub instead of an empty card slot: the cross-bank
+            // "Open in Workspace" deep-link lands on tickers (e.g.
+            // ^FTSE, ^N225) that the HAR-tercile baseline doesn't fit
+            // because it pins on US equity-index RV. Surface the gap
+            // explicitly so the user knows the panel was intentionally
+            // skipped rather than silently failing.
+            <div className="mt-3 rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">
+                HAR-tercile accuracy not available for {request.symbol}.
+              </p>
+              <p className="mt-1">
+                The HAR-tercile baseline is fit on US equity-index realized vol.
+                Switch the asset to one of{" "}
+                {HAR_TERCILE_SUPPORTED_SYMBOLS.join(", ")} to see the
+                backtest surface.
+              </p>
+            </div>
+          )}
           {/* RV / QLIKE-DLq backtest remains SPX-only because the
               QLIKE-DLq artifact pins per-fold coefficients on SPX RV
               and is not yet refit per asset. */}
@@ -1092,7 +1110,17 @@ export default function WorkspacePage() {
               collapsible
               storageKey="workspace-card:rv-accuracy"
             />
-          ) : null}
+          ) : (
+            <div className="mt-3 rounded-md border border-border bg-muted/40 p-4 text-sm text-muted-foreground">
+              <p className="font-medium text-foreground">
+                QLIKE-RV band coverage not available for {request.symbol}.
+              </p>
+              <p className="mt-1">
+                The QLIKE-DLq ensemble is pinned on S&P 500 RV and not refit
+                per asset. Switch to ^GSPC to see the band-coverage backtest.
+              </p>
+            </div>
+          )}
         </main>
       </div>
     </>


### PR DESCRIPTION
## Summary
- frontend/lib/analyze/errors.ts: translate structured replay_unavailable.<code> 422s into user-readable copy; the workspace toast now reads "Replay for this date is not available yet..." instead of "fold_checkpoint_missing"
- frontend/pages/index.tsx: on a non-supported symbol (cross-bank deep-link to ^FTSE etc.), HAR-tercile + QLIKE-RV accuracy panels render a stub card pointing back to the supported list instead of an empty slot

## Test plan
- [ ] Workspace: switch the symbol to ^FTSE and confirm the two stubs render
- [ ] Toggle replay mode + pick a date with no per-fold checkpoint; toast reads the friendly sentence