### PR TITLE
Replay: resolve manifest + checkpoint paths through DATA_DIR

### DIFF
--- a/backend/app/services/replay.py
+++ b/backend/app/services/replay.py
@@ -42,13 +42,15 @@ from datetime import date
 from pathlib import Path
 from typing import Any
 
-# Resolved at import time so callers stay cheap; the file system is only
-# touched at resolve-time.
-_BACKEND_ROOT = Path(__file__).resolve().parents[2]
-_REPO_ROOT = _BACKEND_ROOT.parent
+from app.config import DATA_DIR
 
+# Resolved at import time so callers stay cheap; the file system is only
+# touched at resolve-time. The fold manifest and the per-fold
+# checkpoints live under ``DATA_DIR`` so the path resolves correctly
+# whether ``DATA_DIR`` is the in-repo ``./data`` (dev) or the ``/data``
+# volume mount (prod).
 _DEFAULT_MANIFEST_PATH = (
-    _REPO_ROOT / "data" / "processed" / "canonical" / "fold_manifest_expanding_walk_forward.json"
+    DATA_DIR / "processed" / "canonical" / "fold_manifest_expanding_walk_forward.json"
 )
 
 
@@ -105,9 +107,18 @@ def _resolve_path(value: Any) -> Path | None:
     if not isinstance(value, str) or not value:
         return None
     candidate = Path(value)
-    if not candidate.is_absolute():
-        candidate = _REPO_ROOT / candidate
-    return candidate
+    if candidate.is_absolute():
+        return candidate
+    # Manifest entries store checkpoint paths as ``data/processed/...``
+    # (relative to the repo root in dev). On prod ``DATA_DIR`` is the
+    # ``/data`` volume mount, so strip the leading ``data/`` segment and
+    # resolve under ``DATA_DIR`` instead. Paths that don't start with
+    # ``data/`` fall through to DATA_DIR's parent for backwards
+    # compatibility.
+    parts = candidate.parts
+    if parts and parts[0] == "data":
+        return DATA_DIR.joinpath(*parts[1:])
+    return DATA_DIR.parent / candidate
 
 
 def resolve_fold_for_date(  # noqa: C901 - branching is defensive parsing

--- a/tests/unit/test_replay_mode.py
+++ b/tests/unit/test_replay_mode.py
@@ -412,13 +412,10 @@ def test_canonical_manifest_carries_checkpoint_dir_for_every_fold():
     surface the per-fold checkpoint path. Regression on the gap that
     /analyze replay 422'd before the manifest was extended."""
 
-    repo_root = Path(__file__).resolve().parents[2]
+    from app.config import DATA_DIR
+
     manifest_path = (
-        repo_root
-        / "data"
-        / "processed"
-        / "canonical"
-        / "fold_manifest_expanding_walk_forward.json"
+        DATA_DIR / "processed" / "canonical" / "fold_manifest_expanding_walk_forward.json"
     )
     assert manifest_path.exists(), (
         f"canonical fold manifest missing at {manifest_path}; replay "
@@ -434,8 +431,13 @@ def test_canonical_manifest_carries_checkpoint_dir_for_every_fold():
             f"fold {fold_id!r} is missing the checkpoint_dir field; "
             "_resolve_path will return None and replay will 422"
         )
-        # The relative path convention is anchored at the repo root.
-        resolved = repo_root / ckpt_dir
+        # checkpoint_dir entries store paths as ``data/processed/...``;
+        # strip the leading ``data/`` segment to resolve under DATA_DIR.
+        ckpt_parts = Path(ckpt_dir).parts
+        if ckpt_parts and ckpt_parts[0] == "data":
+            resolved = DATA_DIR.joinpath(*ckpt_parts[1:])
+        else:
+            resolved = DATA_DIR.parent / ckpt_dir
         assert resolved.parent.exists(), (
             f"checkpoint_dir parent does not exist on disk: {resolved.parent}"
         )


### PR DESCRIPTION
Live deployment regression. The replay service builds its default
manifest path from ``Path(__file__).resolve().parents[2] / "data" / ...``,
which resolves to ``/app/data/...`` inside the container. The prod
container mounts data at ``/data`` (not ``/app/data``), so every
replay request 422'd with ``fold_manifest_missing``. Local works only
because the working-copy ``./data`` happens to sit at the location the
hardcoded path picks.

## Fix

- ``_DEFAULT_MANIFEST_PATH`` now goes through ``app.config.DATA_DIR``
- ``_resolve_path`` strips a leading ``data/`` segment from
  manifest-stored checkpoint paths and resolves under ``DATA_DIR``;
  paths without that prefix fall back to ``DATA_DIR.parent`` for
  backward compatibility
- Companion regression test in ``tests/unit/test_replay_mode.py`` was
  making the same hardcoded-path assumption and failing in the dev
  container; updated to read through ``DATA_DIR``

## Test plan

- [ ] ``docker compose exec backend pytest tests/unit/test_replay_mode.py`` (10/10 passes)
- [ ] Local: POST /analyze with as_of_date returns replay block with fold_id + train_end
- [ ] After merge + deploy + rsync: prod /analyze with as_of_date stops 422'ing