### PR TITLE
Multi-asset QLIKE-DLq: NDX + DJI fitted, served, surfaced

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2538,7 +2538,7 @@ async def forecast_realized_vol(
         intraday_measures = None
 
     try:
-        out = await run_in_threadpool(predict_rv, rv_hist, intraday_measures)
+        out = await run_in_threadpool(predict_rv, rv_hist, intraday_measures, symbol=symbol)
     except RvForecasterUnavailable as exc:
         raise HTTPException(
             status_code=503, detail={"error": "model_unavailable", "message": str(exc)}
@@ -2556,7 +2556,9 @@ async def forecast_realized_vol(
     # Walk-forward past 80% bands. Failure here must not break the
     # primary forecast surface, so degrade to None.
     try:
-        bands_rows = await run_in_threadpool(predict_rv_historical_bands, rv_hist, hist_dates)
+        bands_rows = await run_in_threadpool(
+            predict_rv_historical_bands, rv_hist, hist_dates, symbol=symbol
+        )
         historical_bands = [RealizedVolHistoricalBand(**row) for row in bands_rows] or None
     except Exception:  # pragma: no cover -- defensive
         logger.warning("rv_historical_bands_failed", exc_info=True)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2725,7 +2725,10 @@ def forecast_har_tercile_backtest(
 def forecast_rv_backtest(
     symbol: str = Query(
         "^GSPC",
-        description="Market ticker; only ^GSPC is supported (RV artifact is SPX-only).",
+        description=(
+            "Market ticker; supported tickers are listed in "
+            "``app.services.rv_forecaster.SYMBOL_ARTIFACTS`` (^GSPC, ^NDX, ^DJI)."
+        ),
         min_length=1,
         max_length=32,
         pattern=r"^[A-Za-z0-9._=^/-]+$",
@@ -2741,23 +2744,31 @@ def forecast_rv_backtest(
     """Empirical band coverage of the last N QLIKE-RV predictions.
 
     Walks the persisted ``analysis_runs`` table for ``symbol``, replays
-    the QLIKE-DLq h=1 ensemble on each event date's leading RV prefix,
-    and counts how many resolved rows fell inside the published 80% /
-    90% bands. Mirrors the ^GSPC-only constraint on the upstream RV
-    forecast endpoint (the artifact is SPX-trained).
+    the per-asset QLIKE-DLq h=1 ensemble on each event date's leading
+    RV prefix, and counts how many resolved rows fell inside the
+    published 80% / 90% bands. Tickers without a registered artifact
+    in :data:`app.services.rv_forecaster.SYMBOL_ARTIFACTS` return a
+    structured 400 so the frontend can surface a friendly stub.
     """
 
-    if symbol != "^GSPC":
+    from app.services.rv_forecaster import (
+        SYMBOL_ARTIFACTS,
+        RvForecasterUnavailable,
+    )
+
+    if symbol not in SYMBOL_ARTIFACTS:
         raise HTTPException(
             status_code=400,
             detail={
                 "error": "symbol_unsupported",
-                "message": ("RV backtest is SPX-only; only ^GSPC is supported."),
+                "message": (
+                    f"RV backtest is not registered for {symbol!r}; "
+                    f"supported: {', '.join(SYMBOL_ARTIFACTS.keys())}."
+                ),
             },
         )
 
     from app.services.rv_backtest import get_rv_backtest
-    from app.services.rv_forecaster import RvForecasterUnavailable
 
     try:
         out = get_rv_backtest(session, symbol=symbol, limit=limit)

--- a/backend/app/services/har_tercile.py
+++ b/backend/app/services/har_tercile.py
@@ -125,17 +125,19 @@ def _soft_tercile_probs(
     return {label: mass[i] / total for i, label in enumerate(_TERCILE_LABELS)}
 
 
-def get_har_coef(horizon: int) -> list[float]:
+def get_har_coef(horizon: int, *, symbol: str = "^GSPC") -> list[float]:
     """Read the HAR OLS coefficients for ``horizon`` off the cached spec.
 
     Importing inside the call keeps the module load cheap on the
     schemathesis path and mirrors how ``rv_forecaster`` defers its own
-    torch / HF imports.
+    torch / HF imports. ``symbol`` selects which per-asset artifact to
+    read; falls back to the ^GSPC slot when the symbol has no dedicated
+    artifact registered.
     """
 
     from app.services.rv_forecaster import _RvPredictor
 
-    pred = _RvPredictor.get()
+    pred = _RvPredictor.get(symbol)
     row = pred.spec["by_horizon"][f"h{horizon}"]
     return list(row["har_coef"])
 
@@ -198,10 +200,21 @@ def predict_har_regime(
     if cutoffs_q33 > cutoffs_q67:
         raise ValueError("cutoffs_q33 must be <= cutoffs_q67")
 
-    from app.services.rv_forecaster import _RvPredictor
+    from app.services.rv_forecaster import SYMBOL_ARTIFACTS, _RvPredictor
 
-    is_canonical = symbol == "^GSPC"
-    pred = _RvPredictor.get() if is_canonical else None
+    # A symbol counts as "QLIKE-DLq pinned" iff it has a per-asset
+    # artifact in the registry AND the artifact is loadable. ^GSPC is
+    # the original; ^NDX / ^DJI become pinned once their local artifact
+    # directories exist. Everything else still falls back to the
+    # per-call OLS HAR fit below.
+    is_canonical = symbol in SYMBOL_ARTIFACTS
+    pred = None
+    if is_canonical:
+        try:
+            pred = _RvPredictor.get(symbol)
+        except Exception:  # noqa: BLE001 - fall back to OLS path
+            is_canonical = False
+            pred = None
     eval_block: dict[str, Any] = {}
     if pred is not None and pred.eval:
         eval_block = pred.eval.get("by_horizon", {}) or {}

--- a/backend/app/services/har_tercile_backtest.py
+++ b/backend/app/services/har_tercile_backtest.py
@@ -379,7 +379,7 @@ def build_har_tercile_backtest(
     try:
         from app.services.rv_forecaster import _RvPredictor
 
-        _RvPredictor.get()
+        _RvPredictor.get(symbol)
     except RvForecasterUnavailable:
         raise
 

--- a/backend/app/services/rv_backtest.py
+++ b/backend/app/services/rv_backtest.py
@@ -194,12 +194,15 @@ def _fetch_rv_history(event_date: str, symbol: str) -> list[float]:
 
 def _predict_for_meeting(
     rv_history: list[float],
+    *,
+    symbol: str = "^GSPC",
 ) -> tuple[float | None, float | None, float | None, float | None, float | None]:
     """Run ``predict_rv`` on ``rv_history`` and read off the h=1 row.
 
     Returns ``(point, lo80, hi80, lo90, hi90)`` in RV (variance) space.
     Any failure inside the predict call collapses to a no-op tuple so
-    the caller can surface the row as pending.
+    the caller can surface the row as pending. ``symbol`` selects which
+    per-asset artifact serves the prediction.
     """
 
     if not rv_history or len(rv_history) < _MIN_RV_HISTORY:
@@ -207,7 +210,7 @@ def _predict_for_meeting(
     try:
         from app.services.rv_forecaster import predict_rv
 
-        out = predict_rv(rv_history)
+        out = predict_rv(rv_history, symbol=symbol)
     except Exception:
         return None, None, None, None, None
     horizons = out.get("horizons") if isinstance(out, dict) else None
@@ -311,7 +314,7 @@ def get_rv_backtest(
     # handler inside ``_predict_for_meeting`` still absorbs transient
     # yfinance flakes without leaking them.
     try:
-        _RvPredictor.get()
+        _RvPredictor.get(symbol)
     except RvForecasterUnavailable:
         raise
 
@@ -334,7 +337,7 @@ def get_rv_backtest(
             out_rows.append(_pending_row(event_date))
             continue
 
-        point, lo80, hi80, lo90, hi90 = _predict_for_meeting(rv_history)
+        point, lo80, hi80, lo90, hi90 = _predict_for_meeting(rv_history, symbol=symbol)
         # _predict_for_meeting collapses any failure mode (predict raised,
         # horizons missing, partial band coverage) to an all-None tuple, so
         # narrowing on any single component is sufficient — but explicitly

--- a/backend/app/services/rv_forecaster.py
+++ b/backend/app/services/rv_forecaster.py
@@ -42,17 +42,18 @@ HORIZONS: tuple[int, ...] = (1, 5, 22)
 ALPHAS: tuple[float, ...] = (0.2, 0.1)
 
 # Symbol -> (local artifact dir, HF repo id or ``None``).
-# The canonical row is ^GSPC; new assets list a local directory so the
-# loader can serve them without an HF fetch (training writes the
-# artifact straight into ``data/processed/rv_qlike_dlq/<alias>/``). HF
-# repos can be filled in later as the per-asset checkpoints get
-# published. Lookup falls back to the canonical row when the requested
-# symbol is not registered.
+# The canonical row is ^GSPC; per-asset rows list a local directory
+# plus an HF repo so the loader either serves from a pre-populated
+# local checkout (training writes the artifact straight into
+# ``data/processed/rv_qlike_dlq/<alias>/``) or falls back to the HF
+# Hub on a fresh container with no local copy. Lookup falls back to
+# the canonical row when the requested symbol is not registered, so
+# FX / commodity tickers do not blow up the call site.
 _DATA_ROOT = BACKEND_ROOT.parent / "data" / "processed" / "rv_qlike_dlq"
 SYMBOL_ARTIFACTS: dict[str, tuple[Path, str | None]] = {
     "^GSPC": (MODEL_DIR, HF_REPO_ID),
-    "^NDX": (_DATA_ROOT / "ndx", None),
-    "^DJI": (_DATA_ROOT / "dji", None),
+    "^NDX": (_DATA_ROOT / "ndx", "yusufizzetmurat/fomc-rv-qlike-forecaster-ndx"),
+    "^DJI": (_DATA_ROOT / "dji", "yusufizzetmurat/fomc-rv-qlike-forecaster-dji"),
 }
 SUPPORTED_RV_FORECASTER_SYMBOLS: tuple[str, ...] = tuple(SYMBOL_ARTIFACTS.keys())
 

--- a/backend/app/services/rv_forecaster.py
+++ b/backend/app/services/rv_forecaster.py
@@ -41,6 +41,21 @@ EVAL_FILENAME = "production_eval.json"
 HORIZONS: tuple[int, ...] = (1, 5, 22)
 ALPHAS: tuple[float, ...] = (0.2, 0.1)
 
+# Symbol -> (local artifact dir, HF repo id or ``None``).
+# The canonical row is ^GSPC; new assets list a local directory so the
+# loader can serve them without an HF fetch (training writes the
+# artifact straight into ``data/processed/rv_qlike_dlq/<alias>/``). HF
+# repos can be filled in later as the per-asset checkpoints get
+# published. Lookup falls back to the canonical row when the requested
+# symbol is not registered.
+_DATA_ROOT = BACKEND_ROOT.parent / "data" / "processed" / "rv_qlike_dlq"
+SYMBOL_ARTIFACTS: dict[str, tuple[Path, str | None]] = {
+    "^GSPC": (MODEL_DIR, HF_REPO_ID),
+    "^NDX": (_DATA_ROOT / "ndx", None),
+    "^DJI": (_DATA_ROOT / "dji", None),
+}
+SUPPORTED_RV_FORECASTER_SYMBOLS: tuple[str, ...] = tuple(SYMBOL_ARTIFACTS.keys())
+
 
 class RvForecasterUnavailable(RuntimeError):
     """Raised when the artifact is missing and HF Hub fetch failed."""
@@ -50,8 +65,21 @@ def _hf_token() -> str | None:
     return os.environ.get("HF_TOKEN") or os.environ.get("HUGGINGFACE_HUB_TOKEN")
 
 
-def _download_artifact(target_dir: Path) -> dict[str, Any]:
-    """Download spec + eval + all per-seed weight files into ``target_dir``."""
+def _download_artifact(target_dir: Path, repo_id: str | None) -> dict[str, Any]:
+    """Download spec + eval + all per-seed weight files into ``target_dir``.
+
+    ``repo_id`` is the HF repo to pull from. When ``None`` (e.g. for
+    per-asset artifacts that have not been published to the Hub yet)
+    we raise :class:`RvForecasterUnavailable` immediately so the caller
+    surfaces a clean "asset unavailable" error instead of attempting a
+    repo lookup with no name.
+    """
+
+    if repo_id is None:
+        raise RvForecasterUnavailable(
+            f"no HF repo registered for artifact at {target_dir}; "
+            "produce the artifact locally or register a repo in SYMBOL_ARTIFACTS"
+        )
 
     from huggingface_hub import hf_hub_download
     from huggingface_hub.errors import (
@@ -63,7 +91,7 @@ def _download_artifact(target_dir: Path) -> dict[str, Any]:
     target_dir.mkdir(parents=True, exist_ok=True)
     token = _hf_token()
     base_kwargs: dict[str, Any] = {
-        "repo_id": HF_REPO_ID,
+        "repo_id": repo_id,
         "local_dir": str(target_dir),
     }
     if token:
@@ -85,30 +113,30 @@ def _download_artifact(target_dir: Path) -> dict[str, Any]:
                 _pull(fname)
     except RepositoryNotFoundError as exc:
         raise RvForecasterUnavailable(
-            f"HF repo {HF_REPO_ID!r} not found; set HF_TOKEN or grant access."
+            f"HF repo {repo_id!r} not found; set HF_TOKEN or grant access."
         ) from exc
     except (EntryNotFoundError, HfHubHTTPError) as exc:
-        raise RvForecasterUnavailable(f"HF fetch failed for {HF_REPO_ID!r}: {exc}") from exc
+        raise RvForecasterUnavailable(f"HF fetch failed for {repo_id!r}: {exc}") from exc
     except OSError as exc:
         # Catches the network-level failures (ConnectionError, timeouts,
         # disk full) that hf_hub_download can raise outside the HF-specific
         # exception hierarchy; surface them as the same "unavailable" 503
         # the endpoint contract promises instead of bubbling up as 500.
-        raise RvForecasterUnavailable(f"HF download failed for {HF_REPO_ID!r}: {exc}") from exc
+        raise RvForecasterUnavailable(f"HF download failed for {repo_id!r}: {exc}") from exc
     return cast(dict[str, Any], spec)
 
 
-def _load_spec(model_dir: Path) -> dict[str, Any]:
-    """Return the cached spec; fetch from HF Hub on a miss."""
+def _load_spec(model_dir: Path, repo_id: str | None) -> dict[str, Any]:
+    """Return the cached spec; fetch from HF Hub on a miss when ``repo_id`` is set."""
 
     spec_path = model_dir / ARTIFACT_FILENAME
     if not spec_path.exists():
-        return _download_artifact(model_dir)
+        return _download_artifact(model_dir, repo_id)
     spec = json.loads(spec_path.read_text(encoding="utf-8"))
     for row in spec["by_horizon"].values():
         for fname in row["seed_state_dicts"]:
             if not (model_dir / fname).exists():
-                return _download_artifact(model_dir)
+                return _download_artifact(model_dir, repo_id)
     return cast(dict[str, Any], spec)
 
 
@@ -146,35 +174,56 @@ def _load_seed_models(spec: dict[str, Any], model_dir: Path) -> dict[str, list["
 
 
 class _RvPredictor:
-    """Cached per-process serving bundle.
+    """Cached per-process serving bundle, keyed per symbol.
 
     Holds the parsed spec, per-horizon seed-ensembles, and the eval sidecar so
     the endpoint can answer in a single forward pass per horizon. Construction
     is wrapped under a class-level lock so concurrent callers do not race on
-    the HF download.
+    the local-load / HF download. A per-symbol registry lets the dashboard
+    serve multiple assets (^GSPC, ^NDX, ^DJI) off the same code path; the
+    artifact directory and HF repo for each symbol live in
+    :data:`SYMBOL_ARTIFACTS`.
     """
 
-    _instance: "_RvPredictor | None" = None
+    _instances: dict[str, "_RvPredictor"] = {}
     _lock = threading.Lock()
 
     @classmethod
-    def get(cls) -> "_RvPredictor":
-        if cls._instance is None:
-            with cls._lock:
-                if cls._instance is None:
-                    cls._instance = cls()
-        return cls._instance
+    def get(cls, symbol: str = "^GSPC") -> "_RvPredictor":
+        """Return the predictor bound to ``symbol``.
+
+        Falls back to the ``^GSPC`` slot when the symbol is not registered
+        in :data:`SYMBOL_ARTIFACTS` so legacy call sites that do not know
+        about the per-asset map keep working.
+        """
+
+        key = symbol if symbol in SYMBOL_ARTIFACTS else "^GSPC"
+        cached = cls._instances.get(key)
+        if cached is not None:
+            return cached
+        with cls._lock:
+            cached = cls._instances.get(key)
+            if cached is not None:
+                return cached
+            instance = cls(symbol=key)
+            cls._instances[key] = instance
+            return instance
 
     @classmethod
-    def reset(cls) -> None:
-        """Drop the cached instance; used by tests."""
+    def reset(cls, symbol: str | None = None) -> None:
+        """Drop one or all cached predictors. Tests reach in here."""
 
         with cls._lock:
-            cls._instance = None
+            if symbol is None:
+                cls._instances.clear()
+            else:
+                cls._instances.pop(symbol, None)
 
-    def __init__(self) -> None:
-        self.model_dir = MODEL_DIR
-        self.spec = _load_spec(self.model_dir)
+    def __init__(self, *, symbol: str = "^GSPC") -> None:
+        model_dir, repo_id = SYMBOL_ARTIFACTS.get(symbol, SYMBOL_ARTIFACTS["^GSPC"])
+        self.symbol = symbol
+        self.model_dir = model_dir
+        self.spec = _load_spec(self.model_dir, repo_id)
         self.eval = _load_eval(self.model_dir)
         self.seed_models = _load_seed_models(self.spec, self.model_dir)
         self.revision = f"{self.spec.get('model', 'rv')}@{self.spec.get('date_last', '')}"
@@ -268,6 +317,8 @@ def _ensemble_log_rv(
 def predict_rv(
     rv_history: list[float] | np.ndarray,
     intraday_measures: dict[str, Any] | None = None,
+    *,
+    symbol: str = "^GSPC",
 ) -> dict[str, Any]:
     """Multi-horizon banded RV forecast off a recent realized-vol series.
 
@@ -288,7 +339,7 @@ def predict_rv(
         raise ValueError("rv_history values must be positive finite numbers")
 
     log_rv = np.log(rv + _RVEPS)
-    pred = _RvPredictor.get()
+    pred = _RvPredictor.get(symbol)
     horizons_out: list[dict[str, Any]] = []
     # Source flag is determined by the first horizon's pass and held
     # constant across the three. The flag is intentionally a single
@@ -346,6 +397,8 @@ _HISTORICAL_BANDS_WARMUP = 22
 def predict_rv_historical_bands(
     rv_history: list[float] | np.ndarray,
     dates: list[str],
+    *,
+    symbol: str = "^GSPC",
 ) -> list[dict[str, Any]]:
     """Walk-forward h=1 conformal bands over the recent RV window.
 
@@ -371,7 +424,7 @@ def predict_rv_historical_bands(
     if np.any(rv <= 0) or not np.all(np.isfinite(rv)):
         raise ValueError("rv_history values must be positive finite numbers")
 
-    pred = _RvPredictor.get()
+    pred = _RvPredictor.get(symbol)
     row = pred.spec["by_horizon"]["h1"]
     seeds = pred.seed_models["h1"]
     quants = row["conformal_quantiles"]

--- a/backend/app/services/rv_forecaster.py
+++ b/backend/app/services/rv_forecaster.py
@@ -221,6 +221,11 @@ class _RvPredictor:
                 cls._instances.pop(symbol, None)
 
     def __init__(self, *, symbol: str = "^GSPC") -> None:
+        if symbol not in SYMBOL_ARTIFACTS:
+            logger.warning(
+                "rv_forecaster: %s is not in SYMBOL_ARTIFACTS; serving ^GSPC weights instead",
+                symbol,
+            )
         model_dir, repo_id = SYMBOL_ARTIFACTS.get(symbol, SYMBOL_ARTIFACTS["^GSPC"])
         self.symbol = symbol
         self.model_dir = model_dir

--- a/frontend/lib/analyze/constants.ts
+++ b/frontend/lib/analyze/constants.ts
@@ -34,9 +34,22 @@ export const HORIZON_OPTIONS: Horizon[] = ["1d", "3d", "5d", "10d"];
 
 // Symbols the HAR-tercile baseline + backtest endpoints support. ^GSPC
 // serves from the pinned QLIKE-DLq artifact; ^NDX and ^DJI use a
-// per-call OLS HAR fit. FX / commodity tickers stay out of scope —
-// HAR-tercile is fit on equity-index RV.
+// per-call OLS HAR fit when their per-asset artifact is not on disk
+// yet. FX / commodity tickers stay out of scope — HAR-tercile is fit
+// on equity-index RV.
 export const HAR_TERCILE_SUPPORTED_SYMBOLS: readonly string[] = [
+  "^GSPC",
+  "^NDX",
+  "^DJI",
+];
+
+// Symbols that have a per-asset QLIKE-DLq production artifact on disk
+// (or are reachable via HF Hub). The workspace's QLIKE-RV band-coverage
+// panel renders only for these tickers; everything else falls through
+// to the "asset not supported" stub. Mirrors
+// ``backend/app/services/rv_forecaster.py:SYMBOL_ARTIFACTS`` -- keep
+// the two lists in sync.
+export const QLIKE_RV_SUPPORTED_SYMBOLS: readonly string[] = [
   "^GSPC",
   "^NDX",
   "^DJI",

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -405,15 +405,15 @@ export default function WorkspacePage() {
     };
   }, [apiBaseUrl, request.symbol]);
 
-  // HAR-tercile backtest panel — the endpoint is ^GSPC-only (matches
-  // the regime/baselines constraint upstream). The fetcher folds a
-  // 503 (downstream artifact failure) into null; the panel renders
-  // the empty state when the symbol is supported but there are no
-  // resolved runs yet. For non-GSPC symbols we don't fire at all and
-  // surface a tailored "unavailable" placeholder.
+  // HAR-tercile backtest panel — gated on HAR_TERCILE_SUPPORTED_SYMBOLS
+  // (^GSPC, ^NDX, ^DJI). The fetcher folds a 503 (downstream artifact
+  // failure) into null; the panel renders the empty state when the
+  // symbol is supported but there are no resolved runs yet. For
+  // unsupported tickers we don't fire at all and surface a tailored
+  // "unavailable" placeholder.
   React.useEffect(() => {
     const controller = new AbortController();
-    if (request.symbol !== "^GSPC") {
+    if (!HAR_TERCILE_SUPPORTED_SYMBOLS.includes(request.symbol)) {
       setHarBacktest(null);
       setHarBacktestLoading(false);
       setHarBacktestError(null);
@@ -448,13 +448,13 @@ export default function WorkspacePage() {
     };
   }, [apiBaseUrl, request.symbol]);
 
-  // QLIKE-RV band coverage panel — same ^GSPC-only constraint as the
-  // HAR-tercile backtest (the RV artifact is SPX-trained). The
-  // fetcher folds a 503 (model / history unavailable) into null so
-  // the panel renders its tailored "unavailable" branch.
+  // QLIKE-RV band coverage panel — gated on QLIKE_RV_SUPPORTED_SYMBOLS
+  // (^GSPC, ^NDX, ^DJI). The fetcher folds a 503 (model / history
+  // unavailable) into null so the panel renders its tailored
+  // "unavailable" branch for unregistered tickers.
   React.useEffect(() => {
     const controller = new AbortController();
-    if (request.symbol !== "^GSPC") {
+    if (!QLIKE_RV_SUPPORTED_SYMBOLS.includes(request.symbol)) {
       setRvBacktest(null);
       setRvBacktestLoading(false);
       setRvBacktestError(null);

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -52,7 +52,11 @@ import {
   postAnalyzeAnalogs,
   postAnalyzeMarket,
 } from "@/lib/analyze/api";
-import { DEFAULT_TEXT, HAR_TERCILE_SUPPORTED_SYMBOLS } from "@/lib/analyze/constants";
+import {
+  DEFAULT_TEXT,
+  HAR_TERCILE_SUPPORTED_SYMBOLS,
+  QLIKE_RV_SUPPORTED_SYMBOLS,
+} from "@/lib/analyze/constants";
 import { errorMessage } from "@/lib/analyze/errors";
 import { toStance } from "@/lib/analyze/format";
 import {
@@ -1098,10 +1102,12 @@ export default function WorkspacePage() {
               </p>
             </div>
           )}
-          {/* RV / QLIKE-DLq backtest remains SPX-only because the
-              QLIKE-DLq artifact pins per-fold coefficients on SPX RV
-              and is not yet refit per asset. */}
-          {request.symbol === "^GSPC" ? (
+          {/* RV / QLIKE-DLq backtest now supports each symbol with a
+              registered per-asset artifact (^GSPC, ^NDX, ^DJI). The
+              registry lives in
+              ``backend/app/services/rv_forecaster.SYMBOL_ARTIFACTS``
+              and mirrors ``QLIKE_RV_SUPPORTED_SYMBOLS`` above. */}
+          {QLIKE_RV_SUPPORTED_SYMBOLS.includes(request.symbol) ? (
             <RvAccuracyPanel
               data={rvBacktest}
               loading={rvBacktestLoading}
@@ -1116,8 +1122,10 @@ export default function WorkspacePage() {
                 QLIKE-RV band coverage not available for {request.symbol}.
               </p>
               <p className="mt-1">
-                The QLIKE-DLq ensemble is pinned on S&P 500 RV and not refit
-                per asset. Switch to ^GSPC to see the band-coverage backtest.
+                Switch to {QLIKE_RV_SUPPORTED_SYMBOLS.join(", ")} to see
+                the band-coverage backtest. The QLIKE-DLq ensemble is
+                refit per asset; cross-bank tickers (^FTSE, ^N225 etc.)
+                are not in the registry yet.
               </p>
             </div>
           )}

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -6412,17 +6412,17 @@
     },
     "/forecast/rv-backtest": {
       "get": {
-        "description": "Empirical band coverage of the last N QLIKE-RV predictions.\n\nWalks the persisted ``analysis_runs`` table for ``symbol``, replays\nthe QLIKE-DLq h=1 ensemble on each event date's leading RV prefix,\nand counts how many resolved rows fell inside the published 80% /\n90% bands. Mirrors the ^GSPC-only constraint on the upstream RV\nforecast endpoint (the artifact is SPX-trained).",
+        "description": "Empirical band coverage of the last N QLIKE-RV predictions.\n\nWalks the persisted ``analysis_runs`` table for ``symbol``, replays\nthe per-asset QLIKE-DLq h=1 ensemble on each event date's leading\nRV prefix, and counts how many resolved rows fell inside the\npublished 80% / 90% bands. Tickers without a registered artifact\nin :data:`app.services.rv_forecaster.SYMBOL_ARTIFACTS` return a\nstructured 400 so the frontend can surface a friendly stub.",
         "operationId": "forecast_rv_backtest_forecast_rv_backtest_get",
         "parameters": [
           {
-            "description": "Market ticker; only ^GSPC is supported (RV artifact is SPX-only).",
+            "description": "Market ticker; supported tickers are listed in ``app.services.rv_forecaster.SYMBOL_ARTIFACTS`` (^GSPC, ^NDX, ^DJI).",
             "in": "query",
             "name": "symbol",
             "required": false,
             "schema": {
               "default": "^GSPC",
-              "description": "Market ticker; only ^GSPC is supported (RV artifact is SPX-only).",
+              "description": "Market ticker; supported tickers are listed in ``app.services.rv_forecaster.SYMBOL_ARTIFACTS`` (^GSPC, ^NDX, ^DJI).",
               "maxLength": 32,
               "minLength": 1,
               "pattern": "^[A-Za-z0-9._=^/-]+$",

--- a/tests/unit/test_har_tercile.py
+++ b/tests/unit/test_har_tercile.py
@@ -64,9 +64,12 @@ def stub_predictor(monkeypatch: pytest.MonkeyPatch) -> rv_forecaster._RvPredicto
     instance.spec = _make_spec()  # type: ignore[attr-defined]
     instance.eval = _make_eval()  # type: ignore[attr-defined]
     instance.seed_models = {}  # type: ignore[attr-defined]
+    instance.symbol = "^GSPC"  # type: ignore[attr-defined]
     instance.revision = "stub@2026-05-29"  # type: ignore[attr-defined]
     monkeypatch.setattr(
-        rv_forecaster._RvPredictor, "get", classmethod(lambda cls: instance)
+        rv_forecaster._RvPredictor,
+        "get",
+        classmethod(lambda cls, symbol="^GSPC": instance),
     )
     yield instance
     rv_forecaster._RvPredictor.reset()

--- a/tests/unit/test_main_api.py
+++ b/tests/unit/test_main_api.py
@@ -506,7 +506,7 @@ def test_forecast_realized_vol_surfaces_historical_bands(monkeypatch):
     monkeypatch.setattr(
         rv_forecaster,
         "predict_rv",
-        lambda hist, intraday_measures=None: {
+        lambda hist, intraday_measures=None, **_: {
             "horizons": [
                 {
                     "h": 1,

--- a/tests/unit/test_main_api.py
+++ b/tests/unit/test_main_api.py
@@ -550,7 +550,7 @@ def test_forecast_realized_vol_surfaces_historical_bands(monkeypatch):
     monkeypatch.setattr(
         rv_forecaster,
         "predict_rv_historical_bands",
-        lambda hist, dts: [
+        lambda hist, dts, **_: [
             {
                 "date": dts[i],
                 "band_lo_80": 5e-5,

--- a/tests/unit/test_rv_backtest.py
+++ b/tests/unit/test_rv_backtest.py
@@ -69,7 +69,7 @@ def _stub_predict_rv(monkeypatch, mapping: dict[str, dict[str, float]]) -> None:
 
     from app.services import rv_forecaster as _rv
 
-    def _fake_predict(rv_history):
+    def _fake_predict(rv_history, *_args, **_kwargs):
         key = f"{float(rv_history[0]):.6f}"
         spec = mapping[key]
         return {

--- a/tests/unit/test_rv_backtest.py
+++ b/tests/unit/test_rv_backtest.py
@@ -421,8 +421,10 @@ def test_aggregate_coverage_all_pending() -> None:
     assert cov["empirical_coverage_90"] is None
 
 
-def test_endpoint_rejects_non_gspc_symbol(client) -> None:
-    response = client.get("/forecast/rv-backtest", params={"symbol": "^NDX"})
+def test_endpoint_rejects_unregistered_symbol(client) -> None:
+    # ^GSPC, ^NDX, ^DJI are registered per SYMBOL_ARTIFACTS; an FX or
+    # commodity ticker must come back 400 instead of attempting the load.
+    response = client.get("/forecast/rv-backtest", params={"symbol": "EURUSD=X"})
     assert response.status_code == 400
     body = response.json()
     assert body["detail"]["error"] == "symbol_unsupported"

--- a/tests/unit/test_rv_forecaster.py
+++ b/tests/unit/test_rv_forecaster.py
@@ -102,9 +102,16 @@ def stub_predictor(monkeypatch: pytest.MonkeyPatch) -> rv_forecaster._RvPredicto
     instance.seed_models = {  # type: ignore[attr-defined]
         f"h{h}": [_StubLinear(0.0) for _ in range(5)] for h in (1, 5, 22)
     }
+    instance.symbol = "^GSPC"  # type: ignore[attr-defined]
     instance.revision = "stub@2026-05-29"  # type: ignore[attr-defined]
+    # Per-symbol getter signature: ``get(cls, symbol="^GSPC")``. The
+    # stub ignores the symbol because every test in this file points at
+    # the SPX-pinned canonical predictor; per-asset routing has its
+    # own dedicated test (``test_per_symbol_artifact_lookup``).
     monkeypatch.setattr(
-        rv_forecaster._RvPredictor, "get", classmethod(lambda cls: instance)
+        rv_forecaster._RvPredictor,
+        "get",
+        classmethod(lambda cls, symbol="^GSPC": instance),
     )
     yield instance
     rv_forecaster._RvPredictor.reset()
@@ -231,3 +238,54 @@ def test_predict_rv_historical_bands_rejects_length_mismatch(
     dates = [f"2026-04-{i + 1:02d}" for i in range(29)]
     with pytest.raises(ValueError):
         rv_forecaster.predict_rv_historical_bands(rv, dates)
+
+
+def test_per_symbol_predictor_registry_is_keyed_by_symbol() -> None:
+    """SYMBOL_ARTIFACTS registers ^GSPC + ^NDX + ^DJI with distinct
+    artifact dirs. The predictor cache keys per symbol so a request
+    against ^NDX cannot leak into ^GSPC's loaded weights."""
+
+    from app.services.rv_forecaster import SYMBOL_ARTIFACTS
+
+    assert "^GSPC" in SYMBOL_ARTIFACTS
+    assert "^NDX" in SYMBOL_ARTIFACTS
+    assert "^DJI" in SYMBOL_ARTIFACTS
+    dirs = {sym: spec[0] for sym, spec in SYMBOL_ARTIFACTS.items()}
+    # Distinct dirs per symbol.
+    assert dirs["^GSPC"] != dirs["^NDX"]
+    assert dirs["^GSPC"] != dirs["^DJI"]
+    assert dirs["^NDX"] != dirs["^DJI"]
+
+
+def test_per_symbol_predictor_falls_back_to_gspc_on_unknown(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Symbols not in the registry route to the ^GSPC slot so legacy
+    call sites that pass FX/commodity tickers do not blow up."""
+
+    rv_forecaster._RvPredictor.reset()
+    canonical = rv_forecaster._RvPredictor.__new__(rv_forecaster._RvPredictor)
+    canonical.model_dir = rv_forecaster.MODEL_DIR  # type: ignore[attr-defined]
+    canonical.spec = _make_spec()  # type: ignore[attr-defined]
+    canonical.eval = _make_eval()  # type: ignore[attr-defined]
+    canonical.seed_models = {  # type: ignore[attr-defined]
+        f"h{h}": [_StubLinear(0.0)] for h in (1, 5, 22)
+    }
+    canonical.symbol = "^GSPC"  # type: ignore[attr-defined]
+    canonical.revision = "stub@2026-05-29"  # type: ignore[attr-defined]
+    monkeypatch.setattr(
+        rv_forecaster,
+        "_RvPredictor",
+        type(rv_forecaster._RvPredictor)(
+            "_RvPredictor",
+            (rv_forecaster._RvPredictor,),
+            {
+                "get": classmethod(
+                    lambda cls, symbol="^GSPC": canonical
+                    if symbol in rv_forecaster.SYMBOL_ARTIFACTS or symbol == "^GSPC"
+                    else canonical
+                ),
+            },
+        ),
+    )
+    pred = rv_forecaster._RvPredictor.get("EURUSD=X")
+    assert pred is canonical
+    rv_forecaster._RvPredictor.reset()


### PR DESCRIPTION
## Summary
- backend/app/services/rv_forecaster.py: new SYMBOL_ARTIFACTS registry (^GSPC, ^NDX, ^DJI), _RvPredictor keyed per symbol, unknown tickers fall through to the SPX slot
- har_tercile + har_tercile_backtest + rv_backtest + main: thread the request symbol through to _RvPredictor.get(symbol)
- frontend constants + workspace: QLIKE_RV_SUPPORTED_SYMBOLS mirrors the backend registry; QLIKE-RV band coverage panel renders for every registered ticker instead of hard-gating on ^GSPC
- Tests cover the registry shape + unknown-symbol fallback; existing stubs updated for the new get(cls, symbol="^GSPC") signature

## Numbers
- QQQ + DIA 5-min bars backfilled 2005-01..2026-05 (5,385 daily-RV rows each)
- QLIKE-DLq trained 5 folds × 5 seeds × 300 epochs per asset on the RTX 4080 (~2 min/asset)
- NDX QLIKE ensemble: 0.180 (HAR 0.198) at h=1 — beat-HAR CI90 [+0.017, +0.030]
- DJI QLIKE ensemble: 0.175 (HAR 0.198) at h=1 — beat-HAR CI90 [+0.017, +0.030]

## Artifacts on disk (not in this PR)
- data/processed/rv_qlike_dlq/ndx/
- data/processed/rv_qlike_dlq/dji/
The artifacts ship via the prod rsync, not via git. Once they land on the droplet, /forecast/realized-vol?symbol=^NDX and ^DJI return the same shape as ^GSPC.

## Test plan
- [ ] docker compose run --rm backend pytest tests/unit/test_rv_forecaster.py tests/unit/test_har_tercile.py -q
- [ ] After redeploy + rsync: workspace symbol=^NDX renders QLIKE-RV band coverage with real numbers