### PR TITLE
Eager-pull: overwrite drift instead of preserving stale checkpoints

### DIFF
--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -175,6 +175,43 @@ def _split_entry(
     return entry, entry, _DST_ROOT_MODELS
 
 
+_HASH_CHUNK_BYTES = 1024 * 1024
+
+
+def _same_content(a: Path, b: Path) -> bool:
+    """Return True iff ``a`` and ``b`` share the same size and sha256.
+
+    The size guard short-circuits the common case (a file baked into a
+    base image vs the HF snapshot of a different revision will almost
+    always differ in size) without paying the streamed-hash cost. When
+    sizes match we fall back to a streamed sha256 because byte-identical
+    files do exist across revisions (e.g. config JSONs that did not
+    change) and we want the skip-copy fast path there.
+    """
+
+    import hashlib
+
+    try:
+        if a.stat().st_size != b.stat().st_size:
+            return False
+    except OSError:
+        return False
+    try:
+        ah = hashlib.sha256()
+        bh = hashlib.sha256()
+        with a.open("rb") as af, b.open("rb") as bf:
+            while True:
+                ablock = af.read(_HASH_CHUNK_BYTES)
+                bblock = bf.read(_HASH_CHUNK_BYTES)
+                if not ablock and not bblock:
+                    break
+                ah.update(ablock)
+                bh.update(bblock)
+        return ah.digest() == bh.digest()
+    except OSError:
+        return False
+
+
 def _hydrate_one(  # noqa: PLR0913 - seven injected params is the natural shape here
     artefact: Any,
     files: tuple[str | tuple[str, str] | tuple[str, str, str], ...],
@@ -236,9 +273,26 @@ def _hydrate_one(  # noqa: PLR0913 - seven injected params is the natural shape 
                 artefact.hf_uri,
             )
             continue
-        if dst.exists():
-            logger.info("eager-pull: %s already present; not overwriting", dst_relpath)
+        # Drift guard: when the destination already exists and matches
+        # the snapshot byte-for-byte (size + sha256) we skip the copy.
+        # When it exists but differs, we OVERWRITE -- otherwise a stale
+        # checkpoint baked into a base image or left over from a prior
+        # revision masks the pinned artefact and the live serving model
+        # silently drifts away from the registry. Production hit exactly
+        # this: a regression-mode ``forecaster_best.pt`` in MODELS_DIR
+        # outlived a revision bump to a classification-mode pin and
+        # ``/analyze`` started returning ``regime_classification: null``
+        # because the live model's output_mode mismatched.
+        if dst.exists() and _same_content(dst, src):
+            logger.info(
+                "eager-pull: %s already present and matches snapshot; skip", dst_relpath
+            )
             continue
+        if dst.exists():
+            logger.info(
+                "eager-pull: %s already present but DIFFERS from snapshot; overwriting",
+                dst_relpath,
+            )
         dst.parent.mkdir(parents=True, exist_ok=True)
         # Copy to a temp sibling and rename atomically so a mid-copy
         # crash leaves the target either fully intact or absent, never

--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -33,6 +33,7 @@ avoid clobbering the forecaster path.
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import shutil
@@ -288,21 +289,25 @@ def _hydrate_one(  # noqa: PLR0913 - seven injected params is the natural shape 
         if dst.exists() and _same_content(dst, src):
             logger.info("eager-pull: %s already present and matches snapshot; skip", dst_relpath)
             continue
-        if dst.exists():
-            logger.info(
-                "eager-pull: %s already present but DIFFERS from snapshot; overwriting",
-                dst_relpath,
-            )
+        # ``drifted`` flips when an existing local copy will be replaced;
+        # the actual overwrite logs AFTER the atomic rename so the
+        # "hydrated" line reflects what's on disk, not what we intended
+        # to do. If shutil.copy2 / os.replace raises mid-loop the
+        # caller's broad except in ``hydrate`` swallows it, so the post-
+        # success log is the only honest signal operators get.
+        drifted = dst.exists()
         dst.parent.mkdir(parents=True, exist_ok=True)
-        # Copy to a temp sibling and rename atomically so a mid-copy
-        # crash leaves the target either fully intact or absent, never
-        # half-written. Matters most for the forecaster checkpoint where
-        # a torn write surfaces as a cryptic state_dict load error.
         dst_tmp = Path(str(dst) + ".tmp")
-        shutil.copy2(src, dst_tmp)
-        os.replace(dst_tmp, dst)
+        try:
+            shutil.copy2(src, dst_tmp)
+            os.replace(dst_tmp, dst)
+        except OSError:
+            with contextlib.suppress(OSError):
+                dst_tmp.unlink()
+            raise
         logger.info(
-            "eager-pull: hydrated %s <- %s @ %s",
+            "eager-pull: %s %s <- %s @ %s",
+            "overwrote stale" if drifted else "hydrated",
             dst_relpath,
             artefact.hf_uri,
             revision or "main",

--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -3,11 +3,13 @@
 Runs from the container entrypoint before uvicorn starts. For each
 eager artefact mapped in :data:`_ARTEFACT_FILES`, downloads the pinned
 revision via ``huggingface_hub.snapshot_download`` and copies the named
-files into ``MODELS_DIR`` or ``DATA_DIR`` only when the destination is
-absent. A dev box with a freshly trained checkpoint keeps it — the
-shim never clobbers a file already on disk. The shim never raises
-out: on missing token / network failure / 404 it logs and returns so
-the cold-start bootstrap in :mod:`app.main` still runs on first
+files into ``MODELS_DIR`` or ``DATA_DIR``. The copy is conditional on
+content drift: an existing destination that matches the snapshot
+byte-for-byte (same size + sha256) is skipped, but a drifted
+destination is OVERWRITTEN so a stale checkpoint baked into a base
+image cannot mask the pinned artefact. The shim never raises out: on
+missing token / network failure / 404 it logs and returns so the
+cold-start bootstrap in :mod:`app.main` still runs on first
 ``/analyze``.
 
 Mapping policy: each entry is either a flat filename (snapshot path
@@ -308,7 +310,9 @@ def _hydrate_one(  # noqa: PLR0913 - seven injected params is the natural shape 
 
 
 def hydrate() -> None:
-    """Pull every mapped eager artefact, copy each named file if absent."""
+    """Pull every mapped eager artefact, copying each named file when
+    absent or drifted (same size + sha256 skips, anything else
+    overwrites). See the module docstring for the rationale."""
 
     try:
         from app.config import DATA_DIR

--- a/backend/app/boot/eager_pull.py
+++ b/backend/app/boot/eager_pull.py
@@ -284,9 +284,7 @@ def _hydrate_one(  # noqa: PLR0913 - seven injected params is the natural shape 
         # ``/analyze`` started returning ``regime_classification: null``
         # because the live model's output_mode mismatched.
         if dst.exists() and _same_content(dst, src):
-            logger.info(
-                "eager-pull: %s already present and matches snapshot; skip", dst_relpath
-            )
+            logger.info("eager-pull: %s already present and matches snapshot; skip", dst_relpath)
             continue
         if dst.exists():
             logger.info(

--- a/tests/unit/test_boot_eager_pull.py
+++ b/tests/unit/test_boot_eager_pull.py
@@ -2,7 +2,8 @@
 
 The shim must:
 - never raise out; failures degrade silently to the cold-start path
-- never overwrite a file that already exists in ``MODELS_DIR``
+- overwrite a file only when it differs from the snapshot (size or
+  sha256 mismatch); skip byte-identical copies
 - only touch artefacts mapped in ``_ARTEFACT_FILES`` (rates_heads et al.
   are intentionally left out to avoid clobbering the forecaster path)
 - no-op cleanly when ``HF_TOKEN`` is unset

--- a/tests/unit/test_boot_eager_pull.py
+++ b/tests/unit/test_boot_eager_pull.py
@@ -76,10 +76,14 @@ def test_hydrate_skips_artefact_with_no_file_mapping(
     assert list(models_dir.iterdir()) == []
 
 
-def test_hydrate_copies_missing_files_only(
+def test_hydrate_copies_missing_files_and_overwrites_drift(
     monkeypatch: pytest.MonkeyPatch, models_dir: Path, tmp_path: Path
 ) -> None:
-    """Files absent on disk get copied; files already present are left alone."""
+    """Files absent on disk get copied; matching files are skipped;
+    drift (existing local file whose content differs from the snapshot)
+    is OVERWRITTEN so a stale checkpoint from a prior revision cannot
+    mask the pinned artefact.
+    """
 
     monkeypatch.setenv("HF_TOKEN", "stub")
     snapshot = tmp_path / "snap"
@@ -89,10 +93,17 @@ def test_hydrate_copies_missing_files_only(
     for fname in eager_pull._ARTEFACT_FILES["forecaster_canonical"]:
         (snapshot / fname).write_bytes(b"FROM_HF_" + fname.encode())
 
-    # Pre-populate one file locally to prove the shim does not overwrite.
-    pre_existing_name = "forecaster_best.pt"
-    pre_existing = models_dir / pre_existing_name
-    pre_existing.write_bytes(b"LOCAL_CANONICAL")
+    # Pre-populate one file locally with DIFFERENT content so the drift
+    # branch overwrites it. Pre-populate a second file with byte-identical
+    # content so the same-content branch keeps it untouched.
+    drift_name = "forecaster_best.pt"
+    drift_path = models_dir / drift_name
+    drift_path.write_bytes(b"STALE_LOCAL")  # differs from the snapshot payload
+
+    match_name = "forecaster_best.pt.inference_contract.json"
+    match_path = models_dir / match_name
+    match_payload = b"FROM_HF_" + match_name.encode()
+    match_path.write_bytes(match_payload)
 
     monkeypatch.setattr(
         "app.boot.eager_pull.snapshot_download",
@@ -106,12 +117,12 @@ def test_hydrate_copies_missing_files_only(
 
     eager_pull.hydrate()
 
-    # Pre-existing local file is untouched.
-    assert pre_existing.read_bytes() == b"LOCAL_CANONICAL"
+    # Drift was overwritten with the snapshot copy.
+    assert drift_path.read_bytes() == b"FROM_HF_" + drift_name.encode()
+    # Byte-identical local copy stayed in place.
+    assert match_path.read_bytes() == match_payload
     # Every other mapped file got pulled in.
     for fname in eager_pull._ARTEFACT_FILES["forecaster_canonical"]:
-        if fname == pre_existing_name:
-            continue
         assert (models_dir / fname).read_bytes() == b"FROM_HF_" + fname.encode()
 
 

--- a/tests/unit/test_eager_pull.py
+++ b/tests/unit/test_eager_pull.py
@@ -157,14 +157,14 @@ def test_retrieval_bundle_creates_nested_checkpoint_subdirs(
     assert list(models.iterdir()) == []
 
 
-def test_data_root_entry_does_not_overwrite_existing_file(
+def test_data_root_entry_keeps_byte_identical_local_file(
     monkeypatch: pytest.MonkeyPatch,
     models_and_data_dirs: tuple[Path, Path],
     tmp_path: Path,
 ) -> None:
-    """A locally-trained ``model.pt`` survives an eager pull — the no
-    overwrite contract holds for the ``DATA`` root the same way it does
-    for ``MODELS``.
+    """A byte-identical local copy under the ``DATA`` root is skipped
+    (no needless rewrite); a drifted copy is OVERWRITTEN so a stale
+    file from a prior revision cannot mask the pinned artefact.
     """
 
     _, data = models_and_data_dirs
@@ -177,9 +177,14 @@ def test_data_root_entry_does_not_overwrite_existing_file(
     ):
         (snapshot / src_name).write_bytes(b"FROM_HF")
 
-    pre = data / "artifacts" / "trajectory" / "trajectory_transformer" / "model.pt"
-    pre.parent.mkdir(parents=True, exist_ok=True)
-    pre.write_bytes(b"LOCAL_TRAINED")
+    bundle_dir = data / "artifacts" / "trajectory" / "trajectory_transformer"
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    # Drift case: same name, different content — must be overwritten.
+    drift = bundle_dir / "model.pt"
+    drift.write_bytes(b"STALE_LOCAL_TRAINED")
+    # Match case: byte-identical to the snapshot copy — must stay put.
+    match = bundle_dir / "embedding_index.parquet"
+    match.write_bytes(b"FROM_HF")
 
     monkeypatch.setattr(
         "app.boot.eager_pull.snapshot_download",
@@ -192,9 +197,11 @@ def test_data_root_entry_does_not_overwrite_existing_file(
     )
 
     eager_pull.hydrate()
-    assert pre.read_bytes() == b"LOCAL_TRAINED"
-    # Other files still hydrate.
-    assert (pre.parent / "embedding_index.parquet").read_bytes() == b"FROM_HF"
+    # Drift was replaced with the snapshot copy.
+    assert drift.read_bytes() == b"FROM_HF"
+    # Byte-identical entry kept the same content (and the destination
+    # path is the same path, so no spurious copy churn either).
+    assert match.read_bytes() == b"FROM_HF"
 
 
 def test_unknown_dst_root_is_logged_not_raised(


### PR DESCRIPTION
## Summary
- eager_pull.py: replace the unconditional skip-when-exists with size + sha256 compare; byte-identical destinations short-circuit, drift triggers the existing atomic-rename overwrite path so a stale checkpoint can no longer mask the pinned artefact
- New _same_content helper; tests cover both branches (drift overwritten, byte-identical skipped)

## Why
Prod's /api/settings/checkpoints returns forecaster_best.pt with output_mode=regression even though the registry pins the LSTM classification-only revision. The HF snapshot at that revision is classification-mode locally; the file in MODELS_DIR is an old regression-mode artefact baked into a base image. The shim's skip-if-exists rule kept it there across every redeploy and /analyze served regime_classification: null on the dashboard.

## Test plan
- [ ] docker compose run --rm backend pytest tests/unit/test_boot_eager_pull.py tests/unit/test_eager_pull.py -q
- [ ] After merge + deploy: prod /api/settings/checkpoints shows forecaster_best.pt with output_mode=classification