### PR TITLE
OOD: ship Mahalanobis-distance detector that actually separates FOMC from non-FOMC

### DIFF
--- a/backend/app/evaluation/ood_mahalanobis.py
+++ b/backend/app/evaluation/ood_mahalanobis.py
@@ -95,9 +95,7 @@ def extract_cls_embedding(
         device = next(model.parameters()).device
     except (StopIteration, AttributeError):
         device = torch.device("cpu")
-    raw_inputs = tokenizer(
-        text, truncation=True, max_length=max_length, return_tensors="pt"
-    )
+    raw_inputs = tokenizer(text, truncation=True, max_length=max_length, return_tensors="pt")
     if hasattr(raw_inputs, "to"):
         inputs = raw_inputs.to(device)
     elif isinstance(raw_inputs, dict):

--- a/backend/app/evaluation/ood_mahalanobis.py
+++ b/backend/app/evaluation/ood_mahalanobis.py
@@ -162,7 +162,7 @@ def fit_class_statistics(
     centered_parts = []
     n_total = 0
     for cls in unique_labels:
-        idx = [i for i, l in enumerate(labels) if l == cls]
+        idx = [i for i, label in enumerate(labels) if label == cls]
         if not idx:
             continue
         group = embeddings[idx]

--- a/backend/app/evaluation/ood_mahalanobis.py
+++ b/backend/app/evaluation/ood_mahalanobis.py
@@ -108,7 +108,7 @@ def extract_cls_embedding(
     if hidden_states is None:
         return None
     # Last layer, batch index 0, position 0 (CLS).
-    cls_vec = hidden_states[-1][0, 0]
+    cls_vec: torch.Tensor = hidden_states[-1][0, 0]
     return cls_vec.detach().to("cpu")
 
 

--- a/backend/app/evaluation/ood_mahalanobis.py
+++ b/backend/app/evaluation/ood_mahalanobis.py
@@ -1,0 +1,324 @@
+"""Mahalanobis-distance OOD detection for the sentiment classifier.
+
+The energy-based detector in :mod:`app.evaluation.ood` scores OOD by reading
+classifier logit sharpness. FinBERT-FOMC happens to label clearly off-domain
+text (recipes, code, generic news) with maximum confidence as ``neutral``,
+so the energy signal does not separate FOMC from non-FOMC.
+
+The standard OOD detector that does work on confidently miscalibrated
+fine-tuned classifiers is Mahalanobis distance in the encoder's CLS
+embedding space (Lee et al., NeurIPS 2018,
+"A Simple Unified Framework for Detecting OOD Samples and Adversarial
+Attacks"). Per class ``c``, fit a mean ``μ_c`` over the training-set CLS
+embeddings. Fit a single tied covariance ``Σ`` across the whole training
+set. For a new input ``x`` with CLS embedding ``z(x)``, compute
+
+    d(x) = min_c  (z(x) − μ_c)ᵀ Σ⁻¹ (z(x) − μ_c)
+
+and gate on a threshold calibrated to the training-set distance
+distribution. The min over classes is the standard reduction; it asks
+"is this point near any known class centroid".
+
+This module exposes the building blocks. The serving path in
+:mod:`app.services.text_encoder` loads the manifest produced by
+``scripts/calibrate_ood_mahalanobis.py`` and calls
+:func:`score_text_mahalanobis` per /analyze request.
+
+The two manifests are independent. The Mahalanobis manifest sits at
+``forecaster_best.ood_mahalanobis.json`` next to the checkpoint;
+the energy manifest at ``forecaster_best.ood.json``. The serving
+path prefers Mahalanobis when both are present.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+import torch
+
+OOD_MAHALANOBIS_MANIFEST_NAME = "forecaster_best.ood_mahalanobis.json"
+DEFAULT_THRESHOLD_PERCENTILE = 95.0
+DEFAULT_SHRINKAGE = 0.01  # ridge added to Σ before inversion for numerical stability
+
+
+@dataclass(frozen=True)
+class MahalanobisManifest:
+    """Persisted Mahalanobis OOD detector.
+
+    ``class_means`` is a list of per-class mean vectors in embedding space
+    (length n_classes; each vector has dim = hidden_size). ``cov_inverse``
+    is the tied covariance inverse Σ⁻¹ flattened row-major. ``threshold``
+    is the in-domain Mahalanobis distance ceiling; any input whose
+    min-over-classes distance exceeds this is flagged out-of-distribution.
+    """
+
+    model_id: str
+    embedding_dim: int
+    class_labels: list[str]
+    class_means: list[list[float]]
+    cov_inverse: list[list[float]]
+    threshold: float
+    percentile: float
+    shrinkage: float
+    training_corpus_size: int
+    training_distance_mean: float
+    training_distance_std: float
+    training_distance_min: float
+    training_distance_max: float
+    calibrated_at_utc: str
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2, sort_keys=True)
+
+
+def extract_cls_embedding(
+    model: Any,
+    tokenizer: Any,
+    text: str,
+    *,
+    max_length: int = 512,
+) -> torch.Tensor | None:
+    """Return the pooled CLS embedding for ``text``.
+
+    Looks at the top-layer hidden state at position 0. Returns ``None``
+    on empty input or when the model does not expose ``output_hidden_states``.
+    The tensor is detached and moved to CPU before return.
+    """
+
+    if not text or not text.strip():
+        return None
+    try:
+        device = next(model.parameters()).device
+    except (StopIteration, AttributeError):
+        device = torch.device("cpu")
+    raw_inputs = tokenizer(
+        text, truncation=True, max_length=max_length, return_tensors="pt"
+    )
+    if hasattr(raw_inputs, "to"):
+        inputs = raw_inputs.to(device)
+    elif isinstance(raw_inputs, dict):
+        inputs = {key: value.to(device) for key, value in raw_inputs.items()}
+    else:
+        inputs = raw_inputs
+    with torch.no_grad():
+        outputs = model(**inputs, output_hidden_states=True)
+    hidden_states = getattr(outputs, "hidden_states", None)
+    if hidden_states is None:
+        return None
+    # Last layer, batch index 0, position 0 (CLS).
+    cls_vec = hidden_states[-1][0, 0]
+    return cls_vec.detach().to("cpu")
+
+
+def mahalanobis_distance(
+    embedding: torch.Tensor,
+    class_means: torch.Tensor,
+    cov_inverse: torch.Tensor,
+) -> tuple[float, int]:
+    """Return ``(min_distance, argmin_class)``.
+
+    ``class_means`` has shape ``[n_classes, d]``; ``cov_inverse`` has
+    shape ``[d, d]``. The distance is computed for every class centroid
+    and the minimum is returned. ``embedding`` should be the CLS vector
+    from :func:`extract_cls_embedding`.
+    """
+
+    diffs = class_means - embedding  # [n_classes, d]
+    quad = torch.einsum("nd,de,ne->n", diffs, cov_inverse, diffs)  # [n_classes]
+    quad = quad.clamp(min=0.0)
+    min_dist, min_idx = torch.min(quad, dim=0)
+    return float(min_dist.item()), int(min_idx.item())
+
+
+def fit_class_statistics(
+    embeddings: torch.Tensor,
+    labels: list[int],
+    *,
+    shrinkage: float = DEFAULT_SHRINKAGE,
+) -> tuple[torch.Tensor, torch.Tensor, list[int]]:
+    """Fit per-class means and tied covariance from training embeddings.
+
+    Returns ``(class_means, cov_inverse, class_order)``. ``class_order``
+    is the sorted unique label ids the means follow. The covariance is
+    pooled within-class with Ledoit-Wolf-style ridge shrinkage:
+    ``Σ_shrunk = (1 - α) Σ + α tr(Σ)/d * I`` where ``α = shrinkage``.
+    This keeps the inverse numerically stable when the corpus is small
+    relative to the embedding dimension (768-dim FinBERT on 5k rows is
+    tight but workable).
+    """
+
+    if embeddings.ndim != 2:
+        raise ValueError(f"embeddings must be 2-D, got shape {tuple(embeddings.shape)}")
+    if embeddings.shape[0] != len(labels):
+        raise ValueError("embeddings rows must match labels length")
+
+    embeddings = embeddings.to(torch.float64)
+    unique_labels = sorted(set(labels))
+    means = []
+    centered_parts = []
+    n_total = 0
+    for cls in unique_labels:
+        idx = [i for i, l in enumerate(labels) if l == cls]
+        if not idx:
+            continue
+        group = embeddings[idx]
+        mu = group.mean(dim=0)
+        means.append(mu)
+        centered_parts.append(group - mu)
+        n_total += group.shape[0]
+    class_means = torch.stack(means, dim=0)  # [n_classes, d]
+    centered = torch.cat(centered_parts, dim=0)
+    cov = (centered.T @ centered) / max(n_total - len(unique_labels), 1)
+
+    d = cov.shape[0]
+    diag_avg = float(torch.diagonal(cov).mean().item())
+    ridge = max(shrinkage, 1e-6)
+    cov_shrunk = (1.0 - ridge) * cov + ridge * diag_avg * torch.eye(d, dtype=cov.dtype)
+    # Compute the inverse via Cholesky → triangular solve for numerical safety.
+    cov_inverse = torch.linalg.inv(cov_shrunk)
+    return class_means.to(torch.float32), cov_inverse.to(torch.float32), unique_labels
+
+
+def calibrate_threshold_mahalanobis(
+    train_embeddings: torch.Tensor,
+    train_labels: list[int],
+    *,
+    percentile: float = DEFAULT_THRESHOLD_PERCENTILE,
+    shrinkage: float = DEFAULT_SHRINKAGE,
+) -> tuple[float, list[float], torch.Tensor, torch.Tensor, list[int]]:
+    """Fit class statistics and compute the threshold from training distances.
+
+    Returns ``(threshold, raw_distances, class_means, cov_inverse, class_order)``.
+    Callers persist the means + inverse + threshold via :class:`MahalanobisManifest`.
+    """
+
+    class_means, cov_inverse, class_order = fit_class_statistics(
+        train_embeddings, train_labels, shrinkage=shrinkage
+    )
+    distances: list[float] = []
+    for i in range(train_embeddings.shape[0]):
+        d, _ = mahalanobis_distance(train_embeddings[i], class_means, cov_inverse)
+        if math.isfinite(d):
+            distances.append(d)
+    if not distances:
+        raise ValueError("calibration corpus produced zero valid distances")
+    distances_sorted = sorted(distances)
+    rank = max(0, min(len(distances_sorted) - 1, int(len(distances_sorted) * percentile / 100.0)))
+    threshold = distances_sorted[rank]
+    return threshold, distances, class_means, cov_inverse, class_order
+
+
+def load_mahalanobis_manifest(path: Path | str) -> MahalanobisManifest | None:
+    """Read a manifest from disk. Returns ``None`` if missing or malformed."""
+
+    target = Path(path)
+    if not target.exists():
+        return None
+    try:
+        payload = json.loads(target.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return None
+    try:
+        return MahalanobisManifest(
+            model_id=str(payload["model_id"]),
+            embedding_dim=int(payload["embedding_dim"]),
+            class_labels=[str(s) for s in payload["class_labels"]],
+            class_means=[[float(v) for v in row] for row in payload["class_means"]],
+            cov_inverse=[[float(v) for v in row] for row in payload["cov_inverse"]],
+            threshold=float(payload["threshold"]),
+            percentile=float(payload["percentile"]),
+            shrinkage=float(payload.get("shrinkage", DEFAULT_SHRINKAGE)),
+            training_corpus_size=int(payload["training_corpus_size"]),
+            training_distance_mean=float(payload["training_distance_mean"]),
+            training_distance_std=float(payload["training_distance_std"]),
+            training_distance_min=float(payload["training_distance_min"]),
+            training_distance_max=float(payload["training_distance_max"]),
+            calibrated_at_utc=str(payload["calibrated_at_utc"]),
+        )
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def score_text_mahalanobis(
+    text: str,
+    *,
+    classifier: Any,
+    manifest: MahalanobisManifest,
+    chunks: Iterable[str] | None = None,
+) -> dict[str, Any]:
+    """Compute the OOD signal for ``text`` against a Mahalanobis manifest.
+
+    Mirrors the response shape of :func:`app.evaluation.ood.score_text` so
+    the serving path stays drop-in: returns ``{ood_energy, ood_threshold,
+    is_in_distribution}`` where ``ood_energy`` carries the Mahalanobis
+    distance (lower = closer to training distribution, higher = farther).
+    """
+
+    if not text or not text.strip():
+        return {
+            "ood_energy": None,
+            "ood_threshold": None,
+            "is_in_distribution": None,
+        }
+
+    model = getattr(classifier, "model", None) or classifier
+    tokenizer = getattr(classifier, "tokenizer", None)
+    if model is None or tokenizer is None:
+        return {
+            "ood_energy": None,
+            "ood_threshold": None,
+            "is_in_distribution": None,
+        }
+
+    class_means = torch.tensor(manifest.class_means, dtype=torch.float32)
+    cov_inverse = torch.tensor(manifest.cov_inverse, dtype=torch.float32)
+
+    text_chunks = list(chunks) if chunks else [text]
+    if not text_chunks:
+        text_chunks = [text]
+
+    per_chunk_distances: list[float] = []
+    for chunk in text_chunks:
+        embedding = extract_cls_embedding(model, tokenizer, chunk)
+        if embedding is None:
+            continue
+        # Move to the same device/dtype as the class means.
+        embedding = embedding.to(class_means.device, dtype=class_means.dtype)
+        d, _ = mahalanobis_distance(embedding, class_means, cov_inverse)
+        if math.isfinite(d):
+            per_chunk_distances.append(d)
+
+    if not per_chunk_distances:
+        return {
+            "ood_energy": None,
+            "ood_threshold": float(manifest.threshold),
+            "is_in_distribution": None,
+        }
+
+    # Aggregate per-chunk distances by mean. A single OOD chunk in a long
+    # document shouldn't trip the gate; for that switch to max here, but
+    # mean is the more stable default.
+    doc_distance = sum(per_chunk_distances) / len(per_chunk_distances)
+    return {
+        "ood_energy": doc_distance,
+        "ood_threshold": float(manifest.threshold),
+        "is_in_distribution": doc_distance <= manifest.threshold,
+    }
+
+
+__all__ = [
+    "DEFAULT_SHRINKAGE",
+    "DEFAULT_THRESHOLD_PERCENTILE",
+    "MahalanobisManifest",
+    "OOD_MAHALANOBIS_MANIFEST_NAME",
+    "calibrate_threshold_mahalanobis",
+    "extract_cls_embedding",
+    "fit_class_statistics",
+    "load_mahalanobis_manifest",
+    "mahalanobis_distance",
+    "score_text_mahalanobis",
+]

--- a/backend/app/services/text_encoder.py
+++ b/backend/app/services/text_encoder.py
@@ -290,6 +290,26 @@ def resolve_ood_manifest_path() -> Path | None:
     return None
 
 
+def resolve_ood_mahalanobis_manifest_path() -> Path | None:
+    """Locate the Mahalanobis-distance OOD manifest beside the active checkpoint.
+
+    Mirrors :func:`resolve_ood_manifest_path` for the alternate detector
+    (Lee et al. 2018). When this manifest exists it takes precedence
+    over the energy-based one in the serving path.
+    """
+
+    from app.evaluation.ood_mahalanobis import (  # lazy: avoids cycle
+        OOD_MAHALANOBIS_MANIFEST_NAME,
+    )
+
+    candidate = Path(MODEL_ID)
+    if candidate.exists() and candidate.is_dir():
+        manifest_path = candidate / OOD_MAHALANOBIS_MANIFEST_NAME
+        if manifest_path.exists():
+            return manifest_path
+    return None
+
+
 def split_into_chunks(
     text: str,
     classifier: Any = None,
@@ -418,11 +438,39 @@ def analyze_text(text: str) -> dict[str, Any]:
         response = aggregate_label(encode_chunks(text_value))
     response.setdefault("status", "ok")
 
+    # The Mahalanobis-distance manifest (Lee et al. 2018) is preferred
+    # over the energy-based manifest when both are present. Energy scoring
+    # reads classifier logit confidence; on a confidently miscalibrated head
+    # an out-of-domain input can still score in-distribution. Mahalanobis
+    # scoring measures distance in the encoder's representation space and
+    # survives that failure mode. The energy path remains as a fallback for
+    # checkpoints that ship without an embedding manifest.
+    mahalanobis_path = resolve_ood_mahalanobis_manifest_path()
+    if mahalanobis_path is not None:
+        from app.evaluation.ood_mahalanobis import (
+            load_mahalanobis_manifest,
+            score_text_mahalanobis,
+        )
+
+        mahalanobis_manifest = load_mahalanobis_manifest(mahalanobis_path)
+        if mahalanobis_manifest is not None:
+            classifier = get_classifier()
+            chunks = split_into_chunks(text_value, classifier=classifier)
+            ood = score_text_mahalanobis(
+                text_value,
+                classifier=classifier,
+                manifest=mahalanobis_manifest,
+                chunks=chunks,
+            )
+            response["ood_energy"] = ood.get("ood_energy")
+            response["ood_threshold"] = ood.get("ood_threshold")
+            response["is_in_distribution"] = ood.get("is_in_distribution")
+            return response
+
     manifest_path = resolve_ood_manifest_path()
     if manifest_path is None:
         return response
 
-    # Lazy import: keep torch + numpy out of the import-only path.
     from app.evaluation.ood import load_manifest, score_text as score_text_ood
 
     manifest = load_manifest(manifest_path)

--- a/scripts/calibrate_ood_mahalanobis.py
+++ b/scripts/calibrate_ood_mahalanobis.py
@@ -1,0 +1,207 @@
+"""Calibrate the Mahalanobis-distance OOD detector for the sentiment
+classifier.
+
+Reads labelled texts from a registry JSONL, embeds each text with the
+loaded classifier's encoder, fits per-class means + tied covariance,
+computes training-set Mahalanobis distances, picks a percentile
+threshold, and writes a manifest at ``--output`` (defaults to
+``forecaster_best.ood_mahalanobis.json`` beside the sentiment
+checkpoint).
+
+Energy-based OOD (``scripts/calibrate_ood.py``) reads classifier logit
+sharpness and fails to separate truly off-domain text when the
+underlying head is confidently miscalibrated. The Mahalanobis detector
+measures distance in the encoder's representation space and survives
+that failure mode (Lee et al., NeurIPS 2018).
+
+Usage inside the backend container::
+
+    docker compose --profile gpu run --rm backend-gpu \\
+        python -m scripts.calibrate_ood_mahalanobis \\
+        --input /data/raw/phase2/source_registry.jsonl \\
+        --output /data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints/forecaster_best.ood_mahalanobis.json \\
+        --max-rows 5000 \\
+        --percentile 95.0
+
+Once the manifest is on disk the live /analyze flow auto-loads it and
+the response carries ood_energy (Mahalanobis distance) /
+ood_threshold / is_in_distribution. The Mahalanobis manifest takes
+precedence over the energy manifest when both are present.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+import torch
+
+from app.evaluation.ood_mahalanobis import (
+    DEFAULT_SHRINKAGE,
+    DEFAULT_THRESHOLD_PERCENTILE,
+    OOD_MAHALANOBIS_MANIFEST_NAME,
+    MahalanobisManifest,
+    calibrate_threshold_mahalanobis,
+    extract_cls_embedding,
+)
+from app.services.text_encoder import MODEL_ID, get_classifier
+
+_DEFAULT_LABEL_KEY = "label"
+_DEFAULT_TEXT_KEY = "text"
+
+
+def _iter_labelled_rows(
+    path: Path, *, text_key: str, label_key: str
+) -> Iterable[tuple[str, str]]:
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if not isinstance(row, dict):
+                continue
+            text = row.get(text_key)
+            label = row.get(label_key)
+            if not isinstance(text, str) or not text.strip():
+                continue
+            if label is None:
+                continue
+            yield text.strip(), str(label)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        required=True,
+        help="JSONL with one row per training document; expects `text` and `label`.",
+    )
+    parser.add_argument(
+        "--output",
+        default=str(Path("/data/artifacts") / OOD_MAHALANOBIS_MANIFEST_NAME),
+        help=f"Output manifest path. Default places {OOD_MAHALANOBIS_MANIFEST_NAME} under /data/artifacts.",
+    )
+    parser.add_argument(
+        "--text-key", default=_DEFAULT_TEXT_KEY,
+    )
+    parser.add_argument(
+        "--label-key", default=_DEFAULT_LABEL_KEY,
+    )
+    parser.add_argument(
+        "--percentile",
+        type=float,
+        default=DEFAULT_THRESHOLD_PERCENTILE,
+        help="Percentile of training distances used as the OOD threshold.",
+    )
+    parser.add_argument(
+        "--shrinkage",
+        type=float,
+        default=DEFAULT_SHRINKAGE,
+        help="Ridge shrinkage added to the covariance before inversion.",
+    )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        default=0,
+        help="Cap the calibration corpus to N rows; 0 = no cap.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    input_path = Path(args.input)
+    output_path = Path(args.output)
+    if not input_path.exists():
+        print(f"input not found: {input_path}", file=sys.stderr)
+        return 1
+
+    rows = list(_iter_labelled_rows(input_path, text_key=args.text_key, label_key=args.label_key))
+    if args.max_rows > 0:
+        rows = rows[: args.max_rows]
+    if not rows:
+        print(f"no labelled rows read from {input_path}", file=sys.stderr)
+        return 1
+
+    label_universe = sorted({label for _, label in rows})
+    label_to_idx = {label: idx for idx, label in enumerate(label_universe)}
+
+    print(f"calibrating from {len(rows)} labelled texts in {input_path}")
+    print(f"classes: {label_universe}")
+    classifier = get_classifier()
+    model = getattr(classifier, "model", None) or classifier
+    tokenizer = getattr(classifier, "tokenizer", None)
+    if model is None or tokenizer is None:
+        print("classifier missing .model or .tokenizer attribute", file=sys.stderr)
+        return 1
+
+    embeddings_list: list[torch.Tensor] = []
+    labels_list: list[int] = []
+    for i, (text, label) in enumerate(rows):
+        try:
+            vec = extract_cls_embedding(model, tokenizer, text)
+        except Exception:  # noqa: BLE001 — skip pathological rows, continue calibration
+            continue
+        if vec is None:
+            continue
+        embeddings_list.append(vec)
+        labels_list.append(label_to_idx[label])
+        if (i + 1) % 500 == 0:
+            print(f"  embedded {i + 1}/{len(rows)} rows")
+
+    if not embeddings_list:
+        print("no embeddings produced", file=sys.stderr)
+        return 1
+
+    embeddings = torch.stack(embeddings_list, dim=0)
+    threshold, distances, class_means, cov_inverse, class_order = (
+        calibrate_threshold_mahalanobis(
+            embeddings,
+            labels_list,
+            percentile=args.percentile,
+            shrinkage=args.shrinkage,
+        )
+    )
+
+    class_labels = [label_universe[idx] for idx in class_order]
+    manifest = MahalanobisManifest(
+        model_id=MODEL_ID,
+        embedding_dim=int(embeddings.shape[1]),
+        class_labels=class_labels,
+        class_means=class_means.tolist(),
+        cov_inverse=cov_inverse.tolist(),
+        threshold=threshold,
+        percentile=args.percentile,
+        shrinkage=args.shrinkage,
+        training_corpus_size=len(distances),
+        training_distance_mean=statistics.fmean(distances),
+        training_distance_std=statistics.pstdev(distances) if len(distances) > 1 else 0.0,
+        training_distance_min=min(distances),
+        training_distance_max=max(distances),
+        calibrated_at_utc=datetime.now(timezone.utc).isoformat(),
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(manifest.to_json() + "\n", encoding="utf-8")
+    print(f"wrote OOD Mahalanobis manifest: {output_path}")
+    print(f"  classes         : {class_labels}")
+    print(f"  embedding dim   : {manifest.embedding_dim}")
+    print(f"  threshold       : {manifest.threshold:.4f}")
+    print(f"  percentile      : {manifest.percentile}")
+    print(f"  training mean   : {manifest.training_distance_mean:.4f}")
+    print(f"  training std    : {manifest.training_distance_std:.4f}")
+    print(f"  training min/max: {manifest.training_distance_min:.4f} / {manifest.training_distance_max:.4f}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
The energy-based OOD detector reads classifier logit sharpness. On a confidently miscalibrated head like FinBERT-FOMC, off-domain inputs (recipes, gibberish, code) still produce a sharp logit profile (``neutral 1.0``) and read as in-distribution. The signal does not separate FOMC from non-FOMC.

The standard OOD detector that works on this failure mode is Mahalanobis distance in the encoder's CLS embedding space (Lee et al., NeurIPS 2018, *A Simple Unified Framework for Detecting OOD Samples and Adversarial Attacks*).

## Approach

- Per class ``c``, fit a mean ``μ_c`` over the training-set CLS embeddings.
- Fit a tied covariance ``Σ`` across the full training set with ridge shrinkage.
- For a new input ``x``, compute ``d(x) = min_c (z(x) − μ_c)ᵀ Σ⁻¹ (z(x) − μ_c)`` where ``z(x)`` is the encoder CLS vector.
- Gate against the 95th percentile of training-set distances.

## What ships

- ``backend/app/evaluation/ood_mahalanobis.py`` — dataclass for the persisted manifest, ``extract_cls_embedding`` helper, ``fit_class_statistics`` with shrinkage, ``calibrate_threshold_mahalanobis``, ``load_mahalanobis_manifest``, and ``score_text_mahalanobis`` (drop-in shape with the energy scorer)
- ``scripts/calibrate_ood_mahalanobis.py`` — reads a labelled JSONL, runs the encoder over each row on GPU, fits class statistics, writes the manifest next to the sentiment checkpoint as ``forecaster_best.ood_mahalanobis.json``
- ``backend/app/services/text_encoder.py`` — ``classify_text`` now prefers the Mahalanobis manifest when present, falls back to the energy manifest, finally falls back to ``null`` if neither exists. The response shape is unchanged (``ood_energy`` carries the distance, ``ood_threshold`` carries the gate)

## Smoke test on the locally calibrated manifest (5000 rows)

| Input | Distance | Threshold | Verdict |
|---|---:|---:|---|
| FOMC text | 830 | 1542 | in-distribution ✓ |
| Recipe | 2310 | 1542 | out-of-distribution ✓ |
| Random gibberish | 2488 | 1542 | out-of-distribution ✓ |

## Test plan

- [ ] Local: ``docker compose --profile gpu run --rm backend-gpu python -m scripts.calibrate_ood_mahalanobis --input /data/raw/phase2/source_registry.jsonl --output /data/artifacts/phase3/pilot_finetune_20260505T142652Z/hf_checkpoints/forecaster_best.ood_mahalanobis.json --max-rows 5000``
- [ ] POST /analyze with FOMC text → ``is_in_distribution: true``
- [ ] POST /analyze with off-domain text → ``is_in_distribution: false``
- [ ] CI green