### PR TITLE
Cross-bank: progress bar + cold-load messaging while snapshot fetches

### DIFF
--- a/frontend/pages/cross-bank.tsx
+++ b/frontend/pages/cross-bank.tsx
@@ -13,6 +13,7 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
 import { Skeleton } from "@/components/ui/skeleton";
 import { fetchCrossBankSnapshot, resolveApiBaseUrl } from "@/lib/analyze/api";
 import { errorMessage } from "@/lib/analyze/errors";
@@ -227,16 +228,23 @@ function BankCardView({ card }: { card: CrossBankCard }): JSX.Element {
   );
 }
 
+// The backend caches the snapshot for an hour, so warm requests return in
+// well under a second. The cold path runs the multi-axis classifier across
+// six central banks and can take up to ~30 seconds on a fresh process.
+const COLD_LOAD_BUDGET_MS = 30_000;
+
 export default function CrossBankPage(): JSX.Element {
   const apiBaseUrl = React.useMemo(() => resolveApiBaseUrl(), []);
   const [data, setData] = React.useState<CrossBankSnapshotResponse | null>(null);
   const [loading, setLoading] = React.useState(true);
+  const [elapsedMs, setElapsedMs] = React.useState(0);
 
   React.useEffect(() => {
     const controller = new AbortController();
     let cancelled = false;
     async function load() {
       setLoading(true);
+      setElapsedMs(0);
       try {
         const response = await fetchCrossBankSnapshot(apiBaseUrl, controller.signal);
         if (cancelled) return;
@@ -254,6 +262,31 @@ export default function CrossBankPage(): JSX.Element {
       controller.abort();
     };
   }, [apiBaseUrl]);
+
+  // Tick elapsed time while loading. Drives the progress indicator's value
+  // and the messaging that escalates from "Loading" to "First load can take
+  // up to 30 seconds" once the request has been outstanding long enough.
+  React.useEffect(() => {
+    if (!loading) return undefined;
+    const started = Date.now();
+    const id = window.setInterval(() => {
+      setElapsedMs(Date.now() - started);
+    }, 250);
+    return () => window.clearInterval(id);
+  }, [loading]);
+
+  // Logistic curve that climbs fast at the start and crawls toward 95% so the
+  // bar reads "almost there" without overshooting if the cold path takes the
+  // full 30 seconds. The remaining 5% snaps to 100% once data arrives.
+  const progressValue = loading
+    ? Math.min(0.95, 1 - Math.exp(-elapsedMs / (COLD_LOAD_BUDGET_MS / 3)))
+    : 1;
+  const progressMessage = (() => {
+    if (elapsedMs < 1500) return "Loading the latest snapshot.";
+    if (elapsedMs < 8000) return "Scoring stance and certainty for six central banks.";
+    if (elapsedMs < 18000) return "First load after a backend restart can take up to 30 seconds while the classifier warms.";
+    return "Still working. The classifier is on the cold path. Hold on a moment.";
+  })();
 
   return (
     <>
@@ -298,13 +331,28 @@ export default function CrossBankPage(): JSX.Element {
           </div>
 
           {loading ? (
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              <BankCardSkeleton />
-              <BankCardSkeleton />
-              <BankCardSkeleton />
-              <BankCardSkeleton />
-              <BankCardSkeleton />
-              <BankCardSkeleton />
+            <div className="space-y-4">
+              <div
+                role="status"
+                aria-live="polite"
+                className="rounded-md border border-border bg-muted/30 p-3"
+              >
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{progressMessage}</span>
+                  <span className="font-mono tabular-nums">
+                    {(elapsedMs / 1000).toFixed(1)}s
+                  </span>
+                </div>
+                <Progress value={progressValue} className="mt-2 h-1.5" />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                <BankCardSkeleton />
+                <BankCardSkeleton />
+                <BankCardSkeleton />
+                <BankCardSkeleton />
+                <BankCardSkeleton />
+                <BankCardSkeleton />
+              </div>
             </div>
           ) : data ? (
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
The cross-bank snapshot caches for an hour. Warm requests return in under a second. The cold path runs the multi-axis classifier across six central banks and can take up to ~30 seconds on a fresh process. The page currently shows six skeleton cards with no signal anything is happening; long waits feel hung.

## Change

- Tick elapsed time while the fetch is in flight
- Determinate progress bar climbing along a logistic curve toward 95% with a sub-30-second time constant; snaps to 100% when data arrives
- Status line that escalates with elapsed time:
  - < 1.5s: "Loading the latest snapshot."
  - < 8s: "Scoring stance and certainty for six central banks."
  - < 18s: "First load after a backend restart can take up to 30 seconds while the classifier warms."
  - >= 18s: "Still working. The classifier is on the cold path. Hold on a moment."
- Live elapsed-seconds counter on the right
- Skeleton cards stay underneath so the layout does not jump

## Test plan

- [ ] ``cd frontend && npx tsc --noEmit`` (passes locally)
- [ ] Visit ``/cross-bank`` with warm cache: bar appears and snaps to 100% immediately
- [ ] Visit ``/cross-bank`` after backend restart: bar climbs, message escalates, snaps to 100% on response