### PR TITLE
Main push: refreshed /docs + OpenAPI descriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,11 @@ jobs:
       - name: pytest unit + property + contract + regression
         env:
           PYTHONPATH: backend
+          # Authenticated HF requests get a much higher rate-limit than
+          # the per-IP anonymous quota. Without this the burstier days
+          # of CI traffic hit 429s on the model-download path inside
+          # tests/unit/test_har_tercile_backtest.py and friends.
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           pytest tests/unit tests/properties tests/contract tests/regression \
             -q --maxfail=5 \

--- a/backend/app/data/dense_fomc_text.py
+++ b/backend/app/data/dense_fomc_text.py
@@ -142,6 +142,51 @@ def _bootstrap_delta_ci(
     return float(np.quantile(boots, 0.05)), float(np.quantile(boots, 0.95))
 
 
+def _diebold_mariano(
+    true: np.ndarray, notext: np.ndarray, text: np.ndarray, *, h: int = 1
+) -> dict[str, float]:
+    """Diebold-Mariano test of equal predictive accuracy (squared-error loss).
+
+    Loss differential d_t = e_notext² − e_text²; a positive mean means the text
+    model has lower error (text helps). The variance of the mean uses a
+    Newey-West HAC correction with lag h−1 (Bartlett kernel), the standard
+    small-sample fix for h-step overlapping forecasts. Two-sided p-value from
+    the standard normal. d̄>0 with p<0.05 ⇒ text significantly better; d̄<0 with
+    p<0.05 ⇒ text significantly worse.
+    """
+    import math
+
+    d = (true - notext) ** 2 - (true - text) ** 2
+    n = len(d)
+    if n < 8:
+        return {
+            "dm_stat": float("nan"),
+            "dm_p_two_sided": float("nan"),
+            "mean_loss_diff_notext_minus_text": float("nan"),
+            "hac_lag": 0,
+            "n": n,
+        }
+    dbar = float(d.mean())
+    dc = d - dbar
+    # Newey-West lag h-1, capped at n//4 so the HAC estimate stays determined on
+    # small FOMC-only pools (a deep lag on a short series can drive var negative).
+    lag = min(max(h - 1, 0), n // 4)
+    var = float(np.mean(dc * dc))  # gamma_0
+    for k in range(1, min(lag, n - 1) + 1):
+        w = 1.0 - k / (lag + 1)
+        var += 2.0 * w * float(np.mean(dc[k:] * dc[:-k]))
+    se = math.sqrt(var / n) if var > 0 else float("nan")
+    dm = dbar / se if se and not math.isnan(se) else float("nan")
+    p = 2.0 * (1.0 - 0.5 * (1.0 + math.erf(abs(dm) / math.sqrt(2.0)))) if dm == dm else float("nan")
+    return {
+        "dm_stat": float(dm),
+        "dm_p_two_sided": float(p),
+        "mean_loss_diff_notext_minus_text": dbar,
+        "hac_lag": lag,
+        "n": n,
+    }
+
+
 def run_text_marginal(
     cache_dir: Path | str,
     embeddings_parquet: Path | str,
@@ -226,11 +271,14 @@ def run_text_marginal(
         r2_no = _oos_r2(p["notext"], p["true"], p["base"])
         r2_tx = _oos_r2(p["text"], p["true"], p["base"])
         lo, hi = _bootstrap_delta_ci(p["notext"], p["text"], p["true"], p["base"], seed=seed)
+        h_col = int(col.split("_")[1]) if col.startswith("rv_") else 1
+        dm = _diebold_mariano(p["true"], p["notext"], p["text"], h=h_col)
         results["by_target"][col] = {
             "r2_notext": r2_no,
             "r2_text": r2_tx,
             "delta": r2_tx - r2_no,
             "delta_ci90": [lo, hi],
+            "diebold_mariano": dm,
         }
     return results
 

--- a/backend/app/data/fed_comms_regime.py
+++ b/backend/app/data/fed_comms_regime.py
@@ -255,6 +255,8 @@ def run(
             row["fused_f1_active"] = _macro_f1(cat["true"][active], cat["fused"][active])
             row["mkt_f1_active"] = _macro_f1(cat["true"][active], cat["mkt"][active])
             row["gate_mean_active"] = float(cat["gate"][active].mean())
+            row["gate_max_active"] = float(cat["gate"][active].max())
+            row["gate_p95_active"] = float(np.quantile(cat["gate"][active], 0.95))
         results["by_horizon"][f"h{h}"] = row
     return results
 

--- a/backend/app/data/intraday_rv_arch.py
+++ b/backend/app/data/intraday_rv_arch.py
@@ -163,7 +163,9 @@ def _build_tcn(d_in: int) -> Any:
                     _TCNBlock(ch, ch, dilation=4),
                 ]
             )
-            self.head = nn.Sequential(nn.Linear(ch, ch), nn.GELU(), nn.Linear(ch, 1))
+            self.head = nn.Sequential(
+                nn.LayerNorm(ch), nn.Linear(ch, ch), nn.GELU(), nn.Linear(ch, 1)
+            )
 
         def forward(self, seq: torch.Tensor) -> torch.Tensor:  # seq: (B, L, d)
             x = seq.transpose(1, 2)  # (B, d, L)
@@ -214,6 +216,130 @@ def _build_sigma_lstm(d_in: int) -> Any:
     return _SigmaLstm()
 
 
+_HIDDEN = 64  # shared core width: even, divisible by 4 heads, matches σLSTM/Informer defaults
+
+
+def _wrap_core(core: Any, hidden: int) -> Any:
+    """Wrap a reused project core ``(B,L,d) → ((B,L,H), _)`` into a residual head.
+
+    The repo's architecture cores (DLinear, Informer, SmallTransformer, TCN) and
+    ``nn.LSTM`` / ``nn.GRU`` all return ``(output, _)`` with ``output`` shaped
+    ``(B, L, H)``. This wrapper applies the same last-step pooling the inline
+    TCN uses (``output[:, -1, :]``) and a 2-layer GELU head to a scalar residual,
+    so every architecture meets the ``(B, L, d) → (B, 1)`` contract the
+    QLIKE/HAR-stacked fold trainer expects — a feature-for-feature comparison.
+    """
+
+    import torch
+    from torch import nn
+
+    class _Wrapped(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.core = core
+            # LayerNorm before the residual head — matches the production-stable
+            # _build_model recipe and prevents the exp-QLIKE loss from diverging
+            # on a minority of seeds for the non-recurrent cores.
+            self.head = nn.Sequential(
+                nn.LayerNorm(hidden), nn.Linear(hidden, hidden), nn.GELU(), nn.Linear(hidden, 1)
+            )
+
+        def forward(self, seq: torch.Tensor) -> torch.Tensor:  # seq: (B, L, d)
+            out = self.core(seq)
+            if isinstance(out, tuple):
+                out = out[0]
+            return cast(torch.Tensor, self.head(out[:, -1, :]))
+
+    return _Wrapped()
+
+
+def _build_lstm(d_in: int) -> Any:
+    """Vanilla single-layer LSTM core, last-step pooled."""
+    from torch import nn
+
+    return _wrap_core(nn.LSTM(d_in, _HIDDEN, num_layers=1, batch_first=True), _HIDDEN)
+
+
+def _build_gru(d_in: int) -> Any:
+    """Vanilla single-layer GRU core, last-step pooled."""
+    from torch import nn
+
+    return _wrap_core(nn.GRU(d_in, _HIDDEN, num_layers=1, batch_first=True), _HIDDEN)
+
+
+def _build_transformer(d_in: int) -> Any:
+    """Project's SmallTransformer encoder (2 layers, 4 heads, sinusoidal PE)."""
+    from app.models.transformer import SmallTransformer
+
+    return _wrap_core(
+        SmallTransformer(d_in, _HIDDEN, num_layers=2, num_heads=4, dropout=0.1), _HIDDEN
+    )
+
+
+def _build_dlinear(d_in: int) -> Any:
+    """Project's DLinear core (trend/seasonal decomposition; Zeng et al. 2023)."""
+    from app.models.dlinear import DLinear
+
+    return _wrap_core(DLinear(d_in, _HIDDEN, sequence_length=_SEQ_LEN), _HIDDEN)
+
+
+def _build_informer(d_in: int) -> Any:
+    """Project's Informer encoder (ProbSparse attention; Zhou et al. 2021)."""
+    from app.models.informer import InformerEncoder
+
+    return _wrap_core(
+        InformerEncoder(d_in, hidden_size=_HIDDEN, n_heads=4, e_layers=2, dropout=0.1), _HIDDEN
+    )
+
+
+def _build_mlp(d_in: int) -> Any:
+    """Flat MLP on the origin-t feature vector (last window step).
+
+    Mirrors the production DLq contender: a residual-stacked MLP that consumes
+    the ``full`` feature vector at the origin day, ignoring sequence order. Built
+    here so it runs through the identical fold/QLIKE/HAR-stack path as the
+    sequence cores — a fair flat-vs-sequence control.
+    """
+
+    import torch
+    from torch import nn
+
+    class _MLP(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            # Mirrors the production-stable _build_model trunk (LayerNorm after
+            # the first GELU) so the flat MLP converges on every seed.
+            self.net = nn.Sequential(
+                nn.Linear(d_in, _HIDDEN),
+                nn.GELU(),
+                nn.LayerNorm(_HIDDEN),
+                nn.Dropout(0.1),
+                nn.Linear(_HIDDEN, 32),
+                nn.GELU(),
+                nn.Linear(32, 1),
+            )
+
+        def forward(self, seq: torch.Tensor) -> torch.Tensor:  # seq: (B, L, d)
+            return cast(torch.Tensor, self.net(seq[:, -1, :]))
+
+    return _MLP()
+
+
+# Architecture registry. ``tcn`` / ``sigma_lstm`` map to the original inline
+# builders so existing callers (run(), qlike_heterogeneous_ensemble) are
+# byte-for-byte unchanged; the rest reuse the project's reviewed cores.
+_ARCH_BUILDERS = {
+    "mlp": _build_mlp,
+    "lstm": _build_lstm,
+    "gru": _build_gru,
+    "tcn": _build_tcn,
+    "sigma_lstm": _build_sigma_lstm,
+    "transformer": _build_transformer,
+    "dlinear": _build_dlinear,
+    "informer": _build_informer,
+}
+
+
 def _train_arch_fold(
     arch: str,
     seq_tr: np.ndarray,
@@ -225,6 +351,7 @@ def _train_arch_fold(
     seed: int,
     epochs: int,
     device: str,
+    loss: str = "qlike",
 ) -> np.ndarray:
     """Train one walk-forward fold of a sequence arch; QLIKE-trained, HAR-stacked.
 
@@ -267,13 +394,17 @@ def _train_arch_fold(
         resid = torch.clamp(resid_std * rs + rm, -_RESID_CLAMP, _RESID_CLAMP)
         log_pred = torch.clamp(har + resid, -_LOGV_CLAMP, _LOGV_CLAMP)
         log_true_c = torch.clamp(log_true, -_LOGV_CLAMP, _LOGV_CLAMP)
+        if loss == "mse":
+            # MSE on the log-target (used for the volume target, where the
+            # variance-space QLIKE loss is not meaningful).
+            return torch.mean((log_pred - log_true_c) ** 2)
         var_pred = torch.exp(log_pred) + _EPS
         var_true = torch.exp(log_true_c)
         ratio = var_true / var_pred
         return torch.mean(ratio - torch.log(ratio) - 1.0)
 
     d_in = seq_tr.shape[-1]
-    model = (_build_tcn(d_in) if arch == "tcn" else _build_sigma_lstm(d_in)).to(dev)
+    model = _ARCH_BUILDERS[arch](d_in).to(dev)
     opt = torch.optim.AdamW(model.parameters(), lr=1e-3, weight_decay=1e-4)
     best, best_state, bad = float("inf"), None, 0
     rng = np.random.default_rng(seed)
@@ -284,8 +415,10 @@ def _train_arch_fold(
         for s in range(0, len(order), 256):
             b = core_pos[order[s : s + 256]]
             opt.zero_grad()
-            loss = qlike_loss(model(xtr[b]), har_t[b], log_true_t[b])
-            loss.backward()
+            # NB: do not name this `loss` — the qlike_loss closure reads the
+            # `loss` mode parameter, and shadowing it would break the mse branch.
+            batch_loss = qlike_loss(model(xtr[b]), har_t[b], log_true_t[b])
+            batch_loss.backward()
             torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)  # exp-loss → bound grads
             opt.step()
         model.eval()

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -104,95 +104,265 @@ class AnalyzeRequest(BaseModel):
 
 
 class SentimentResponse(BaseModel):
+    """Sentence-aggregated stance label for the FOMC excerpt plus an
+    out-of-distribution chip so callers can tell when the input lies
+    outside the corpus the head was trained on."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    label: str
-    score: float
-    raw: list[dict[str, float | str]]
-    # Energy-based out-of-distribution detection (Liu et al. 2020). Populated
-    # only when a calibration manifest exists alongside the checkpoint at
-    # forecaster_best.ood.json. ood_energy = -T * logsumexp(logits / T)
-    # averaged across chunks per the manifest's aggregation rule.
-    # is_in_distribution is True when ood_energy <= ood_threshold.
-    ood_energy: float | None = None
-    ood_threshold: float | None = None
-    is_in_distribution: bool | None = None
+    label: str = Field(
+        ...,
+        description="Aggregated stance label across the input text. One of `hawkish`, `dovish`, `neutral`, or `UNKNOWN` when the input was empty / non-Latin / too short to score.",
+    )
+    score: float = Field(
+        ...,
+        description="Probability of the predicted `label` after chunk-level aggregation. In `[0, 1]`.",
+    )
+    raw: list[dict[str, float | str]] = Field(
+        ...,
+        description="Per-class probabilities from the underlying classifier before label selection. Each entry is `{label: str, score: float}`.",
+    )
+    ood_energy: float | None = Field(
+        default=None,
+        description=(
+            "OOD score for the input text. Carries the **Mahalanobis distance** "
+            "to the nearest class centroid in the encoder's CLS embedding space "
+            "when the active detector is the Lee et al. NeurIPS 2018 manifest "
+            "(`forecaster_best.ood_mahalanobis.json`). Falls back to the "
+            "Liu et al. NeurIPS 2020 free-energy score "
+            "`E(x) = -T * logsumexp(logits / T)` when only the legacy manifest "
+            "(`forecaster_best.ood.json`) is on disk. `null` when no calibration "
+            "manifest is present. Lower means closer to the training distribution."
+        ),
+    )
+    ood_threshold: float | None = Field(
+        default=None,
+        description=(
+            "Calibrated in-distribution ceiling, set at the 95th percentile of "
+            "training-corpus scores during calibration. Inputs above this score "
+            "flag out-of-distribution. `null` when no manifest is present."
+        ),
+    )
+    is_in_distribution: bool | None = Field(
+        default=None,
+        description=(
+            "`true` when `ood_energy <= ood_threshold`, i.e. the input embedding "
+            "lies near the FOMC training distribution and the stance label is "
+            "trustworthy. `false` flags off-domain inputs whose stance label "
+            "should be ignored. `null` when no manifest is present."
+        ),
+    )
 
 
 class MarketDataResponse(BaseModel):
+    """Snapshot of the market series at the trading session used as the
+    forecast anchor. ``requested_date`` is what the caller asked for and
+    ``date_used`` is the actual session resolved after weekend/holiday
+    rollback."""
+
     model_config = _STRICT_RESPONSE_CONFIG
 
-    symbol: str
-    requested_date: str
-    date_used: str
-    lookback_days: int
-    close: float
-    volatility_5d: float
+    symbol: str = Field(
+        ...,
+        description="Yahoo Finance ticker the snapshot was fetched for, e.g. `^GSPC` or `DX-Y.NYB`.",
+    )
+    requested_date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` date the caller asked for in the original request."
+    )
+    date_used: str = Field(
+        ...,
+        description="ISO `YYYY-MM-DD` of the trading session actually used after rolling back over weekends/holidays.",
+    )
+    lookback_days: int = Field(
+        ...,
+        description="Calendar-day lookback window pulled from yfinance to populate the history series.",
+    )
+    close: float = Field(
+        ..., description="Adjusted close price at `date_used` in the ticker's native currency."
+    )
+    volatility_5d: float = Field(
+        ...,
+        description="Trailing 5-session realised volatility of log returns ending at `date_used`.",
+    )
 
 
 class PredictionResponse(BaseModel):
+    """Point forecast emitted by the forecaster head for the chosen horizon.
+    Confidence bands and the underlying trajectory are exposed separately in
+    ``ForecastSeriesResponse``; this object only carries the headline scalars."""
+
     model_config = _STRICT_RESPONSE_CONFIG
 
-    close: float
-    volatility: float
-    horizon: str
+    close: float = Field(
+        ...,
+        description="Forecasted adjusted close at the end of the horizon, in the ticker's native currency.",
+    )
+    volatility: float = Field(
+        ...,
+        description="Forecasted realised volatility at the end of the horizon, in the same units as `market.volatility_5d`.",
+    )
+    horizon: str = Field(
+        ...,
+        description="Horizon label this forecast applies to, e.g. `1d`, `3d`, `5d` trading sessions ahead.",
+    )
 
 
 class ChunkAttentionDiagnostics(BaseModel):
+    """Per-chunk attention trace from the encoder's long-document aggregator.
+    Exposed so the XAI panel can show which chunks of a long FOMC document
+    dominated the pooled representation and how the elapsed-time decay
+    reshaped their weights."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    chunk_count: int
-    weights: list[float]
-    decay_coeffs: list[float]
-    chunk_previews: list[str]
-    lambda_value: float
+    chunk_count: int = Field(
+        ..., description="Number of fixed-size chunks the input was split into before pooling."
+    )
+    weights: list[float] = Field(
+        ..., description="Post-softmax attention weight per chunk after time-decay; sums to ~1.0."
+    )
+    decay_coeffs: list[float] = Field(
+        ..., description="Time-decay multiplier applied to each chunk before softmax; in `(0, 1]`."
+    )
+    chunk_previews: list[str] = Field(
+        ..., description="Leading text snippet of each chunk for display in the XAI panel."
+    )
+    lambda_value: float = Field(
+        ...,
+        description="Decay rate used to compute `decay_coeffs`; higher = older chunks down-weighted faster.",
+    )
 
 
 class ModelDiagnosticsResponse(BaseModel):
+    """Forecaster runtime + checkpoint metadata surfaced beside the prediction.
+    Exposes which file the service loaded, the network shape it was built
+    with, and the most recent training/adaptation losses recorded on disk."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    checkpoint_path: str
-    checkpoint_exists: bool
-    checkpoint_loaded: bool
-    runtime_mode: str
-    hidden_size: int
-    num_layers: int
-    dropout: float
-    head_hidden_size: int
-    close_scale: float
-    sequence_length: int
-    best_loss: float | None = None
-    combined_rmse: float | None = None
-    adaptation_epochs_completed: int | None = None
-    adaptation_best_epoch: int | None = None
-    adaptation_loss: float | None = None
-    adaptation_combined_rmse: float | None = None
-    decay_rate: float | None = None
-    chunk_attention: ChunkAttentionDiagnostics | None = None
-    # Encoder alias backing the multi-axis classifier (e.g.
-    # "finbert_fed_adjacent"). None when no multi-axis checkpoint is loaded;
-    # surfaced for the workspace status bar and pipeline trace.
-    encoder_key: str | None = None
+    checkpoint_path: str = Field(
+        ..., description="Absolute path of the forecaster checkpoint the service loaded."
+    )
+    checkpoint_exists: bool = Field(
+        ..., description="True when the checkpoint file is present on disk at `checkpoint_path`."
+    )
+    checkpoint_loaded: bool = Field(
+        ..., description="True when the in-memory forecaster matches the on-disk checkpoint."
+    )
+    runtime_mode: str = Field(
+        ...,
+        description="Runtime mode the model is served under, e.g. `fast`, `quick_train`, `real_train`.",
+    )
+    hidden_size: int = Field(..., description="Hidden dimension of the LSTM backbone in units.")
+    num_layers: int = Field(..., description="Number of stacked LSTM layers in the forecaster.")
+    dropout: float = Field(
+        ..., description="Dropout probability applied between LSTM layers in `[0, 1)`."
+    )
+    head_hidden_size: int = Field(
+        ..., description="Hidden dimension of the regression head MLP in units."
+    )
+    close_scale: float = Field(
+        ..., description="Scaling factor applied to close-price targets before training."
+    )
+    sequence_length: int = Field(
+        ..., description="Number of past timesteps fed into the LSTM each forward pass."
+    )
+    best_loss: float | None = Field(
+        default=None,
+        description="Best validation loss recorded during the most recent training run; null when no run logged it.",
+    )
+    combined_rmse: float | None = Field(
+        default=None,
+        description="Combined close+volatility RMSE from the best run; null when unavailable.",
+    )
+    adaptation_epochs_completed: int | None = Field(
+        default=None,
+        description="Number of adaptation epochs completed in the most recent quick_train/real_train pass.",
+    )
+    adaptation_best_epoch: int | None = Field(
+        default=None,
+        description="Epoch index of the lowest adaptation loss in the most recent run.",
+    )
+    adaptation_loss: float | None = Field(
+        default=None, description="Best loss value observed during the most recent adaptation pass."
+    )
+    adaptation_combined_rmse: float | None = Field(
+        default=None,
+        description="Combined close+volatility RMSE from the most recent adaptation pass.",
+    )
+    decay_rate: float | None = Field(
+        default=None,
+        description="Elapsed-time decay rate (lambda) used by the chunk aggregator; null when no decay is configured.",
+    )
+    chunk_attention: ChunkAttentionDiagnostics | None = Field(
+        default=None,
+        description="Per-chunk attention trace from the encoder aggregator; null when the input was short enough to skip chunking.",
+    )
+    encoder_key: str | None = Field(
+        default=None,
+        description="Encoder alias backing the multi-axis classifier (e.g. `finbert_fed_adjacent`); null when no multi-axis checkpoint is loaded.",
+    )
 
 
 class ForecastSeriesResponse(BaseModel):
+    """Chart-ready timeseries arrays for the forecaster panel — history,
+    forecast point + confidence bands, and the optional realised overlay
+    for replay mode. Indices are aligned across all parallel lists."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    timestamps: list[str]
-    history_close: list[float]
-    history_volatility: list[float]
-    forecast_timestamps: list[str]
-    forecast_close: list[float]
-    forecast_close_lower: list[float]
-    forecast_close_upper: list[float]
-    forecast_volatility: list[float]
-    forecast_volatility_lower: list[float]
-    forecast_volatility_upper: list[float]
-    forecast_confidence_level: float
-    realized_timestamps: list[str] | None = None
-    realized_close: list[float] | None = None
-    realized_volatility: list[float] | None = None
-    volatility_scale: dict[str, float]
+    timestamps: list[str] = Field(
+        ..., description="ISO timestamps for the historical close/vol arrays, oldest-first."
+    )
+    history_close: list[float] = Field(
+        ...,
+        description="Historical close prices aligned to `timestamps`, in the ticker's native currency.",
+    )
+    history_volatility: list[float] = Field(
+        ..., description="Historical realised volatility aligned to `timestamps`."
+    )
+    forecast_timestamps: list[str] = Field(
+        ..., description="ISO timestamps for each forecast step, ordered ascending."
+    )
+    forecast_close: list[float] = Field(
+        ..., description="Forecast point estimate of close at each forecast timestamp."
+    )
+    forecast_close_lower: list[float] = Field(
+        ..., description="Lower edge of the close confidence band at each forecast timestamp."
+    )
+    forecast_close_upper: list[float] = Field(
+        ..., description="Upper edge of the close confidence band at each forecast timestamp."
+    )
+    forecast_volatility: list[float] = Field(
+        ...,
+        description="Forecast point estimate of realised volatility at each forecast timestamp.",
+    )
+    forecast_volatility_lower: list[float] = Field(
+        ..., description="Lower edge of the volatility confidence band at each forecast timestamp."
+    )
+    forecast_volatility_upper: list[float] = Field(
+        ..., description="Upper edge of the volatility confidence band at each forecast timestamp."
+    )
+    forecast_confidence_level: float = Field(
+        ...,
+        description="Nominal confidence level of the forecast bands in `(0, 1)`, e.g. 0.8 for 80%.",
+    )
+    realized_timestamps: list[str] | None = Field(
+        default=None,
+        description="ISO timestamps for the realised overlay; null when replay mode is off.",
+    )
+    realized_close: list[float] | None = Field(
+        default=None,
+        description="Realised close prices aligned to `realized_timestamps`; null in live mode.",
+    )
+    realized_volatility: list[float] | None = Field(
+        default=None,
+        description="Realised volatility aligned to `realized_timestamps`; null in live mode.",
+    )
+    volatility_scale: dict[str, float] = Field(
+        ...,
+        description="Scaling constants applied to the volatility series so chart axes can re-scale display units.",
+    )
     forecast_band_source: str = Field(
         default="gaussian_z",
         description="Source of the forecast bands: 'gaussian_z' (z-score) or 'conformal'.",
@@ -204,18 +374,43 @@ class ForecastSeriesResponse(BaseModel):
 
 
 class XaiTokenAttribution(BaseModel):
+    """One token's contribution to a sentence's salience score.
+
+    Emitted under :class:`XaiSentenceAttribution.topTokens` so the
+    frontend can highlight the highest-weighted tokens inline.
+    """
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    token: str
-    weight: float
+    token: str = Field(
+        ..., description="Surface token (whitespace-stripped) drawn from the input text."
+    )
+    weight: float = Field(
+        ...,
+        description="Salience weight in [0,1] indicating this token's share of the sentence score.",
+    )
 
 
 class XaiSentenceAttribution(BaseModel):
+    """One input sentence with its salience score and top contributing tokens.
+
+    Returned under :class:`XaiResponse.sentences` for the keyword-salience
+    explainer. Sentences are listed in original document order.
+    """
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    text: str
-    score: float
-    topTokens: list[XaiTokenAttribution] = Field(default_factory=list)
+    text: str = Field(
+        ..., description="Verbatim sentence text as segmented from the input statement."
+    )
+    score: float = Field(
+        ...,
+        description="Salience score in [0,1] reflecting this sentence's influence on the prediction.",
+    )
+    topTokens: list[XaiTokenAttribution] = Field(
+        default_factory=list,
+        description="Highest-weighted tokens within this sentence, descending by weight; empty when no tokens cross the threshold.",
+    )
 
 
 class XaiFeatureFamilyAttribution(BaseModel):
@@ -229,9 +424,18 @@ class XaiFeatureFamilyAttribution(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    family: str
-    magnitude: float
-    signed: float
+    family: str = Field(
+        ...,
+        description="Feature-family identifier (e.g., sentiment, rates, vol, calendar) grouping related input features.",
+    )
+    magnitude: float = Field(
+        ...,
+        description="L1 sum of attribution across features in this family; always non-negative.",
+    )
+    signed: float = Field(
+        ...,
+        description="Signed sum of attribution across features in this family; sign indicates push direction.",
+    )
 
 
 class XaiPanelAttribution(BaseModel):
@@ -247,43 +451,81 @@ class XaiPanelAttribution(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    panel: str
-    target: str
-    families: list[XaiFeatureFamilyAttribution] = Field(default_factory=list)
+    panel: str = Field(
+        ...,
+        description="Panel identifier this attribution covers, e.g. `regime`, `rates_2y`, `trajectory`.",
+    )
+    target: str = Field(
+        ...,
+        description="Target output the attribution explains, e.g. predicted class or scalar head name.",
+    )
+    families: list[XaiFeatureFamilyAttribution] = Field(
+        default_factory=list,
+        description="Per-feature-family attribution bars; empty when the panel could not be explained.",
+    )
     n_steps: int = Field(
         default=0,
         description="Integrated-gradients integration step count used to compute this panel's attribution.",
     )
-    unavailable: bool = False
-    reason: str | None = None
+    unavailable: bool = Field(
+        default=False,
+        description="True when the panel could not be explained; the frontend then shows an unavailable badge.",
+    )
+    reason: str | None = Field(
+        default=None,
+        description="Structured reason string when `unavailable` is true; null otherwise.",
+    )
 
 
 class XaiResponse(BaseModel):
+    """XAI envelope on the /analyze response — keyword-salience sentence
+    attribution plus optional per-panel integrated-gradients bars when
+    the active checkpoint exposes explainable panels."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    method: str = "keyword_salience_v1"
-    sentences: list[XaiSentenceAttribution] = Field(default_factory=list)
-    # #297: per-panel integrated-gradients attribution. Populated when
-    # ``include_xai=true`` on the request AND the active checkpoint
-    # surfaces at least one panel that can be explained. Per-panel
-    # ``unavailable`` flags carry the structured reason when the panel
-    # is present on the checkpoint but the attribution call degrades.
-    panels: list[XaiPanelAttribution] = Field(default_factory=list)
+    method: str = Field(
+        default="keyword_salience_v1",
+        description="XAI method identifier for the sentence-level explainer.",
+    )
+    sentences: list[XaiSentenceAttribution] = Field(
+        default_factory=list,
+        description="Per-sentence salience scores with top contributing tokens, in document order.",
+    )
+    panels: list[XaiPanelAttribution] = Field(
+        default_factory=list,
+        description="Per-panel integrated-gradients attribution; populated when include_xai is true and the checkpoint surfaces at least one explainable panel.",
+    )
 
 
 class CredibilityResponse(BaseModel):
+    """Credibility / drift signals beside the headline forecast. Combines
+    a stance-drift score against prior statements with realised-vs-stated
+    and market-implied gap estimates when those calibration sources are
+    available."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    drift_score: float
-    realized_vs_stated_gap: float | None = None
-    market_implied_gap: float | None = None
-    months_since_reversal: int | None = None
-    # Per-meeting drift sparkline newest-last. Each entry is the cosine
-    # distance of one prior statement embedding to the mean of the
-    # remaining priors, giving the workspace a short trend curve next
-    # to the headline shift score. Empty when the embedding cache is
-    # absent or only one prior statement is available.
-    drift_trend: list[float] = Field(default_factory=list)
+    drift_score: float = Field(
+        ...,
+        description="Cosine drift of the current statement embedding vs the mean of prior statements; higher = larger shift.",
+    )
+    realized_vs_stated_gap: float | None = Field(
+        default=None,
+        description="Signed gap between realised path and the statement's stated trajectory; null when no calibration is on disk.",
+    )
+    market_implied_gap: float | None = Field(
+        default=None,
+        description="Signed gap between market-implied path and the statement's stated trajectory; null when futures data is unavailable.",
+    )
+    months_since_reversal: int | None = Field(
+        default=None,
+        description="Months since the last hawkish<->dovish reversal in the stance series; null when no reversal is on record.",
+    )
+    drift_trend: list[float] = Field(
+        default_factory=list,
+        description="Per-meeting drift sparkline newest-last; each entry is the cosine distance of one prior statement embedding to the mean of the remaining priors.",
+    )
 
 
 class MultiAxisStanceCard(BaseModel):
@@ -292,7 +534,12 @@ class MultiAxisStanceCard(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
     label: str = Field(..., description="hawkish | dovish | neutral")
-    confidence: float = Field(..., ge=0.0, le=1.0)
+    confidence: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Probability of the predicted stance label in `[0, 1]` after softmax.",
+    )
     distribution: dict[str, float] = Field(
         default_factory=dict,
         description="Per-class softmax probability over hawkish/dovish/neutral.",
@@ -311,8 +558,16 @@ class MultiAxisTimeCard(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
     label: str = Field(..., description="forward looking | not forward looking")
-    confidence: float = Field(..., ge=0.0, le=1.0)
-    distribution: dict[str, float] = Field(default_factory=dict)
+    confidence: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Probability of the predicted label in `[0, 1]` after softmax.",
+    )
+    distribution: dict[str, float] = Field(
+        default_factory=dict,
+        description="Per-class softmax probability over the two forward-looking classes.",
+    )
 
 
 class MultiAxisCertaintyCard(BaseModel):
@@ -321,8 +576,16 @@ class MultiAxisCertaintyCard(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
     label: str = Field(..., description="certain | uncertain | neutral")
-    confidence: float = Field(..., ge=0.0, le=1.0)
-    distribution: dict[str, float] = Field(default_factory=dict)
+    confidence: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Probability of the predicted certainty label in `[0, 1]` after softmax.",
+    )
+    distribution: dict[str, float] = Field(
+        default_factory=dict,
+        description="Per-class softmax probability over the three certainty classes.",
+    )
 
 
 class MultiAxisBlock(BaseModel):
@@ -335,9 +598,17 @@ class MultiAxisBlock(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    stance: MultiAxisStanceCard
-    certainty: MultiAxisCertaintyCard | None = None
-    time: MultiAxisTimeCard | None = None
+    stance: MultiAxisStanceCard = Field(
+        ..., description="Stance head prediction (hawkish/dovish/neutral) with class distribution."
+    )
+    certainty: MultiAxisCertaintyCard | None = Field(
+        default=None,
+        description="Certainty head prediction; null when the active checkpoint omits this axis.",
+    )
+    time: MultiAxisTimeCard | None = Field(
+        default=None,
+        description="Forward-looking time head prediction; null when the active checkpoint omits this axis.",
+    )
 
 
 class RatesReactionCard(BaseModel):
@@ -418,8 +689,14 @@ class VolRegimeReactionCard(BaseModel):
             "checkpoints."
         ),
     )
-    log_rv_lower: float | None = None
-    log_rv_upper: float | None = None
+    log_rv_lower: float | None = Field(
+        default=None,
+        description="Lower edge of the 80% conformal band on `log_rv_point`; null when no conformal sidecar is present.",
+    )
+    log_rv_upper: float | None = Field(
+        default=None,
+        description="Upper edge of the 80% conformal band on `log_rv_point`; null when no conformal sidecar is present.",
+    )
     regime_label: str = Field(
         ...,
         description="Argmax regime label: calm | normal | high.",
@@ -432,7 +709,10 @@ class VolRegimeReactionCard(BaseModel):
         default_factory=list,
         description="Calibrated APS prediction set (list of regime labels).",
     )
-    coverage: float | None = None
+    coverage: float | None = Field(
+        default=None,
+        description="Nominal conformal coverage (1 - alpha) for the APS set; null when no sidecar is on disk.",
+    )
 
 
 class MarketReactionPanel(BaseModel):
@@ -446,10 +726,22 @@ class MarketReactionPanel(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    rates: list[RatesReactionCard] = Field(default_factory=list)
-    vol_regime: VolRegimeReactionCard | None = None
-    encoder_alias: str | None = None
-    checkpoint_path: str | None = None
+    rates: list[RatesReactionCard] = Field(
+        default_factory=list,
+        description="One reaction card per mounted rates head (2y/5y/terminal); empty when no rates heads are mounted.",
+    )
+    vol_regime: VolRegimeReactionCard | None = Field(
+        default=None,
+        description="Vol-regime reaction card; null when the active checkpoint has no regime head.",
+    )
+    encoder_alias: str | None = Field(
+        default=None,
+        description="Registry alias of the encoder backing this market-reaction panel; null on a stateless build.",
+    )
+    checkpoint_path: str | None = Field(
+        default=None,
+        description="Absolute path of the checkpoint that produced these cards; null when no checkpoint is loaded.",
+    )
 
 
 class RegimeClassificationCard(BaseModel):
@@ -470,12 +762,26 @@ class RegimeClassificationCard(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    predicted_set: list[str]
-    set_label: str
-    set_size: int
-    coverage: float
-    distribution: dict[str, float]
-    argmax_class: str
+    predicted_set: list[str] = Field(
+        ...,
+        description="Calibrated APS prediction set of regime labels admitted at the `coverage` level.",
+    )
+    set_label: str = Field(
+        ..., description="UI-friendly bracketed label of the prediction set, e.g. `{calm, normal}`."
+    )
+    set_size: int = Field(
+        ..., description="Cardinality of `predicted_set`; ranges 1-3 for the 3-class regime head."
+    )
+    coverage: float = Field(
+        ..., description="Nominal coverage of the conformal APS set in `(0, 1)`."
+    )
+    distribution: dict[str, float] = Field(
+        ...,
+        description="Per-class softmax probabilities over the regime labels for the inference row.",
+    )
+    argmax_class: str = Field(
+        ..., description="Argmax regime label drawn from `distribution`; one of calm/normal/high."
+    )
     log_rv_point: float | None = Field(
         default=None,
         description=(
@@ -530,9 +836,18 @@ class RegimeRegressionCard(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    log_rv_point: float
-    log_rv_lower: float | None = None
-    log_rv_upper: float | None = None
+    log_rv_point: float = Field(
+        ...,
+        description="Regression-head point prediction in standardised log(forward realized vol) space.",
+    )
+    log_rv_lower: float | None = Field(
+        default=None,
+        description="Lower edge of the symmetric conformal interval at `coverage`; null when no sidecar is on disk.",
+    )
+    log_rv_upper: float | None = Field(
+        default=None,
+        description="Upper edge of the symmetric conformal interval at `coverage`; null when no sidecar is on disk.",
+    )
     coverage: float | None = Field(
         default=None,
         description=(
@@ -625,10 +940,22 @@ class InferenceStatusSurface(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    status: str
-    missing_kwarg: str | None = None
-    exception_class: str | None = None
-    detail: str | None = None
+    status: str = Field(
+        ...,
+        description="Degradation branch token: 'not_classification_mode', 'inference_kwarg_missing', or 'unexpected_exception'.",
+    )
+    missing_kwarg: str | None = Field(
+        default=None,
+        description="Name of the inference kwarg the checkpoint expected but did not receive; only set when status is 'inference_kwarg_missing'.",
+    )
+    exception_class: str | None = Field(
+        default=None,
+        description="Python class name of the caught exception when status is 'unexpected_exception'; None otherwise.",
+    )
+    detail: str | None = Field(
+        default=None,
+        description="Free-text message lifted from the caught exception so operators can grep without parsing logs.",
+    )
 
 
 class RealisedOutcomeHorizon(BaseModel):
@@ -647,19 +974,41 @@ class RealisedOutcomeHorizon(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    horizon: int
-    log_return: float | None = None
-    realised_volatility_5d_post_event: float | None = None
-    close: float | None = None
-    date: str | None = None
+    horizon: int = Field(
+        ..., description="Trading-day horizon offset from the replay anchor, e.g. 1, 3, 5."
+    )
+    log_return: float | None = Field(
+        default=None,
+        description="Realised log return from anchor close to t+h close; null when forward data is missing.",
+    )
+    realised_volatility_5d_post_event: float | None = Field(
+        default=None,
+        description="Rolling 5-bar realised volatility ending at t+h, measured strictly post-event.",
+    )
+    close: float | None = Field(
+        default=None, description="Realised adjusted close at t+h in the ticker's native currency."
+    )
+    date: str | None = Field(
+        default=None,
+        description="ISO `YYYY-MM-DD` of the trading session at t+h; null when the forward bar is unavailable.",
+    )
 
 
 class RealisedOutcomeBlock(BaseModel):
+    """Replay-mode reveal block — what actually happened forward of
+    `as_of_date` for each tracked horizon. Surfaced only when the request
+    set `as_of_date` and the forward bars are on disk."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    as_of_date: str
-    symbol: str
-    horizons: list[RealisedOutcomeHorizon]
+    as_of_date: str = Field(
+        ...,
+        description="ISO `YYYY-MM-DD` replay anchor the realised outcomes are measured forward of.",
+    )
+    symbol: str = Field(..., description="Yahoo Finance ticker the realised series was pulled for.")
+    horizons: list[RealisedOutcomeHorizon] = Field(
+        ..., description="Per-horizon realised outcomes ordered ascending by `horizon`."
+    )
 
 
 class ReplayModeBlock(BaseModel):
@@ -678,111 +1027,182 @@ class ReplayModeBlock(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    as_of_date: str
-    fold_id: str | None = None
-    train_end: str | None = None
-    classifier_rewind: bool = False
-    # ``True`` once the forecaster service is wired to load the per-fold
-    # checkpoint identified by ``fold_id``. Until that follow-up lands,
-    # this stays ``False`` so a consumer comparing ``replay.fold_id`` to
-    # ``model.checkpoint_path`` can tell the scaffolding apart from the
-    # full feature.
-    forecaster_checkpoint_rewound: bool = False
-    notes: list[str] = Field(default_factory=list)
+    as_of_date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` replay anchor echoed from the request."
+    )
+    fold_id: str | None = Field(
+        default=None,
+        description="Walk-forward fold identifier whose checkpoint served this prediction; null when no fold matched.",
+    )
+    train_end: str | None = Field(
+        default=None,
+        description="Latest date the fold's training slice contained; everything after is unseen by the model.",
+    )
+    classifier_rewind: bool = Field(
+        default=False,
+        description="True when the text-encoder weights are also rewound to `as_of_date`; false flags the known DAPT-pinned caveat.",
+    )
+    forecaster_checkpoint_rewound: bool = Field(
+        default=False,
+        description="True once the forecaster is wired to load the per-fold checkpoint identified by `fold_id`; false flags the scaffolding-only state.",
+    )
+    notes: list[str] = Field(
+        default_factory=list,
+        description="Free-text advisories on the replay run, e.g. caveats about partial rewind.",
+    )
 
 
 class AnalyzeResponse(BaseModel):
+    """Top-level envelope for `POST /analyze`. Bundles the stance classifier
+    output, the forecaster headline + bands, the market snapshot used as
+    anchor, runtime diagnostics, and the optional XAI, replay, multi-axis,
+    regime, rates and policy sub-blocks."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    sentiment: SentimentResponse
-    prediction: PredictionResponse
-    market: MarketDataResponse
-    model: ModelDiagnosticsResponse
-    series: ForecastSeriesResponse
-    # Replay-mode metadata + the "what actually happened" reveal. Both
-    # populated only when ``AnalyzeRequest.as_of_date`` is set. The
-    # frontend hides the replay banner + the reveal card when these are
-    # ``None`` so live-mode payloads stay byte-identical to the legacy
-    # shape.
-    replay: ReplayModeBlock | None = None
-    realised_outcome: RealisedOutcomeBlock | None = None
-    xai: XaiResponse | None = None
-    credibility: CredibilityResponse | None = None
-    multi_axis: MultiAxisBlock | None = None
-    regime_classification: RegimeClassificationCard | None = None
-    # #304 regression sibling. Populated when the active checkpoint
-    # mounts the dual-head regression head AND the classification card
-    # carried a non-null ``log_rv_point``. The classification card
-    # stays the headline; this block surfaces the continuous
-    # prediction + 90% conformal interval as a standalone read for the
-    # frontend's "show details" toggle on the regime panel.
-    regime_regression: RegimeRegressionCard | None = None
-    # #292 rates-reaction cards. One card per mounted rates head
-    # (2y / 5y / terminal) carrying the bps point + conformal interval
-    # plus the optional directional bucket / APS prediction set when
-    # ``--rates-classification-heads`` was on. ``None`` on a legacy
-    # single-head checkpoint or on a regression-output run; an empty
-    # list when the heads exist but the per-event forward produced no
-    # rows. Hooked by #293's MarketReactionPanel.
-    rates_reaction: list[RatesReactionCard] | None = None
-    # #446 mechanical policy decision extracted from the statement
-    # text. Pure regex / keyword pass — no model inference. None when
-    # the request carries no statement text (defensive; the schema
-    # requires text but the extractor wrapper still short-circuits on
-    # an empty body). Populated for any statement that names a target
-    # range; balance-sheet posture rides off the balance-sheet
-    # paragraph when present.
-    policy_action: PolicyActionCard | None = None
-    # #341 sibling status surface so an operator can grep the JSON
-    # response for the structured error branch when the regime card
-    # degrades. Mutually exclusive with ``regime_classification``
-    # being populated -- either the card lands, or this field carries
-    # the structured reason.
-    regime_classification_status: InferenceStatusSurface | None = None
+    sentiment: SentimentResponse = Field(
+        ..., description="Stance classifier output for the input statement including OOD chip."
+    )
+    prediction: PredictionResponse = Field(
+        ..., description="Headline scalar forecast at the chosen horizon."
+    )
+    market: MarketDataResponse = Field(
+        ..., description="Market snapshot at the trading session used as forecast anchor."
+    )
+    model: ModelDiagnosticsResponse = Field(
+        ..., description="Forecaster runtime + checkpoint diagnostics for this response."
+    )
+    series: ForecastSeriesResponse = Field(
+        ..., description="Chart-ready history, forecast and band arrays for the panel."
+    )
+    replay: ReplayModeBlock | None = Field(
+        default=None,
+        description="Replay-mode metadata; populated only when the request set `as_of_date`.",
+    )
+    realised_outcome: RealisedOutcomeBlock | None = Field(
+        default=None,
+        description="What-actually-happened reveal beside the forecast; populated only in replay mode.",
+    )
+    xai: XaiResponse | None = Field(
+        default=None,
+        description="XAI sentence + panel attribution; populated when `include_xai=true`.",
+    )
+    credibility: CredibilityResponse | None = Field(
+        default=None,
+        description="Stance-drift and credibility signals; null when no history is available.",
+    )
+    multi_axis: MultiAxisBlock | None = Field(
+        default=None,
+        description="Multi-task head per-axis predictions; null when no multi-axis checkpoint is loaded.",
+    )
+    regime_classification: RegimeClassificationCard | None = Field(
+        default=None,
+        description="Calibrated regime prediction set; null when the active checkpoint has no regime head.",
+    )
+    regime_regression: RegimeRegressionCard | None = Field(
+        default=None,
+        description="Regression sibling of the regime card carrying `log_rv_point` + conformal interval; null when the dual-head regression is absent.",
+    )
+    rates_reaction: list[RatesReactionCard] | None = Field(
+        default=None,
+        description="Per-rates-head reaction cards (2y/5y/terminal); null on legacy single-head runs, empty when heads exist but no rows were produced.",
+    )
+    policy_action: PolicyActionCard | None = Field(
+        default=None,
+        description="Mechanical policy decision extracted from the text via regex/keyword; null when the statement names no target range.",
+    )
+    regime_classification_status: InferenceStatusSurface | None = Field(
+        default=None,
+        description="Structured degradation surface mutually exclusive with `regime_classification`; carries the reason the regime card was not built.",
+    )
 
 
 class HistoryEntry(BaseModel):
-    id: str
-    created_at: str
-    symbol: str
-    document_date: str
-    horizon: str
-    forecast_mode: str
-    stance: str
-    sentiment_score: float | None = None
-    # Signed stance value ``P(hawkish) - P(dovish)`` derived from the persisted
-    # multi-axis distribution. ``None`` when the row pre-dates multi-axis or
-    # when the payload is regression-mode (no stance head). The History chart
-    # uses this for the Y-axis; ``sentiment_score`` is unsigned confidence and
-    # should not drive a signed axis.
-    stance_score: float | None = None
-    predicted_close: float | None = None
-    current_close: float | None = None
-    predicted_volatility: float | None = None
-    text_excerpt: str | None = None
-    # Regime summary extracted from the persisted payload. None when the row
-    # came from a regression-mode checkpoint or pre-dated the regime head.
-    argmax_regime: str | None = None
-    argmax_probability: float | None = None
-    regime_set_size: int | None = None
+    """One persisted analyze run summarised for the history list. Carries
+    the headline scalars and regime summary so the listing page can render
+    without re-fetching the full payload."""
+
+    id: str = Field(..., description="UUID identifier of the persisted analyze run.")
+    created_at: str = Field(..., description="ISO-8601 UTC timestamp the run was persisted.")
+    symbol: str = Field(..., description="Yahoo Finance ticker the run was anchored to.")
+    document_date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` event date of the analyzed FOMC document."
+    )
+    horizon: str = Field(..., description="Forecast horizon label, e.g. `1d`, `3d`, `5d`.")
+    forecast_mode: str = Field(
+        ...,
+        description="Forecast mode the run was executed under: `fast`, `quick_train`, or `real_train`.",
+    )
+    stance: str = Field(
+        ...,
+        description="Aggregated stance label persisted with the row: hawkish/dovish/neutral/UNKNOWN.",
+    )
+    sentiment_score: float | None = Field(
+        default=None,
+        description="Unsigned confidence of the persisted stance label in `[0, 1]`; null when missing.",
+    )
+    stance_score: float | None = Field(
+        default=None,
+        description="Signed stance value `P(hawkish) - P(dovish)` from the multi-axis distribution; null when the row pre-dates multi-axis.",
+    )
+    predicted_close: float | None = Field(
+        default=None,
+        description="Persisted point forecast of close at the chosen horizon; null when missing.",
+    )
+    current_close: float | None = Field(
+        default=None,
+        description="Anchor-session close from the persisted market snapshot; null when missing.",
+    )
+    predicted_volatility: float | None = Field(
+        default=None,
+        description="Persisted point forecast of realised volatility at the chosen horizon; null when missing.",
+    )
+    text_excerpt: str | None = Field(
+        default=None,
+        description="Leading excerpt of the analyzed statement text for the listing tile; null when redacted.",
+    )
+    argmax_regime: str | None = Field(
+        default=None,
+        description="Argmax regime label from the persisted regime card; null when the row pre-dates the regime head.",
+    )
+    argmax_probability: float | None = Field(
+        default=None,
+        description="Probability of the `argmax_regime` label in `[0, 1]`; null when no regime card was persisted.",
+    )
+    regime_set_size: int | None = Field(
+        default=None,
+        description="Cardinality of the persisted conformal regime set; null when no regime card was persisted.",
+    )
 
 
 class HistoryDetail(HistoryEntry):
-    payload: dict[str, Any]
+    payload: dict[str, Any] = Field(
+        ..., description="Full persisted analyze payload as a raw JSON object."
+    )
 
 
 class HistoryList(BaseModel):
-    items: list[HistoryEntry]
-    total: int
-    limit: int
-    offset: int
+    """Paginated listing envelope for the history page."""
+
+    items: list[HistoryEntry] = Field(
+        ..., description="History entries on the current page, newest-first by default."
+    )
+    total: int = Field(
+        ..., description="Total number of history entries available across all pages."
+    )
+    limit: int = Field(..., description="Page size echoed from the request.")
+    offset: int = Field(..., description="Page offset echoed from the request.")
 
 
 class StanceContextPoint(BaseModel):
     """One historical (date, score) pair for the rolling z-score baseline."""
 
-    document_date: str
-    stance_score: float
+    document_date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` event date of the historical FOMC row."
+    )
+    stance_score: float = Field(
+        ..., description="Signed stance score `P(hawkish) - P(dovish)` for the historical row."
+    )
 
 
 class StanceContextResponse(BaseModel):
@@ -795,25 +1215,40 @@ class StanceContextResponse(BaseModel):
     in which case the tile falls back to the raw-value rendering.
     """
 
-    n: int
-    mean: float | None
-    std: float | None
-    history: list[StanceContextPoint]
+    n: int = Field(..., description="Number of usable historical rows in `history`.")
+    mean: float | None = Field(
+        ...,
+        description="Trailing mean of `stance_score`; null when fewer than two rows are usable.",
+    )
+    std: float | None = Field(
+        ...,
+        description="Trailing sample standard deviation of `stance_score`; null when fewer than two rows are usable.",
+    )
+    history: list[StanceContextPoint] = Field(
+        ..., description="Historical (date, score) pairs ordered oldest-first."
+    )
 
 
 class HistoryRealizedResponse(BaseModel):
-    run_id: str
-    symbol: str
-    document_date: str
-    horizon: str
-    timestamps: list[str]
-    close: list[float]
-    volatility: list[float]
-    # Realized regime label derived from the post-event 10d-forward vol
-    # path, bucketed against the classifier's trained quantile cutoffs
-    # when those cutoffs are accessible. None when the cutoffs are not
-    # available on this host (regression-only checkpoint, cold start).
-    realized_regime: str | None = None
+    """Realised forward market path for a single persisted history run,
+    plus the bucketed realised regime label so the detail page can
+    render a predicted-vs-realised badge."""
+
+    run_id: str = Field(
+        ..., description="UUID of the history run this realised payload belongs to."
+    )
+    symbol: str = Field(..., description="Yahoo Finance ticker the realised series was pulled for.")
+    document_date: str = Field(..., description="ISO `YYYY-MM-DD` event date the run anchored to.")
+    horizon: str = Field(..., description="Forecast horizon label echoed from the run, e.g. `3d`.")
+    timestamps: list[str] = Field(
+        ..., description="ISO timestamps of the forward sessions, oldest-first."
+    )
+    close: list[float] = Field(..., description="Realised close prices aligned to `timestamps`.")
+    volatility: list[float] = Field(..., description="Realised volatility aligned to `timestamps`.")
+    realized_regime: str | None = Field(
+        default=None,
+        description="Realised regime label derived from the 10d-forward vol path; null when the classifier cutoffs are unavailable on this host.",
+    )
 
 
 class HistoryRealizedBatchResponse(BaseModel):
@@ -821,8 +1256,12 @@ class HistoryRealizedBatchResponse(BaseModel):
     yfinance failure) come back under ``missing`` so the caller can render
     a partial result instead of failing the whole page."""
 
-    items: dict[str, HistoryRealizedResponse]
-    missing: list[str]
+    items: dict[str, HistoryRealizedResponse] = Field(
+        ..., description="Realised payloads keyed by history run UUID."
+    )
+    missing: list[str] = Field(
+        ..., description="Run UUIDs for which realised data could not be fetched."
+    )
 
 
 class HistoryEventStudyResponse(BaseModel):
@@ -833,14 +1272,31 @@ class HistoryEventStudyResponse(BaseModel):
     "predicted X, realized Y".
     """
 
-    event_date: str
-    symbol: str
-    forward_dates: list[str]
-    forward_close: list[float]
-    forward_log_returns: list[float]
-    realized_vol_10d: float | None = None
-    predicted_regime: str | None = None
-    realized_regime: str | None = None
+    event_date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` event date the forward path is anchored to."
+    )
+    symbol: str = Field(..., description="Yahoo Finance ticker the forward series was pulled for.")
+    forward_dates: list[str] = Field(
+        ..., description="ISO dates of the 10 forward trading sessions, oldest-first."
+    )
+    forward_close: list[float] = Field(
+        ..., description="Realised close prices aligned to `forward_dates`."
+    )
+    forward_log_returns: list[float] = Field(
+        ..., description="Bar-to-bar log returns aligned to `forward_dates`."
+    )
+    realized_vol_10d: float | None = Field(
+        default=None,
+        description="Realised 10-day forward volatility derived from `forward_log_returns`; null when insufficient bars.",
+    )
+    predicted_regime: str | None = Field(
+        default=None,
+        description="Predicted regime label persisted with the original run; null when no regime card was persisted.",
+    )
+    realized_regime: str | None = Field(
+        default=None,
+        description="Realised regime label bucketed from `realized_vol_10d`; null when cutoffs are unavailable.",
+    )
 
 
 class EvaluationCoverageResponse(BaseModel):
@@ -854,32 +1310,73 @@ class EvaluationCoverageResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    nominal: float | None = None
-    empirical: float | None = None
-    sample_size: int
-    runs_total: int
-    computed_at: str
+    nominal: float | None = Field(
+        default=None,
+        description="Conformal target the active model was calibrated to; null when no recent run carries one.",
+    )
+    empirical: float | None = Field(
+        default=None,
+        description="Empirical hit rate of the predicted set across qualifying runs; null when no runs qualify.",
+    )
+    sample_size: int = Field(
+        ..., description="Number of qualifying runs the empirical coverage was computed over."
+    )
+    runs_total: int = Field(
+        ..., description="Total number of history runs considered before filtering."
+    )
+    computed_at: str = Field(
+        ..., description="ISO-8601 UTC timestamp the aggregate was computed at."
+    )
 
 
 class ClassificationBreakdownClass(BaseModel):
+    """Per-class accuracy metrics for one class in the regime breakdown."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    class_id: int
-    precision: float
-    recall: float
-    f1: float
-    support: int
-    roc_auc: float | None = None
-    pr_auc: float | None = None
+    class_id: int = Field(
+        ...,
+        description="Integer class index in canonical regime ordering (0=calm, 1=normal, 2=high).",
+    )
+    precision: float = Field(
+        ...,
+        description="Precision for this class in `[0, 1]`: true positives / predicted positives.",
+    )
+    recall: float = Field(
+        ..., description="Recall for this class in `[0, 1]`: true positives / actual positives."
+    )
+    f1: float = Field(
+        ...,
+        description="F1 score for this class in `[0, 1]`: harmonic mean of precision and recall.",
+    )
+    support: int = Field(..., description="Number of ground-truth samples in this class.")
+    roc_auc: float | None = Field(
+        default=None,
+        description="One-vs-rest ROC AUC for this class; null when the source artifact omits it.",
+    )
+    pr_auc: float | None = Field(
+        default=None,
+        description="One-vs-rest PR AUC for this class; null when the source artifact omits it.",
+    )
 
 
 class ClassificationBreakdownSource(BaseModel):
+    """Provenance metadata for the artifact backing a classification breakdown."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    relative_path: str
-    training_package_id: str | None = None
-    checkpoint_path: str | None = None
-    modified_at: str
+    relative_path: str = Field(
+        ..., description="Path of the source artifact relative to `data/artifacts/`."
+    )
+    training_package_id: str | None = Field(
+        default=None,
+        description="Training package ID the artifact was produced under; null when the field is absent on disk.",
+    )
+    checkpoint_path: str | None = Field(
+        default=None,
+        description="Checkpoint path the breakdown was computed against; null when not recorded.",
+    )
+    modified_at: str = Field(..., description="ISO-8601 mtime of the source artifact in UTC.")
 
 
 class ClassificationBreakdownResponse(BaseModel):
@@ -892,37 +1389,79 @@ class ClassificationBreakdownResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    available: bool
-    confusion_matrix: list[list[int]] | None = None
-    per_class: list[ClassificationBreakdownClass] | None = None
-    macro_f1: float | None = None
-    macro_precision: float | None = None
-    macro_recall: float | None = None
-    macro_roc_auc: float | None = None
-    macro_pr_auc: float | None = None
-    weighted_f1: float | None = None
-    n_classes: int | None = None
-    # Frontend assumes the canonical {calm, normal, high} ordering for
-    # 3-class regime models. ``class_labels`` is filled when the source
-    # artifact carries it; otherwise the field is None and the UI uses
-    # its defaults.
-    class_labels: list[str] | None = None
-    source: ClassificationBreakdownSource | None = None
+    available: bool = Field(
+        ...,
+        description="True when a qualifying artifact was found; false flags UI fallback to client-side aggregation.",
+    )
+    confusion_matrix: list[list[int]] | None = Field(
+        default=None,
+        description="Row-actual, column-predicted confusion matrix in canonical class order; null when unavailable.",
+    )
+    per_class: list[ClassificationBreakdownClass] | None = Field(
+        default=None,
+        description="Per-class precision/recall/F1/support entries; null when the artifact is missing.",
+    )
+    macro_f1: float | None = Field(
+        default=None,
+        description="Unweighted mean F1 across classes in `[0, 1]`; null when unavailable.",
+    )
+    macro_precision: float | None = Field(
+        default=None,
+        description="Unweighted mean precision across classes in `[0, 1]`; null when unavailable.",
+    )
+    macro_recall: float | None = Field(
+        default=None,
+        description="Unweighted mean recall across classes in `[0, 1]`; null when unavailable.",
+    )
+    macro_roc_auc: float | None = Field(
+        default=None,
+        description="Unweighted mean one-vs-rest ROC AUC across classes; null when unavailable.",
+    )
+    macro_pr_auc: float | None = Field(
+        default=None,
+        description="Unweighted mean one-vs-rest PR AUC across classes; null when unavailable.",
+    )
+    weighted_f1: float | None = Field(
+        default=None,
+        description="Support-weighted mean F1 across classes in `[0, 1]`; null when unavailable.",
+    )
+    n_classes: int | None = Field(
+        default=None, description="Number of classes in the breakdown; null when unavailable."
+    )
+    class_labels: list[str] | None = Field(
+        default=None,
+        description="Ordered class labels (e.g. calm/normal/high) from the source artifact; null when the artifact omits them.",
+    )
+    source: ClassificationBreakdownSource | None = Field(
+        default=None,
+        description="Provenance of the backing artifact; null when no artifact was found.",
+    )
 
 
 class SymbolDescriptor(BaseModel):
+    """One entry in the supported-symbols registry served to the asset picker."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    symbol: str
-    name: str
-    category: str
-    default_horizon: str
+    symbol: str = Field(..., description="Yahoo Finance ticker, e.g. `^GSPC` or `DX-Y.NYB`.")
+    name: str = Field(..., description="Human-readable name of the instrument shown in the picker.")
+    category: str = Field(
+        ...,
+        description="Category bucket the symbol falls into, e.g. `equity_index`, `currency`, `rates`.",
+    )
+    default_horizon: str = Field(
+        ..., description="Default forecast horizon label paired with this symbol on the workspace."
+    )
 
 
 class SymbolListResponse(BaseModel):
+    """Response envelope for `GET /symbols`."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    symbols: list[SymbolDescriptor]
+    symbols: list[SymbolDescriptor] = Field(
+        ..., description="Supported symbols ordered for display in the picker."
+    )
 
 
 class SettingsCheckpoint(BaseModel):
@@ -945,67 +1484,139 @@ class SettingsCheckpoint(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    filename: str
-    relative_path: str
-    role: str
-    size_bytes: int
-    modified_at: str
-    is_active: bool = False
-    output_mode: str | None = None
-    encoder_alias: str | None = None
-    conformal_sidecar_present: bool | None = None
-    required_kwargs: list[str] = Field(default_factory=list)
-    supplied_at_inference: dict[str, bool] = Field(default_factory=dict)
-    inference_contract_status: str | None = None
-    # Where the file actually lives. ``models_dir`` is the host-mounted
-    # ``backend/models/`` directory; ``hf_cache`` is the
-    # ``huggingface_hub`` snapshot cache the eager-pull /
-    # ``hf_hub_download`` paths land into when the file is not yet on
-    # disk under MODELS_DIR. The settings page renders a small badge so
-    # the operator can see at a glance whether a checkpoint is being
-    # served straight from the HF cache instead of the local mount.
-    source: str = "models_dir"
-    # HF Hub provenance — populated only for ``source == "hf_cache"``
-    # rows. ``repo`` is the ``owner/name`` slug, ``revision`` is the
-    # pinned commit (empty for unpinned artefacts), ``snapshot_path`` is
-    # the absolute path inside the HF cache the file resolves to.
-    repo: str | None = None
-    revision: str | None = None
-    snapshot_path: str | None = None
+    filename: str = Field(
+        ..., description="Bare filename of the checkpoint under `backend/models/`."
+    )
+    relative_path: str = Field(
+        ..., description="Path of the checkpoint relative to the models directory."
+    )
+    role: str = Field(
+        ..., description="Inferred role: forecaster / multi_axis / lora / calibration."
+    )
+    size_bytes: int = Field(..., description="File size in bytes as reported by the filesystem.")
+    modified_at: str = Field(..., description="ISO-8601 UTC mtime of the checkpoint file.")
+    is_active: bool = Field(
+        default=False,
+        description="True when the active service is currently loaded from this file.",
+    )
+    output_mode: str | None = Field(
+        default=None,
+        description="Output mode declared by the active checkpoint (e.g. classification/regression/dual); null on inactive rows.",
+    )
+    encoder_alias: str | None = Field(
+        default=None,
+        description="Registry alias of the encoder backing this checkpoint; null on inactive rows.",
+    )
+    conformal_sidecar_present: bool | None = Field(
+        default=None,
+        description="True when a sibling conformal calibration sidecar is on disk; null on inactive rows.",
+    )
+    required_kwargs: list[str] = Field(
+        default_factory=list,
+        description="Inference kwargs declared in the checkpoint's contract sidecar; empty for legacy artefacts.",
+    )
+    supplied_at_inference: dict[str, bool] = Field(
+        default_factory=dict,
+        description="Mapping from declared kwarg name to whether the live serving wiring supplies it.",
+    )
+    inference_contract_status: str | None = Field(
+        default=None,
+        description="`present` when a contract sidecar exists, `sidecar_absent` for legacy checkpoints.",
+    )
+    source: str = Field(
+        default="models_dir",
+        description="Origin of the file on disk: `models_dir` for the host-mounted directory or `hf_cache` for HF snapshot cache.",
+    )
+    repo: str | None = Field(
+        default=None,
+        description="HF Hub `owner/name` slug when `source == hf_cache`; null otherwise.",
+    )
+    revision: str | None = Field(
+        default=None,
+        description="Pinned HF commit hash when known; empty/null for unpinned artefacts.",
+    )
+    snapshot_path: str | None = Field(
+        default=None,
+        description="Absolute path inside the HF cache the file resolves to; null when `source == models_dir`.",
+    )
 
 
 class SettingsCheckpointsResponse(BaseModel):
+    """Response envelope for the settings-page checkpoint inventory."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    models_dir: str
-    checkpoints: list[SettingsCheckpoint]
+    models_dir: str = Field(
+        ..., description="Absolute path of the host-mounted `backend/models/` directory."
+    )
+    checkpoints: list[SettingsCheckpoint] = Field(
+        ...,
+        description="One entry per checkpoint file discovered under the models directory or HF cache.",
+    )
 
 
 class FomcMeetingResponse(BaseModel):
-    meeting_date: str
-    meeting_type: str
-    statement_release_date: str | None = None
-    minutes_release_date: str | None = None
-    notes: str | None = None
-    statement_available: bool = False
-    minutes_available: bool = False
-    press_conference_available: bool = False
+    """One FOMC meeting row in the calendar response."""
+
+    meeting_date: str = Field(..., description="ISO `YYYY-MM-DD` date of the FOMC meeting.")
+    meeting_type: str = Field(
+        ..., description="Meeting type label, e.g. `scheduled` or `unscheduled`."
+    )
+    statement_release_date: str | None = Field(
+        default=None,
+        description="ISO date the statement was released; null when not yet scheduled or recorded.",
+    )
+    minutes_release_date: str | None = Field(
+        default=None, description="ISO date the minutes were released; null when not yet released."
+    )
+    notes: str | None = Field(
+        default=None,
+        description="Free-text annotation on the meeting, e.g. inter-meeting context; null when absent.",
+    )
+    statement_available: bool = Field(
+        default=False,
+        description="True when the statement body is available in the `/documents` cache.",
+    )
+    minutes_available: bool = Field(
+        default=False,
+        description="True when the minutes body is available in the `/documents` cache.",
+    )
+    press_conference_available: bool = Field(
+        default=False,
+        description="True when a press-conference transcript is available in the cache.",
+    )
 
 
 class FomcCalendarResponse(BaseModel):
-    past: list[FomcMeetingResponse]
-    upcoming: list[FomcMeetingResponse]
+    """Past and upcoming FOMC meetings for the calendar panel."""
+
+    past: list[FomcMeetingResponse] = Field(
+        ..., description="Past FOMC meetings ordered newest-first."
+    )
+    upcoming: list[FomcMeetingResponse] = Field(
+        ..., description="Scheduled future FOMC meetings ordered soonest-first."
+    )
 
 
 class DocumentParseUrlRequest(BaseModel):
-    url: str
+    """Request body for `POST /documents/parse-url` — fetch and parse a remote PDF/HTML page."""
+
+    url: str = Field(
+        ..., description="Remote URL of the FOMC document (PDF or HTML page) to fetch and parse."
+    )
 
 
 class DocumentParseResponse(BaseModel):
-    text: str
-    char_count: int
-    source_kind: str
-    source_metadata: dict[str, str]
+    """Parsed plain-text payload extracted from a fetched FOMC document."""
+
+    text: str = Field(
+        ..., description="Extracted plain-text body after parsing the source document."
+    )
+    char_count: int = Field(..., description="Length of `text` in characters.")
+    source_kind: str = Field(..., description="Detected source kind, e.g. `pdf`, `html`, `text`.")
+    source_metadata: dict[str, str] = Field(
+        ..., description="Extracted metadata key/value pairs from the source, e.g. title or author."
+    )
 
 
 class DocumentDetailResponse(BaseModel):
@@ -1040,147 +1651,315 @@ class ArtifactFile(BaseModel):
     model_config = _FORBID_FROZEN_CONFIG
 
     relative_path: str = Field(..., description="Path relative to data/artifacts/")
-    size_bytes: int
+    size_bytes: int = Field(..., description="File size in bytes as reported by the filesystem.")
     modified_at: str = Field(..., description="ISO-8601 mtime, UTC.")
     suffix: str = Field(..., description="File extension including the dot, e.g. .json")
 
 
 class EncoderBakeoffRow(BaseModel):
+    """One encoder's seed-aggregated macro-F1 row in the bake-off table."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    encoder_key: str
-    checkpoint: str
-    seeds: list[int]
-    macro_f1_values: list[float]
-    macro_f1_mean: float
-    macro_f1_ci_low: float | None = None
-    macro_f1_ci_high: float | None = None
-    weighted_f1_mean: float | None = None
-    accuracy_mean: float | None = None
-    cohen_kappa: float | None = None
+    encoder_key: str = Field(..., description="Registry alias of the encoder being compared.")
+    checkpoint: str = Field(
+        ..., description="Checkpoint path or HF revision the bake-off was run against."
+    )
+    seeds: list[int] = Field(..., description="Seed set the bake-off was averaged across.")
+    macro_f1_values: list[float] = Field(
+        ..., description="Per-seed macro-F1 values aligned to `seeds`."
+    )
+    macro_f1_mean: float = Field(..., description="Mean macro-F1 across `seeds` in `[0, 1]`.")
+    macro_f1_ci_low: float | None = Field(
+        default=None,
+        description="Lower edge of the macro-F1 95% bootstrap CI; null when CI was not computed.",
+    )
+    macro_f1_ci_high: float | None = Field(
+        default=None,
+        description="Upper edge of the macro-F1 95% bootstrap CI; null when CI was not computed.",
+    )
+    weighted_f1_mean: float | None = Field(
+        default=None, description="Support-weighted mean F1 across seeds; null when not recorded."
+    )
+    accuracy_mean: float | None = Field(
+        default=None, description="Mean accuracy across seeds in `[0, 1]`; null when not recorded."
+    )
+    cohen_kappa: float | None = Field(
+        default=None, description="Mean Cohen kappa across seeds; null when not recorded."
+    )
 
 
 class EncoderBakeoffSection(BaseModel):
+    """Encoder bake-off table for the research artefacts response."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    available: bool
-    coverage: float | None = None
-    rows: list[EncoderBakeoffRow] = Field(default_factory=list)
-    source_files: list[str] = Field(default_factory=list)
+    available: bool = Field(
+        ..., description="True when at least one bake-off artifact was found on disk."
+    )
+    coverage: float | None = Field(
+        default=None,
+        description="Fraction of the official seed set covered by the rows in `[0, 1]`; null when unavailable.",
+    )
+    rows: list[EncoderBakeoffRow] = Field(
+        default_factory=list,
+        description="Per-encoder bake-off rows ordered by descending macro-F1 mean.",
+    )
+    source_files: list[str] = Field(
+        default_factory=list,
+        description="Relative paths of artefact files contributing to this section.",
+    )
 
 
 class TransferMatrixCell(BaseModel):
+    """One source -> target cell in the cross-bank transfer matrix."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    source: str
-    target: str
-    metric: float
+    source: str = Field(..., description="Source bank short code the model was fine-tuned on.")
+    target: str = Field(..., description="Target bank short code the model was evaluated on.")
+    metric: float = Field(
+        ...,
+        description="Transfer metric value (e.g. macro-F1) on `target` after training on `source`.",
+    )
 
 
 class CrossBankTransferSection(BaseModel):
+    """Cross-bank transfer matrix surfaced on the research page."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    available: bool
-    metric_name: str = "macro_f1"
-    sources: list[str] = Field(default_factory=list)
-    targets: list[str] = Field(default_factory=list)
-    cells: list[TransferMatrixCell] = Field(default_factory=list)
-    source_files: list[str] = Field(default_factory=list)
+    available: bool = Field(
+        ..., description="True when at least one source/target cell was found on disk."
+    )
+    metric_name: str = Field(
+        default="macro_f1",
+        description="Metric carried in each cell, e.g. `macro_f1` or `accuracy`.",
+    )
+    sources: list[str] = Field(
+        default_factory=list,
+        description="Distinct source banks present in `cells`, ordered for display.",
+    )
+    targets: list[str] = Field(
+        default_factory=list,
+        description="Distinct target banks present in `cells`, ordered for display.",
+    )
+    cells: list[TransferMatrixCell] = Field(
+        default_factory=list,
+        description="Flattened (source, target, metric) cells of the transfer matrix.",
+    )
+    source_files: list[str] = Field(
+        default_factory=list,
+        description="Relative paths of artefact files contributing to this section.",
+    )
 
 
 class EncoderAxisStanceRow(BaseModel):
+    """One encoder's validity-study row on the stance axis."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    encoder_alias: str
-    encoder_display: str
-    held_out_f1: float
-    spearman_rho: float
-    auc_hike_vs_cut: float
-    is_validity_winner: bool = False
-    is_held_out_winner: bool = False
+    encoder_alias: str = Field(..., description="Registry alias of the encoder being compared.")
+    encoder_display: str = Field(..., description="Display name of the encoder for UI rendering.")
+    held_out_f1: float = Field(
+        ..., description="Held-out macro-F1 of the stance head fine-tuned on this encoder."
+    )
+    spearman_rho: float = Field(
+        ...,
+        description="Spearman correlation between predicted stance scores and the labelled axis.",
+    )
+    auc_hike_vs_cut: float = Field(
+        ..., description="AUC of stance scores separating hike vs cut meetings."
+    )
+    is_validity_winner: bool = Field(
+        default=False, description="True when this encoder won the validity-study tie-break."
+    )
+    is_held_out_winner: bool = Field(
+        default=False, description="True when this encoder won on the held-out macro-F1 metric."
+    )
 
 
 class EncoderAxisStanceSection(BaseModel):
+    """Validity-study table for the stance axis on the research page."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    available: bool
-    rows: list[EncoderAxisStanceRow] = Field(default_factory=list)
-    source_doc: str = ""
+    available: bool = Field(
+        ..., description="True when at least one validity-study row was found on disk."
+    )
+    rows: list[EncoderAxisStanceRow] = Field(
+        default_factory=list, description="Per-encoder validity rows ordered by display priority."
+    )
+    source_doc: str = Field(
+        default="", description="Citation of the source document the rows were lifted from."
+    )
 
 
 class ResearchArtifactsResponse(BaseModel):
+    """Aggregate research-page envelope: artifact file index plus the
+    bake-off / validity / cross-bank-transfer sections."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    artifacts_root: str
-    sections: dict[str, list[ArtifactFile]]
-    encoder_bakeoff: EncoderBakeoffSection
-    encoder_axis_stance: EncoderAxisStanceSection = Field(
-        default_factory=lambda: EncoderAxisStanceSection(available=False, rows=[])
+    artifacts_root: str = Field(
+        ..., description="Absolute path of the `data/artifacts/` root the listing was taken from."
     )
-    cross_bank_transfer: CrossBankTransferSection
+    sections: dict[str, list[ArtifactFile]] = Field(
+        ..., description="Mapping from section name to its artifact file index."
+    )
+    encoder_bakeoff: EncoderBakeoffSection = Field(
+        ..., description="Encoder bake-off table on the canonical seed set."
+    )
+    encoder_axis_stance: EncoderAxisStanceSection = Field(
+        default_factory=lambda: EncoderAxisStanceSection(available=False, rows=[]),
+        description="Validity-study table for the stance axis.",
+    )
+    cross_bank_transfer: CrossBankTransferSection = Field(
+        ..., description="Cross-bank transfer matrix across the six covered central banks."
+    )
 
 
 class NextFomcMeetingPrediction(BaseModel):
+    """One next-FOMC ordinal prediction row keyed by model name."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    target_event_date: str
-    target_as_of_ts: str
+    target_event_date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` event date the prediction targets."
+    )
+    target_as_of_ts: str = Field(
+        ..., description="ISO-8601 UTC timestamp the features were anchored at."
+    )
     target_class: str | None = Field(
         default=None,
         description="Realised class, when known. None for the next-scheduled meeting.",
     )
-    n_train_rows: int
-    probabilities: dict[str, dict[str, float]]
-    predicted_class: dict[str, str]
+    n_train_rows: int = Field(
+        ..., description="Number of training rows that fed the model for this target."
+    )
+    probabilities: dict[str, dict[str, float]] = Field(
+        ..., description="Per-model dict of class -> probability for the target meeting."
+    )
+    predicted_class: dict[str, str] = Field(
+        ..., description="Per-model argmax class label drawn from `probabilities`."
+    )
 
 
 class NextFomcModelMetrics(BaseModel):
+    """Aggregate accuracy metrics for one next-FOMC model on a window."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    n: int
-    brier: float | None = None
-    log_loss: float | None = None
-    top1_accuracy: float | None = None
-    macro_f1: float | None = None
-    confusion_matrix: dict[str, dict[str, int]] = Field(default_factory=dict)
+    n: int = Field(..., description="Number of resolved predictions in the window.")
+    brier: float | None = Field(
+        default=None, description="Multiclass Brier score over the window; null when unavailable."
+    )
+    log_loss: float | None = Field(
+        default=None, description="Mean cross-entropy loss over the window; null when unavailable."
+    )
+    top1_accuracy: float | None = Field(
+        default=None, description="Top-1 argmax accuracy in `[0, 1]`; null when unavailable."
+    )
+    macro_f1: float | None = Field(
+        default=None,
+        description="Unweighted mean F1 across classes in `[0, 1]`; null when unavailable.",
+    )
+    confusion_matrix: dict[str, dict[str, int]] = Field(
+        default_factory=dict, description="Nested actual -> predicted counts over the window."
+    )
 
 
 class NextFomcAttributionRow(BaseModel):
+    """One feature-family attribution row in the next-FOMC ablation table."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    subset: str
-    families: list[str]
-    n_features: int | None = None
-    n: int | None = None
-    brier: float | None = None
-    log_loss: float | None = None
-    top1_accuracy: float | None = None
-    macro_f1: float | None = None
+    subset: str = Field(
+        ..., description="Subset identifier the row was scored on (e.g. `full`, `ex_pandemic`)."
+    )
+    families: list[str] = Field(..., description="Feature families included in this ablation row.")
+    n_features: int | None = Field(
+        default=None,
+        description="Number of features used after the family subset was applied; null when unavailable.",
+    )
+    n: int | None = Field(
+        default=None,
+        description="Number of resolved predictions used for the metrics; null when unavailable.",
+    )
+    brier: float | None = Field(
+        default=None, description="Multiclass Brier score for this row; null when unavailable."
+    )
+    log_loss: float | None = Field(
+        default=None, description="Mean cross-entropy loss for this row; null when unavailable."
+    )
+    top1_accuracy: float | None = Field(
+        default=None, description="Top-1 argmax accuracy in `[0, 1]`; null when unavailable."
+    )
+    macro_f1: float | None = Field(
+        default=None,
+        description="Unweighted mean F1 across classes in `[0, 1]`; null when unavailable.",
+    )
 
 
 class NextFomcUpcomingMeeting(BaseModel):
+    """Lightweight descriptor of the upcoming meeting the headline targets."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    meeting_date: str
-    meeting_type: str
-    statement_release_date: str | None = None
-    days_until: int | None = None
+    meeting_date: str = Field(..., description="ISO `YYYY-MM-DD` date of the next FOMC meeting.")
+    meeting_type: str = Field(..., description="Meeting type label, e.g. `scheduled`.")
+    statement_release_date: str | None = Field(
+        default=None, description="ISO date the statement is expected; null when not yet scheduled."
+    )
+    days_until: int | None = Field(
+        default=None,
+        description="Calendar days from today to `meeting_date`; null when unavailable.",
+    )
 
 
 class NextFomcForecastResponse(BaseModel):
+    """Response envelope for `GET /forecast/next-fomc`."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    available: bool
-    artifacts_dir: str
-    ordinal_classes: list[str]
-    model_names: list[str] = Field(default_factory=list)
-    upcoming_meeting: NextFomcUpcomingMeeting | None = None
-    headline: NextFomcMeetingPrediction | None = None
-    history: list[NextFomcMeetingPrediction] = Field(default_factory=list)
-    metrics_full_window: dict[str, NextFomcModelMetrics] = Field(default_factory=dict)
-    metrics_ex_pandemic: dict[str, NextFomcModelMetrics] = Field(default_factory=dict)
-    feature_attribution: list[NextFomcAttributionRow] = Field(default_factory=list)
-    summary: dict[str, int] = Field(default_factory=dict)
+    available: bool = Field(..., description="True when a next-FOMC artifact was found on disk.")
+    artifacts_dir: str = Field(
+        ..., description="Absolute path of the artifacts directory backing this response."
+    )
+    ordinal_classes: list[str] = Field(
+        ..., description="Ordered class labels the next-FOMC heads emit, e.g. cut/hold/hike."
+    )
+    model_names: list[str] = Field(
+        default_factory=list, description="Model identifiers compared in this response."
+    )
+    upcoming_meeting: NextFomcUpcomingMeeting | None = Field(
+        default=None,
+        description="Descriptor of the upcoming meeting the headline targets; null when none is scheduled.",
+    )
+    headline: NextFomcMeetingPrediction | None = Field(
+        default=None,
+        description="Headline next-meeting prediction row; null when no prediction is available.",
+    )
+    history: list[NextFomcMeetingPrediction] = Field(
+        default_factory=list,
+        description="Historical next-meeting predictions ordered oldest-first.",
+    )
+    metrics_full_window: dict[str, NextFomcModelMetrics] = Field(
+        default_factory=dict,
+        description="Per-model aggregate metrics over the full window keyed by model name.",
+    )
+    metrics_ex_pandemic: dict[str, NextFomcModelMetrics] = Field(
+        default_factory=dict,
+        description="Per-model aggregate metrics excluding the COVID pandemic window.",
+    )
+    feature_attribution: list[NextFomcAttributionRow] = Field(
+        default_factory=list,
+        description="Feature-family ablation rows for the model attribution table.",
+    )
+    summary: dict[str, int] = Field(
+        default_factory=dict,
+        description="Free-form integer summary counters surfaced beside the response.",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1463,22 +2242,44 @@ class TrajectoryResponse(BaseModel):
 
 
 class ResearchRegistryBaseline(BaseModel):
+    """No-text baseline reference row for the encoder registry."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    label: str
-    dual_f1: float | None = None
-    cls_f1: float | None = None
-    regression_f1: float | None = None
+    label: str = Field(..., description="Label of the no-text baseline, e.g. `market_only`.")
+    dual_f1: float | None = Field(
+        default=None,
+        description="Baseline macro-F1 on the dual-head surface; null when not recorded.",
+    )
+    cls_f1: float | None = Field(
+        default=None,
+        description="Baseline macro-F1 on the classification-only surface; null when not recorded.",
+    )
+    regression_f1: float | None = Field(
+        default=None,
+        description="Baseline macro-F1 on the regression-only surface; null when not recorded.",
+    )
 
 
 class ResearchRegistryRow(BaseModel):
+    """One encoder's row in the registry table comparing it to the no-text baseline."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    encoder_alias: str
-    encoder_display: str
-    dual_f1: float | None = None
-    cls_f1: float | None = None
-    regression_f1: float | None = None
+    encoder_alias: str = Field(..., description="Registry alias of the encoder being compared.")
+    encoder_display: str = Field(..., description="Display name of the encoder for UI rendering.")
+    dual_f1: float | None = Field(
+        default=None,
+        description="Encoder macro-F1 on the dual-head surface; null when not recorded.",
+    )
+    cls_f1: float | None = Field(
+        default=None,
+        description="Encoder macro-F1 on the classification-only surface; null when not recorded.",
+    )
+    regression_f1: float | None = Field(
+        default=None,
+        description="Encoder macro-F1 on the regression-only surface; null when not recorded.",
+    )
     delta_dual: float | None = Field(
         default=None,
         description="Δ macro-F1 on the dual-head surface vs no-text baseline.",
@@ -1491,12 +2292,17 @@ class ResearchRegistryRow(BaseModel):
         default=False,
         description="True iff the active surfaces Δ is >= 0 (non-negative lift).",
     )
-    checkpoint_relpath: str | None = None
+    checkpoint_relpath: str | None = Field(
+        default=None,
+        description="Path of the encoder checkpoint relative to the models directory; null when not published.",
+    )
     cache_uri: str | None = Field(
         default=None,
         description="hf:// URI of the shareable embedding cache parquet, if published.",
     )
-    notes: str = ""
+    notes: str = Field(
+        default="", description="Free-text notes for the row, e.g. caveats; empty when none."
+    )
 
 
 class ResearchRegistryResponse(BaseModel):
@@ -1510,15 +2316,31 @@ class ResearchRegistryResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    available: bool
-    surface: Literal["dual", "cls"]
-    baseline: ResearchRegistryBaseline | None = None
-    rows: list[ResearchRegistryRow] = Field(default_factory=list)
-    rejected_count: int = 0
-    training_package_id: str = ""
-    head: str = ""
-    seeds: list[int] = Field(default_factory=list)
-    source_wiki_section: str = ""
+    available: bool = Field(..., description="True when a registry manifest was found on disk.")
+    surface: Literal["dual", "cls"] = Field(
+        ..., description="Which head surface the lift is computed on: `dual` or `cls`."
+    )
+    baseline: ResearchRegistryBaseline | None = Field(
+        default=None, description="Reference no-text baseline row; null when not recorded."
+    )
+    rows: list[ResearchRegistryRow] = Field(
+        default_factory=list, description="Per-encoder registry rows after filtering on lift sign."
+    )
+    rejected_count: int = Field(
+        default=0, description="Number of rows filtered out for negative or null lift."
+    )
+    training_package_id: str = Field(
+        default="", description="Training package ID the registry was assembled from."
+    )
+    head: str = Field(
+        default="", description="Head identifier within the package the rows were computed on."
+    )
+    seeds: list[int] = Field(
+        default_factory=list, description="Seed set the registry rows were averaged across."
+    )
+    source_wiki_section: str = Field(
+        default="", description="Wiki section identifier the registry sources its baseline from."
+    )
 
 
 # #299 PR-B — stance-directional backtest engine
@@ -1553,12 +2375,20 @@ class BacktestRequest(BaseModel):
 
 
 class BacktestTradeRow(BaseModel):
+    """One realised trade row from the stance-directional backtest."""
+
     model_config = _FORBID_FROZEN_CONFIG
 
-    date: str
-    position: int
-    forward_return_pct: float | None = None
-    strategy_return_pct: float | None = None
+    date: str = Field(..., description="ISO `YYYY-MM-DD` date of the signal entry.")
+    position: int = Field(..., description="Position taken on `date`: -1 short, 0 flat, +1 long.")
+    forward_return_pct: float | None = Field(
+        default=None,
+        description="Forward holding-period close-to-close % return from `date`; null when forward bars are missing.",
+    )
+    strategy_return_pct: float | None = Field(
+        default=None,
+        description="Strategy % return for the trade = `position * forward_return_pct`; null when the trade is unresolved.",
+    )
 
 
 class BacktestResponse(BaseModel):
@@ -1566,16 +2396,38 @@ class BacktestResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    trades: list[BacktestTradeRow] = Field(default_factory=list)
-    n_trades: int
-    sharpe: float | None = None
-    hit_rate: float | None = None
-    max_dd_pct: float | None = None
-    cum_return_pct: float | None = None
-    benchmark_cum_pct: float | None = None
-    alpha_cum_pct: float | None = None
-    horizon_days: int
-    symbol: str
+    trades: list[BacktestTradeRow] = Field(
+        default_factory=list, description="Per-signal trade rows produced by the backtest."
+    )
+    n_trades: int = Field(..., description="Number of trades executed in the backtest.")
+    sharpe: float | None = Field(
+        default=None,
+        description="Annualised Sharpe ratio of the strategy returns; null when fewer than two resolved trades.",
+    )
+    hit_rate: float | None = Field(
+        default=None,
+        description="Fraction of resolved trades with positive strategy return in `[0, 1]`; null when none resolved.",
+    )
+    max_dd_pct: float | None = Field(
+        default=None,
+        description="Maximum % drawdown of the cumulative strategy curve; null when unavailable.",
+    )
+    cum_return_pct: float | None = Field(
+        default=None,
+        description="Cumulative % return of the strategy across all resolved trades; null when none resolved.",
+    )
+    benchmark_cum_pct: float | None = Field(
+        default=None,
+        description="Cumulative % return of buy-and-hold on `symbol` over the same window; null when unavailable.",
+    )
+    alpha_cum_pct: float | None = Field(
+        default=None,
+        description="Strategy cumulative return minus benchmark cumulative return; null when either side is unavailable.",
+    )
+    horizon_days: int = Field(
+        ..., description="Forward holding period in trading days echoed from the request."
+    )
+    symbol: str = Field(..., description="Yahoo Finance ticker the backtest was run against.")
 
 
 class RealizedVolHorizonForecast(BaseModel):
@@ -1590,15 +2442,32 @@ class RealizedVolHorizonForecast(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    h: int
-    point: float
-    band_lo_80: float
-    band_hi_80: float
-    band_lo_90: float
-    band_hi_90: float
-    qlike_model: float | None = None
-    qlike_har: float | None = None
-    coverage_empirical_90: float | None = None
+    h: int = Field(..., description="Forecast horizon in trading days, e.g. 1, 5, or 22.")
+    point: float = Field(..., description="Point forecast of realized variance at horizon h.")
+    band_lo_80: float = Field(
+        ..., description="Lower edge of the 80% conformal band on `point` in RV units."
+    )
+    band_hi_80: float = Field(
+        ..., description="Upper edge of the 80% conformal band on `point` in RV units."
+    )
+    band_lo_90: float = Field(
+        ..., description="Lower edge of the 90% conformal band on `point` in RV units."
+    )
+    band_hi_90: float = Field(
+        ..., description="Upper edge of the 90% conformal band on `point` in RV units."
+    )
+    qlike_model: float | None = Field(
+        default=None,
+        description="Pooled walk-forward QLIKE loss for the model at this horizon (lower is better); null when unavailable.",
+    )
+    qlike_har: float | None = Field(
+        default=None,
+        description="Pooled walk-forward QLIKE loss for HAR-OLS at this horizon (baseline); null when unavailable.",
+    )
+    coverage_empirical_90: float | None = Field(
+        default=None,
+        description="Prospective empirical coverage of the 90% band in `[0, 1]`; null when unavailable.",
+    )
 
 
 class RealizedVolHistoricalBand(BaseModel):
@@ -1610,10 +2479,18 @@ class RealizedVolHistoricalBand(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    date: str
-    band_lo_80: float
-    band_hi_80: float
-    realized_rv: float | None = None
+    date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` of the trading session this band targeted."
+    )
+    band_lo_80: float = Field(
+        ..., description="Lower edge of the 80% conformal band at this session in RV units."
+    )
+    band_hi_80: float = Field(
+        ..., description="Upper edge of the 80% conformal band at this session in RV units."
+    )
+    realized_rv: float | None = Field(
+        default=None, description="Realised RV on this session; null when the bar is unavailable."
+    )
 
 
 class RealizedVolForecastResponse(BaseModel):
@@ -1621,24 +2498,31 @@ class RealizedVolForecastResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    symbol: str
-    horizons: list[RealizedVolHorizonForecast]
-    history: list[float] = Field(default_factory=list)
-    history_dates: list[str] = Field(default_factory=list)
-    model_revision: str
-    historical_bands: list[RealizedVolHistoricalBand] | None = None
-    # "live" when the QLIKE head was filled with intraday-derived
-    # realized measures (full QLIKE edge); "training_means" when the
-    # head fell back to feat_mean (HAR-grade forecast). The dashboard
-    # surfaces this so the displayed point + bands are not misread as
-    # the full edge when intraday isn't reachable.
-    realized_features_source: str = "training_means"
-    # ISO date of the most-recent full intraday session the live
-    # measures were reduced from. ``None`` when the head fell back to
-    # training_means. The dashboard renders this in the badge tooltip
-    # so the reader can tell a Friday measure feeding a Tuesday forecast
-    # from one off the previous full session.
-    realized_features_date: str | None = None
+    symbol: str = Field(..., description="Yahoo Finance ticker the RV forecast was produced for.")
+    horizons: list[RealizedVolHorizonForecast] = Field(
+        ..., description="Per-horizon point + conformal-band forecasts ordered ascending by `h`."
+    )
+    history: list[float] = Field(
+        default_factory=list, description="Last-60d realised RV history aligned to `history_dates`."
+    )
+    history_dates: list[str] = Field(
+        default_factory=list, description="ISO dates aligned to `history` entries, oldest-first."
+    )
+    model_revision: str = Field(
+        ..., description="Model revision identifier the forecast was produced under."
+    )
+    historical_bands: list[RealizedVolHistoricalBand] | None = Field(
+        default=None,
+        description="Per-day walk-forward h=1 conformal bands for the sparkline; null when unavailable.",
+    )
+    realized_features_source: str = Field(
+        default="training_means",
+        description="`live` when intraday-derived measures filled the QLIKE head; `training_means` when the head fell back to feat_mean.",
+    )
+    realized_features_date: str | None = Field(
+        default=None,
+        description="ISO date of the most-recent intraday session the live measures were reduced from; null when the head fell back to training_means.",
+    )
 
 
 class HarTercileHorizon(BaseModel):
@@ -1657,9 +2541,13 @@ class HarTercileHorizon(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    h: int
-    predicted_rv: float
-    tercile: Literal["low", "medium", "high"]
+    h: int = Field(..., description="Forecast horizon in trading days, e.g. 1, 5, or 22.")
+    predicted_rv: float = Field(
+        ..., description="HAR-OLS point forecast of realized variance at horizon h."
+    )
+    tercile: Literal["low", "medium", "high"] = Field(
+        ..., description="Argmax tercile bucket for `predicted_rv` against the q33/q67 cutoffs."
+    )
     tercile_probs: dict[str, float] = Field(
         default_factory=dict,
         description="Per-class probability over (low, medium, high). Sums to 1.0.",
@@ -1705,8 +2593,12 @@ class HarTercileBaselineResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    symbol: str
-    horizons: list[HarTercileHorizon]
+    symbol: str = Field(
+        ..., description="Yahoo Finance ticker the HAR-tercile baseline was produced for."
+    )
+    horizons: list[HarTercileHorizon] = Field(
+        ..., description="Per-horizon HAR-tercile rows ordered ascending by `h`."
+    )
     cutoffs_q33: float = Field(
         ...,
         description=(
@@ -1719,8 +2611,12 @@ class HarTercileBaselineResponse(BaseModel):
         ...,
         description="Upper tercile cutoff on realized variance.",
     )
-    model_revision: str
-    generated_at: str
+    model_revision: str = Field(
+        ..., description="Model revision identifier the baseline was produced under."
+    )
+    generated_at: str = Field(
+        ..., description="ISO-8601 UTC timestamp the response was generated at."
+    )
 
 
 # Workspace-spine bundle: shared response models for the four
@@ -1747,15 +2643,34 @@ class ExpectedVolumeHorizonForecast(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    h: int
-    point_log_residual: float
-    point_pct_vs_baseline: float
-    band_lo_80: float
-    band_hi_80: float
-    band_lo_90: float
-    band_hi_90: float
-    r2_har: float | None = None
-    calendar_adjusted: bool
+    h: int = Field(..., description="Forecast horizon in trading days, e.g. 1, 5, or 22.")
+    point_log_residual: float = Field(
+        ...,
+        description="Point estimate in log-volume residual space after optional calendar adjustment.",
+    )
+    point_pct_vs_baseline: float = Field(
+        ...,
+        description="Point estimate as a % deviation from the rolling calendar-adjusted baseline.",
+    )
+    band_lo_80: float = Field(
+        ..., description="Lower edge of the 80% conformal band on `point_log_residual`."
+    )
+    band_hi_80: float = Field(
+        ..., description="Upper edge of the 80% conformal band on `point_log_residual`."
+    )
+    band_lo_90: float = Field(
+        ..., description="Lower edge of the 90% conformal band on `point_log_residual`."
+    )
+    band_hi_90: float = Field(
+        ..., description="Upper edge of the 90% conformal band on `point_log_residual`."
+    )
+    r2_har: float | None = Field(
+        default=None,
+        description="Pooled walk-forward R^2 of the HAR volume head at this horizon; null when unavailable.",
+    )
+    calendar_adjusted: bool = Field(
+        ..., description="True when the baseline subtraction used a calendar-adjusted rolling mean."
+    )
 
 
 class ExpectedVolumeForecastResponse(BaseModel):
@@ -1765,10 +2680,18 @@ class ExpectedVolumeForecastResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    symbol: str
-    horizons: list[ExpectedVolumeHorizonForecast]
-    model_revision: str
-    generated_at: str
+    symbol: str = Field(
+        ..., description="Yahoo Finance ticker the volume forecast was produced for."
+    )
+    horizons: list[ExpectedVolumeHorizonForecast] = Field(
+        ..., description="Per-horizon volume forecast rows ordered ascending by `h`."
+    )
+    model_revision: str = Field(
+        ..., description="Model revision identifier the forecast was produced under."
+    )
+    generated_at: str = Field(
+        ..., description="ISO-8601 UTC timestamp the response was generated at."
+    )
 
 
 class MonetaryPolicySurpriseResponse(BaseModel):
@@ -1784,12 +2707,27 @@ class MonetaryPolicySurpriseResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    event_date: str
-    mp_surprise_level_bps: float
-    direction: Literal["hawkish", "dovish", "no_surprise"]
-    magnitude_bps: float
-    is_intermeeting: bool
-    ff_target_prior_bps: float | None = None
+    event_date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` of the FOMC event the surprise was measured at."
+    )
+    mp_surprise_level_bps: float = Field(
+        ...,
+        description="Realised rate-path surprise vs the pre-meeting fed-funds futures consensus, in basis points (signed).",
+    )
+    direction: Literal["hawkish", "dovish", "no_surprise"] = Field(
+        ..., description="Discrete sign bucket of the surprise the panel renders."
+    )
+    magnitude_bps: float = Field(
+        ..., description="Absolute magnitude of the surprise in basis points (non-negative)."
+    )
+    is_intermeeting: bool = Field(
+        ...,
+        description="True when the action was off-cycle and the consensus baseline was constructed differently.",
+    )
+    ff_target_prior_bps: float | None = Field(
+        default=None,
+        description="Prior fed-funds target midpoint in basis points; null when unavailable.",
+    )
 
 
 class FuturesConsensusHorizon(BaseModel):
@@ -1802,12 +2740,24 @@ class FuturesConsensusHorizon(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    horizon_label: str
-    implied_rate_bps: float
-    change_vs_current_bps: float
-    probability_hike: float
-    probability_cut: float
-    probability_pause: float
+    horizon_label: str = Field(
+        ..., description="Horizon identifier for the futures contract, e.g. `next` or `+3m`."
+    )
+    implied_rate_bps: float = Field(
+        ..., description="Futures-implied fed-funds rate at this horizon in basis points."
+    )
+    change_vs_current_bps: float = Field(
+        ..., description="Signed change in basis points vs the current target midpoint."
+    )
+    probability_hike: float = Field(
+        ..., description="Implied probability of a rate hike at this horizon in `[0, 1]`."
+    )
+    probability_cut: float = Field(
+        ..., description="Implied probability of a rate cut at this horizon in `[0, 1]`."
+    )
+    probability_pause: float = Field(
+        ..., description="Implied probability of a hold at this horizon in `[0, 1]`."
+    )
 
 
 class FuturesConsensusResponse(BaseModel):
@@ -1819,13 +2769,27 @@ class FuturesConsensusResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    meeting_date: str
-    generated_at: str
-    current_target_lo_bps: float
-    current_target_hi_bps: float
-    horizons: list[FuturesConsensusHorizon]
-    methodology: str
-    data_source: str
+    meeting_date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` of the FOMC meeting the consensus targets."
+    )
+    generated_at: str = Field(
+        ..., description="ISO-8601 UTC timestamp the response was generated at."
+    )
+    current_target_lo_bps: float = Field(
+        ..., description="Lower bound of the current fed-funds target range in basis points."
+    )
+    current_target_hi_bps: float = Field(
+        ..., description="Upper bound of the current fed-funds target range in basis points."
+    )
+    horizons: list[FuturesConsensusHorizon] = Field(
+        ..., description="Per-horizon implied-rate + bucket-probability rows ordered by horizon."
+    )
+    methodology: str = Field(
+        ..., description="Short description of how the implied probabilities were derived."
+    )
+    data_source: str = Field(
+        ..., description="Upstream data source identifier, e.g. `FRED` or `CME`."
+    )
 
 
 class SemanticDiffSpan(BaseModel):
@@ -1839,9 +2803,14 @@ class SemanticDiffSpan(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    kind: Literal["unchanged", "added", "removed", "substituted"]
-    text: str
-    paired_text: str | None = None
+    kind: Literal["unchanged", "added", "removed", "substituted"] = Field(
+        ..., description="Alignment bucket of this span vs the prior statement."
+    )
+    text: str = Field(..., description="Surface text of the span on the current-statement side.")
+    paired_text: str | None = Field(
+        default=None,
+        description="Matched span on the prior-statement side for `substituted` kinds; null when no near-match neighbour was emitted.",
+    )
 
 
 class SemanticDiffTopic(BaseModel):
@@ -1855,11 +2824,18 @@ class SemanticDiffTopic(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    topic: str
-    prior_emphasis: float
-    current_emphasis: float
-    delta: float
-    sample_phrases: list[str] = Field(default_factory=list)
+    topic: str = Field(..., description="Topic identifier from the topic model used for the diff.")
+    prior_emphasis: float = Field(
+        ..., description="Topic-share mass in the prior statement in `[0, 1]`."
+    )
+    current_emphasis: float = Field(
+        ..., description="Topic-share mass in the current statement in `[0, 1]`."
+    )
+    delta: float = Field(..., description="Signed delta = current_emphasis - prior_emphasis.")
+    sample_phrases: list[str] = Field(
+        default_factory=list,
+        description="Highest-loading n-grams the panel surfaces alongside the topic bar.",
+    )
 
 
 class SemanticDiffRequest(BaseModel):
@@ -1899,12 +2875,27 @@ class SemanticDiffResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    current_date: str
-    prior_date: str
-    token_spans: list[SemanticDiffSpan]
-    topic_deltas: list[SemanticDiffTopic]
-    summary: str
-    status: Literal["ok", "no_input", "no_prior", "non_english"] | None = None
+    current_date: str = Field(
+        ..., description="ISO `YYYY-MM-DD` event date of the current statement."
+    )
+    prior_date: str = Field(
+        ...,
+        description="ISO `YYYY-MM-DD` event date of the strict-prior statement on file; empty when none.",
+    )
+    token_spans: list[SemanticDiffSpan] = Field(
+        ...,
+        description="Token-aligned span sequence between the two statements in current-statement order.",
+    )
+    topic_deltas: list[SemanticDiffTopic] = Field(
+        ..., description="Topic-emphasis delta rows ordered by absolute delta magnitude."
+    )
+    summary: str = Field(
+        ..., description="Short human-readable summary of the diff, e.g. headline phrase changes."
+    )
+    status: Literal["ok", "no_input", "no_prior", "non_english"] | None = Field(
+        default=None,
+        description="Parseable status flag for the panel banner; null on legacy responses that pre-date the field.",
+    )
 
 
 class HarTercileBacktestRow(BaseModel):
@@ -1919,12 +2910,27 @@ class HarTercileBacktestRow(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    event_date: str
-    predicted_tercile: str | None = None
-    predicted_prob: float | None = None
-    realized_tercile: str | None = None
-    realized_rv: float | None = None
-    correct: bool | None = None
+    event_date: str = Field(..., description="ISO `YYYY-MM-DD` event date the row was anchored to.")
+    predicted_tercile: str | None = Field(
+        default=None,
+        description="HAR-tercile predicted bucket (low/medium/high) at the event; null when the forecast was outside the warmup window.",
+    )
+    predicted_prob: float | None = Field(
+        default=None,
+        description="Probability of the predicted tercile in `[0, 1]`; null when the forecast is unavailable.",
+    )
+    realized_tercile: str | None = Field(
+        default=None,
+        description="Realised forward-vol tercile bucketed off the same cutoffs; null when the forward window has not yet closed.",
+    )
+    realized_rv: float | None = Field(
+        default=None,
+        description="Realised RV measured at the forward bar; null when the forward window has not yet closed.",
+    )
+    correct: bool | None = Field(
+        default=None,
+        description="True when `predicted_tercile == realized_tercile`; null when the row is unresolved.",
+    )
 
 
 class HarAccuracyMetrics(BaseModel):
@@ -1940,10 +2946,19 @@ class HarAccuracyMetrics(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    total_runs: int
-    resolved_runs: int
-    accuracy_overall: float | None = None
-    per_tercile_hit_rate: dict[str, float] = Field(default_factory=dict)
+    total_runs: int = Field(
+        ..., description="Total rows in the window regardless of forward-window resolution."
+    )
+    resolved_runs: int = Field(
+        ..., description="Number of rows whose realised tercile could be derived."
+    )
+    accuracy_overall: float | None = Field(
+        default=None,
+        description="Hit rate across resolved rows in `[0, 1]`; null when none resolved.",
+    )
+    per_tercile_hit_rate: dict[str, float] = Field(
+        default_factory=dict, description="Per-predicted-tercile hit rate keyed by predicted label."
+    )
 
 
 class HarTercileBacktestResponse(BaseModel):
@@ -1956,11 +2971,19 @@ class HarTercileBacktestResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    symbol: str
-    horizon: int
-    rows: list[HarTercileBacktestRow]
-    metrics: HarAccuracyMetrics
-    generated_at: str
+    symbol: str = Field(..., description="Yahoo Finance ticker the backtest was run against.")
+    horizon: int = Field(
+        ..., description="Forward horizon in trading days the realised tercile was measured at."
+    )
+    rows: list[HarTercileBacktestRow] = Field(
+        ..., description="Per-event backtest rows ordered by `event_date`."
+    )
+    metrics: HarAccuracyMetrics = Field(
+        ..., description="Aggregate accuracy metrics across the rows."
+    )
+    generated_at: str = Field(
+        ..., description="ISO-8601 UTC timestamp the response was generated at."
+    )
 
 
 class RvBacktestRow(BaseModel):
@@ -1976,15 +2999,35 @@ class RvBacktestRow(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    event_date: str
-    point_forecast_rv: float | None = None
-    band_lo_80: float | None = None
-    band_hi_80: float | None = None
-    band_lo_90: float | None = None
-    band_hi_90: float | None = None
-    realized_rv: float | None = None
-    in_band_80: bool | None = None
-    in_band_90: bool | None = None
+    event_date: str = Field(..., description="ISO `YYYY-MM-DD` event date the row was anchored to.")
+    point_forecast_rv: float | None = Field(
+        default=None,
+        description="h=1 point forecast of realised variance; null on pending rows inside the HAR warmup or beyond RV history.",
+    )
+    band_lo_80: float | None = Field(
+        default=None, description="Lower edge of the 80% conformal band; null on pending rows."
+    )
+    band_hi_80: float | None = Field(
+        default=None, description="Upper edge of the 80% conformal band; null on pending rows."
+    )
+    band_lo_90: float | None = Field(
+        default=None, description="Lower edge of the 90% conformal band; null on pending rows."
+    )
+    band_hi_90: float | None = Field(
+        default=None, description="Upper edge of the 90% conformal band; null on pending rows."
+    )
+    realized_rv: float | None = Field(
+        default=None,
+        description="Realised RV on the predicted bar; null when the bar is unresolved.",
+    )
+    in_band_80: bool | None = Field(
+        default=None,
+        description="True when `realized_rv` lies inside the 80% band; null when realised RV is unresolved.",
+    )
+    in_band_90: bool | None = Field(
+        default=None,
+        description="True when `realized_rv` lies inside the 90% band; null when realised RV is unresolved.",
+    )
 
 
 class RvBacktestCoverage(BaseModel):
@@ -2002,13 +3045,30 @@ class RvBacktestCoverage(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    total_runs: int
-    resolved_runs: int
-    pending_runs: int = 0
-    empirical_coverage_80: float | None = None
-    empirical_coverage_90: float | None = None
-    nominal_coverage_80: float = 0.80
-    nominal_coverage_90: float = 0.90
+    total_runs: int = Field(
+        ..., description="Total rows in the backtest window regardless of resolution."
+    )
+    resolved_runs: int = Field(
+        ..., description="Number of rows with realised RV on the predicted bar."
+    )
+    pending_runs: int = Field(
+        default=0,
+        description="Rows that could not be scored because the event sits in the HAR warmup or beyond available RV history.",
+    )
+    empirical_coverage_80: float | None = Field(
+        default=None,
+        description="Fraction of resolved rows whose realised RV landed inside the 80% band; null when none resolved.",
+    )
+    empirical_coverage_90: float | None = Field(
+        default=None,
+        description="Fraction of resolved rows whose realised RV landed inside the 90% band; null when none resolved.",
+    )
+    nominal_coverage_80: float = Field(
+        default=0.80, description="Calibration target for the 80% band, pinned to 0.80."
+    )
+    nominal_coverage_90: float = Field(
+        default=0.90, description="Calibration target for the 90% band, pinned to 0.90."
+    )
 
 
 class RvBacktestResponse(BaseModel):
@@ -2022,11 +3082,19 @@ class RvBacktestResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    symbol: str
-    horizon: int
-    rows: list[RvBacktestRow]
-    coverage: RvBacktestCoverage
-    generated_at: str
+    symbol: str = Field(..., description="Yahoo Finance ticker the RV backtest was run against.")
+    horizon: int = Field(
+        ..., description="Forward horizon in trading days the bands were calibrated for (h=1)."
+    )
+    rows: list[RvBacktestRow] = Field(
+        ..., description="Per-event RV backtest rows ordered by `event_date`."
+    )
+    coverage: RvBacktestCoverage = Field(
+        ..., description="Aggregate empirical-vs-nominal coverage across the rows."
+    )
+    generated_at: str = Field(
+        ..., description="ISO-8601 UTC timestamp the response was generated at."
+    )
 
 
 class CrossBankCard(BaseModel):
@@ -2043,24 +3111,65 @@ class CrossBankCard(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    bank: str
-    short_code: str
-    display_name: str
-    flag: str
-    symbol: str
-    latest_statement_date: str | None
-    stance: dict[str, float] | None
-    stance_label: str | None
-    stance_confidence: float | None
-    certainty_label: str | None
-    certainty_confidence: float | None
-    time_axis: str | None
-    vol_regime_label: str | None
-    vol_regime_confidence: float | None
-    vol_regime_as_of: str | None
-    vol_regime_status: str | None
-    sample_size: int
-    status: str
+    bank: str = Field(
+        ...,
+        description="Full bank name identifier, e.g. `federal_reserve`, `european_central_bank`.",
+    )
+    short_code: str = Field(
+        ..., description="Short code used in artifacts/keys, e.g. `fed`, `ecb`, `boj`."
+    )
+    display_name: str = Field(..., description="Human-readable bank name shown on the card.")
+    flag: str = Field(..., description="Flag emoji or ISO code for the bank's jurisdiction.")
+    symbol: str = Field(
+        ..., description="Yahoo Finance ticker the vol-regime card was anchored to."
+    )
+    latest_statement_date: str | None = Field(
+        ...,
+        description="ISO `YYYY-MM-DD` event date of the latest statement scored; null when no statement was found.",
+    )
+    stance: dict[str, float] | None = Field(
+        ...,
+        description="Per-class stance distribution over hawkish/dovish/neutral; null when the head is unavailable.",
+    )
+    stance_label: str | None = Field(
+        ..., description="Argmax stance label; null when the head is unavailable."
+    )
+    stance_confidence: float | None = Field(
+        ...,
+        description="Probability of `stance_label` in `[0, 1]`; null when the head is unavailable.",
+    )
+    certainty_label: str | None = Field(
+        ..., description="Argmax certainty label; null when the head is unavailable."
+    )
+    certainty_confidence: float | None = Field(
+        ...,
+        description="Probability of `certainty_label` in `[0, 1]`; null when the head is unavailable.",
+    )
+    time_axis: str | None = Field(
+        ..., description="Forward-looking time axis label; null when the head is unavailable."
+    )
+    vol_regime_label: str | None = Field(
+        ...,
+        description="Argmax vol-regime label (calm/normal/high); null when the head is unavailable.",
+    )
+    vol_regime_confidence: float | None = Field(
+        ...,
+        description="Probability of `vol_regime_label` in `[0, 1]`; null when the head is unavailable.",
+    )
+    vol_regime_as_of: str | None = Field(
+        ...,
+        description="ISO `YYYY-MM-DD` of the trading session the vol-regime card was anchored at; null when unavailable.",
+    )
+    vol_regime_status: str | None = Field(
+        ..., description="Status string for the vol-regime card, e.g. `ok` or a degradation reason."
+    )
+    sample_size: int = Field(
+        ..., description="Number of historical statements that fed the card's distribution."
+    )
+    status: str = Field(
+        ...,
+        description="Overall status string for the card, e.g. `ok` or the reason the card is partial.",
+    )
 
 
 class CrossBankSnapshotResponse(BaseModel):
@@ -2074,6 +3183,12 @@ class CrossBankSnapshotResponse(BaseModel):
 
     model_config = _FORBID_FROZEN_CONFIG
 
-    banks: list[CrossBankCard]
-    generated_at: str
-    cache_ttl_seconds: int
+    banks: list[CrossBankCard] = Field(
+        ..., description="Six-bank stance+vol-regime card list ordered for display."
+    )
+    generated_at: str = Field(
+        ..., description="ISO-8601 UTC timestamp the snapshot was generated at."
+    )
+    cache_ttl_seconds: int = Field(
+        ..., description="Seconds the in-process cache holds this snapshot before re-deriving."
+    )

--- a/scripts/build_forecasting_matrix.py
+++ b/scripts/build_forecasting_matrix.py
@@ -1,0 +1,333 @@
+"""Forecasting matrix — every neural core on the same RV-regression / QLIKE task.
+
+Runs HAR, GARCH(1,1) and the neural cores (MLP, LSTM, GRU, TCN, σLSTM,
+Transformer, DLinear, Informer) on one realized-measure series, walk-forward,
+across horizons {1,5,22} and two targets:
+
+  - realized volatility (QLIKE-trained, variance-space QLIKE + OOS-R²)
+  - abnormal volume    (MSE-trained on log-volume residual, OOS-R² only;
+                         QLIKE is a variance loss and is not reported here)
+
+Every model is scored on the identical set of (origin, true) test pairs per
+fold, residual-stacked on HAR, with the official seed set {11,29,47,71,97}.
+Neural rows report mean ± 90% CI over the five seeds; HAR and GARCH are
+deterministic single values. Output: a JSON artefact and a printed table.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from app.data.dense_daily_dataset import walk_forward_splits
+from app.data.dense_forecast_train import _fit_predict_ols, _oos_r2
+from app.data.intraday_rv_arch import (
+    _SEQ_LEN,
+    _train_arch_fold,
+    build_sequences,
+)
+from app.data.intraday_rv_forecast import _EPS, _forward_log_rv, _har_lags, _qlike
+
+OFFICIAL_SEEDS = (11, 29, 47, 71, 97)
+HORIZONS = (1, 5, 22)
+NEURAL_ARCHS = ("mlp", "lstm", "gru", "tcn", "sigma_lstm", "transformer", "dlinear", "informer")
+_T_95_DF4 = 2.131847  # two-sided 90% Student-t quantile, df = n_seeds - 1 = 4
+
+
+def _ci90(values: list[float]) -> dict[str, float]:
+    """Mean ± 90% Student-t CI over seeds (degenerate to the point if n<2)."""
+    arr = np.asarray(values, dtype=np.float64)
+    mean = float(arr.mean())
+    if len(arr) < 2:
+        return {"mean": mean, "std": 0.0, "ci90_lo": mean, "ci90_hi": mean}
+    std = float(arr.std(ddof=1))
+    half = _T_95_DF4 * std / math.sqrt(len(arr)) if len(arr) == 5 else (
+        1.645 * std / math.sqrt(len(arr))
+    )
+    return {
+        "mean": mean,
+        "std": std,
+        "ci90_lo": mean - half,
+        "ci90_hi": mean + half,
+        # median + IQR — robust to a single diverged seed under the exp-QLIKE loss
+        "median": float(np.median(arr)),
+        "iqr": [float(np.quantile(arr, 0.25)), float(np.quantile(arr, 0.75))],
+    }
+
+
+def _series_matrix(rv_path: Path | str, target: str) -> dict[str, np.ndarray]:
+    """Feature matrix + HAR floor + raw series for the chosen target.
+
+    target='rv'     → series is realized variance, HAR on log-RV.
+    target='volume' → series is daily volume, HAR on log-volume.
+    Exogenous channels (rs_pos, rs_neg, bv, rq, rskew, rkurt, parkinson, log-vol)
+    are identical for both, so the architecture comparison is feature-for-feature.
+    """
+    df = pd.read_parquet(rv_path).sort_values("date").reset_index(drop=True)
+    series = (df["rv"] if target == "rv" else df["rvol"]).to_numpy(dtype=np.float64)
+    log_s = np.log(series + _EPS)
+    har = _har_lags(log_s)
+    feat_cols = ["rs_pos", "rs_neg", "bv", "rq", "rskew", "rkurt", "parkinson"]
+    extra = np.column_stack([df[c].to_numpy(dtype=np.float64) for c in feat_cols])
+    extra = np.column_stack([extra, np.log(df["rvol"].to_numpy(dtype=np.float64) + 1.0)])
+    full = np.column_stack([har, extra])
+    return {
+        "series": series,
+        "har": har,
+        "full": full,
+        "dates": df["date"].astype(str).to_numpy(),
+    }
+
+
+def _daily_log_returns(close_path: Path | str, dates: np.ndarray) -> np.ndarray:
+    """Percent daily log returns aligned to the RV dates (NaN before first obs)."""
+    px = pd.read_parquet(close_path)[["date", "close"]].copy()
+    px["date"] = px["date"].astype(str)
+    base = pd.DataFrame({"date": pd.Series(dates).astype(str)})
+    merged = base.merge(px, on="date", how="left").sort_values("date").reset_index(drop=True)
+    close = merged["close"].to_numpy(dtype=np.float64)
+    ret = np.full(len(close), np.nan)
+    ret[1:] = 100.0 * np.log(close[1:] / close[:-1])
+    return ret
+
+
+def _neural_pools(
+    arch: str,
+    *,
+    seq_all: np.ndarray,
+    har: np.ndarray,
+    origin: np.ndarray,
+    y: np.ndarray,
+    idx: np.ndarray,
+    folds: list[tuple[list[int], list[int]]],
+    seed: int,
+    epochs: int,
+    device: str,
+    loss: str,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Walk-forward predictions for one arch/seed; returns (pred, true, base)."""
+    pred_pool: list[float] = []
+    true_pool: list[float] = []
+    base_pool: list[float] = []
+    for tr_l, te_l in folds:
+        tr, te = idx[np.array(tr_l)], idx[np.array(te_l)]
+        o_tr, o_te = origin[tr], origin[te]
+        ytr, yte = y[o_tr], y[o_te]
+        pred = _train_arch_fold(
+            arch, seq_all[tr], seq_all[te], har[o_tr], har[o_te], ytr,
+            seed=seed, epochs=epochs, device=device, loss=loss,
+        )
+        pred_pool.extend(pred.tolist())
+        true_pool.extend(yte.tolist())
+        base_pool.extend([float(ytr.mean())] * len(te))
+    return np.asarray(pred_pool), np.asarray(true_pool), np.asarray(base_pool)
+
+
+def _har_pools(
+    *, har: np.ndarray, origin: np.ndarray, y: np.ndarray,
+    idx: np.ndarray, folds: list[tuple[list[int], list[int]]],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    pred_pool, true_pool, base_pool = [], [], []
+    for tr_l, te_l in folds:
+        tr, te = idx[np.array(tr_l)], idx[np.array(te_l)]
+        o_tr, o_te = origin[tr], origin[te]
+        ytr, yte = y[o_tr], y[o_te]
+        pred = _fit_predict_ols(har[o_tr], ytr, har[o_te])
+        pred_pool.extend(pred.tolist())
+        true_pool.extend(yte.tolist())
+        base_pool.extend([float(ytr.mean())] * len(te))
+    return np.asarray(pred_pool), np.asarray(true_pool), np.asarray(base_pool)
+
+
+def _garch_pools(
+    *, ret: np.ndarray, origin: np.ndarray, y: np.ndarray, h: int,
+    idx: np.ndarray, folds: list[tuple[list[int], list[int]]],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """GARCH(1,1) on daily % log-returns: forecast mean variance over t+1..t+h.
+
+    Fit constant-mean GARCH(1,1) on each fold's contiguous train returns, then
+    roll the conditional-variance recursion forward over the test block with the
+    train-fitted params (no refit, no leak). The h-step forecast uses the closed
+    form E[σ²_{t+k}] = σ²_∞ + (α+β)^{k-1}·(σ²_{t+1} − σ²_∞), averaged over
+    k=1..h. The percent-variance forecast is converted to decimal-variance
+    (÷1e4) and compared in the same log-variance space as HAR/RV. GARCH on daily
+    returns is a structurally weaker vol proxy than 5-min RV, so any level bias
+    it carries is a fair part of the result.
+    """
+    from arch import arch_model
+
+    pred_pool, true_pool, base_pool = [], [], []
+    for tr_l, te_l in folds:
+        tr, te = idx[np.array(tr_l)], idx[np.array(te_l)]
+        o_tr, o_te = origin[tr], origin[te]
+        ytr, yte = y[o_tr], y[o_te]
+        # contiguous train returns by ROW index (origins are monotone)
+        r_tr = ret[o_tr.min() : o_tr.max() + 1]
+        r_tr = r_tr[~np.isnan(r_tr)]
+        res = arch_model(r_tr, mean="Constant", vol="GARCH", p=1, q=1, dist="normal").fit(
+            disp="off"
+        )
+        pr = res.params
+        mu = float(pr.get("mu", 0.0))
+        omega, alpha, beta = float(pr["omega"]), float(pr["alpha[1]"]), float(pr["beta[1]"])
+        persist = alpha + beta
+        var_uncond = omega / (1.0 - persist) if persist < 1.0 else float(np.var(r_tr))
+
+        # Roll σ²_t over the full return path up to the last test origin (fixed
+        # params, realized returns only — strictly leak-safe per origin).
+        last = int(o_te.max())
+        sigma2 = np.full(last + 2, var_uncond)  # sigma2[t] = Var(r_t | info up to t-1)
+        for t in range(1, last + 1):
+            eps_prev = (ret[t - 1] - mu) if not np.isnan(ret[t - 1]) else 0.0
+            sigma2[t] = omega + alpha * eps_prev**2 + beta * sigma2[t - 1]
+
+        preds = []
+        for o in o_te.tolist():
+            eps_o = (ret[o] - mu) if not np.isnan(ret[o]) else 0.0
+            s2_next = omega + alpha * eps_o**2 + beta * sigma2[o]  # σ²_{o+1}
+            fk = [var_uncond + (persist ** (k - 1)) * (s2_next - var_uncond) for k in range(1, h + 1)]
+            mean_var_pct = float(np.mean(fk))
+            preds.append(math.log(max(mean_var_pct, _EPS) / 1e4 + _EPS))
+        pred_pool.extend(preds)
+        true_pool.extend(yte.tolist())
+        base_pool.extend([float(ytr.mean())] * len(te))
+    return np.asarray(pred_pool), np.asarray(true_pool), np.asarray(base_pool)
+
+
+def run(
+    rv_path: Path | str,
+    close_path: Path | str,
+    *,
+    seeds: tuple[int, ...] = OFFICIAL_SEEDS,
+    horizons: tuple[int, ...] = HORIZONS,
+    archs: tuple[str, ...] = NEURAL_ARCHS,
+    epochs: int = 120,
+    n_folds: int = 5,
+    device: str = "cuda",
+    with_garch: bool = True,
+) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "seeds": list(seeds),
+        "horizons": list(horizons),
+        "n_folds": n_folds,
+        "epochs": epochs,
+        "seq_len": _SEQ_LEN,
+        "targets": {},
+    }
+    for target in ("rv", "volume"):
+        loss = "qlike" if target == "rv" else "mse"
+        data = _series_matrix(rv_path, target)
+        series, har, full = data["series"], data["har"], data["full"]
+        ret = _daily_log_returns(close_path, data["dates"]) if target == "rv" else None
+        seqs = build_sequences(full, np.ones(len(series), dtype=bool))
+        origin, seq_all = seqs["origin"], seqs["seq"]
+        out["targets"][target] = {"n_days": int(len(series)), "loss": loss, "by_horizon": {}}
+        for h in horizons:
+            y = _forward_log_rv(series, h)
+            ok = ~np.isnan(y[origin])
+            idx = np.where(ok)[0]
+            folds = walk_forward_splits(len(idx), n_folds=n_folds, embargo=h + 1)
+            row: dict[str, Any] = {"models": {}}
+
+            hp, ht, hb = _har_pools(har=har, origin=origin, y=y, idx=idx, folds=folds)
+            row["models"]["har"] = {
+                "qlike": _qlike(hp, ht) if target == "rv" else None,
+                "r2": _oos_r2(hp, ht, hb),
+                "deterministic": True,
+                "n_eval": int(len(ht)),
+            }
+
+            if with_garch and target == "rv" and ret is not None:
+                try:
+                    gp, gt, gb = _garch_pools(
+                        ret=ret, origin=origin, y=y, h=h, idx=idx, folds=folds
+                    )
+                    row["models"]["garch"] = {
+                        "qlike": _qlike(gp, gt),
+                        "r2": _oos_r2(gp, gt, gb),
+                        "deterministic": True,
+                        "n_eval": int(len(gt)),
+                    }
+                except Exception as exc:  # noqa: BLE001 — record, don't abort the matrix
+                    row["models"]["garch"] = {"failed": f"{type(exc).__name__}: {exc}"}
+
+            for arch in archs:
+                q_seeds, r_seeds = [], []
+                for seed in seeds:
+                    pp, pt, pb = _neural_pools(
+                        arch, seq_all=seq_all, har=har, origin=origin, y=y, idx=idx,
+                        folds=folds, seed=seed, epochs=epochs, device=device, loss=loss,
+                    )
+                    if target == "rv":
+                        q_seeds.append(_qlike(pp, pt))
+                    r_seeds.append(_oos_r2(pp, pt, pb))
+                row["models"][arch] = {
+                    "qlike": _ci90(q_seeds) if target == "rv" else None,
+                    "r2": _ci90(r_seeds),
+                    "deterministic": False,
+                    "seed_qlike": q_seeds if target == "rv" else None,
+                    "seed_r2": r_seeds,
+                }
+            out["targets"][target]["by_horizon"][f"h{h}"] = row
+            print(f"[{target} h{h}] done — {len(idx)} scorable origins")
+    return out
+
+
+def _fmt(model: dict[str, Any], key: str) -> str:
+    v = model.get(key)
+    if v is None:
+        return f"{'—':>10}"
+    if isinstance(v, dict):
+        return f"{v['mean']:>10.4f}"
+    return f"{v:>10.4f}"
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--rv-path", type=Path, default=Path("/data/external/alphavantage_bars/spx_5min_daily_rv.parquet"))
+    p.add_argument(
+        "--close-path",
+        type=Path,
+        # 1975→2026 daily close (covers the full 2005+ RV range; /data/raw/market
+        # only starts 2010, which starves the early GARCH folds).
+        default=Path("/data/processed/canonical_60bar/_market_cache/GSPC.parquet"),
+    )
+    p.add_argument("--out-dir", type=Path, default=Path("/data/artifacts/forecasting_matrix"))
+    p.add_argument("--epochs", type=int, default=120)
+    p.add_argument("--device", default="cuda")
+    p.add_argument("--seeds", type=int, nargs="+", default=list(OFFICIAL_SEEDS))
+    p.add_argument("--horizons", type=int, nargs="+", default=list(HORIZONS))
+    p.add_argument("--archs", nargs="+", default=list(NEURAL_ARCHS))
+    p.add_argument("--no-garch", action="store_true")
+    args = p.parse_args()
+
+    res = run(
+        args.rv_path, args.close_path,
+        seeds=tuple(args.seeds), horizons=tuple(args.horizons), archs=tuple(args.archs),
+        epochs=args.epochs, device=args.device, with_garch=not args.no_garch,
+    )
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "forecasting_matrix.json").write_text(json.dumps(res, indent=2), encoding="utf-8")
+
+    for target, tdata in res["targets"].items():
+        print(f"\n===== TARGET: {target} ({tdata['loss']}-trained) =====")
+        for hk, row in tdata["by_horizon"].items():
+            print(f"\n  {hk}:")
+            print(f"    {'model':<14}{'QLIKE':>10}{'OOS-R2':>10}")
+            for name, m in row["models"].items():
+                if "failed" in m:
+                    print(f"    {name:<14}  FAILED: {m['failed']}")
+                    continue
+                print(f"    {name:<14}{_fmt(m,'qlike')}{_fmt(m,'r2')}")
+    print(f"\nwrote {args.out_dir / 'forecasting_matrix.json'}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/build_stance_bakeoff.py
+++ b/scripts/build_stance_bakeoff.py
@@ -1,0 +1,519 @@
+"""Unified stance encoder bake-off — every model on ONE held-out split.
+
+All models are scored on the Fed-stance held-out (TEST_SOURCES =
+gtfintechlab_federal_reserve_system + op_fed, n≈1112), which has zero
+text-hash overlap with the TDW training pool — so no row has train leakage.
+Metric per model: macro-F1 (primary), per-class F1 (hawkish/dovish/neutral),
+accuracy. Confidence intervals:
+
+  - fine-tuned encoder rows (bert-base, ProsusAI/finbert, and the three "ours"
+    variants): a 3-class head + encoder fine-tuned on TDW, repeated over the
+    official seeds {11,29,47,71,97} → mean ± 95% Student-t CI over seeds.
+  - zero-shot rows (ZiweiChen/FinBERT-FOMC, gtfintechlab/FOMC-RoBERTa [ceiling],
+    Gemini LLM @ temp 0): deterministic → 95% bootstrap CI over the test set.
+  - frozen-embedding + linear head (bge-large, MiniLM): LogReg on TDW
+    embeddings, eval on the held-out → 95% bootstrap CI.
+  - sanity: majority-class (deterministic) and stratified-random (5 seeds).
+
+Every row is wrapped so one failure (missing API key, offline HF, etc.) is
+recorded and the rest of the leaderboard still completes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import traceback
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from sklearn.metrics import accuracy_score, f1_score
+
+from app.data.finetune_stance import (
+    _predict,
+    _ROBERTA_MAP,
+    _val_carve,
+    LABELS,
+    load_labeled,
+    train,
+)
+from app.determinism import enable_deterministic_mode
+
+OFFICIAL_SEEDS = (11, 29, 47, 71, 97)
+TRAIN_SOURCES = ["hf_fomc_communication"]
+TEST_SOURCES = ["gtfintechlab_federal_reserve_system", "op_fed"]
+_T_95 = {4: 2.776}  # two-sided 95% Student-t, df = n_seeds - 1
+
+
+def _score(y_true: np.ndarray, y_pred: np.ndarray) -> dict[str, Any]:
+    per = f1_score(y_true, y_pred, average=None, labels=[0, 1, 2], zero_division=0)
+    return {
+        "macro_f1": round(float(f1_score(y_true, y_pred, average="macro", zero_division=0)), 4),
+        "accuracy": round(float(accuracy_score(y_true, y_pred)), 4),
+        "per_class_f1": {LABELS[i]: round(float(per[i]), 4) for i in range(3)},
+    }
+
+
+def _bootstrap_ci(y_true: np.ndarray, y_pred: np.ndarray, *, n_boot: int = 2000) -> list[float]:
+    rng = np.random.default_rng(11)
+    n = len(y_true)
+    boots = []
+    for _ in range(n_boot):
+        idx = rng.integers(0, n, size=n)
+        boots.append(f1_score(y_true[idx], y_pred[idx], average="macro", zero_division=0))
+    return [round(float(np.quantile(boots, 0.025)), 4), round(float(np.quantile(boots, 0.975)), 4)]
+
+
+def _seed_ci(vals: list[float]) -> dict[str, float]:
+    arr = np.asarray(vals, dtype=np.float64)
+    mean = float(arr.mean())
+    if len(arr) < 2:
+        return {"mean": round(mean, 4), "std": 0.0, "ci95_lo": round(mean, 4), "ci95_hi": round(mean, 4)}
+    std = float(arr.std(ddof=1))
+    t = _T_95.get(len(arr) - 1, 1.96)
+    half = t * std / np.sqrt(len(arr))
+    return {
+        "mean": round(mean, 4),
+        "std": round(std, 4),
+        "ci95_lo": round(mean - half, 4),
+        "ci95_hi": round(mean + half, 4),
+    }
+
+
+def _hf_label_map(model: Any) -> dict[int, int]:
+    """Map a HF model's output index → stance index via its id2label names."""
+    id2label = getattr(model.config, "id2label", {}) or {}
+    mapping: dict[int, int] = {}
+    for idx, name in id2label.items():
+        low = str(name).lower()
+        if "hawk" in low:
+            mapping[int(idx)] = 0
+        elif "dov" in low:
+            mapping[int(idx)] = 1
+        elif "neutr" in low:
+            mapping[int(idx)] = 2
+    return mapping
+
+
+# ---- row runners -----------------------------------------------------------
+
+def run_baselines(train_y: np.ndarray, test_y: np.ndarray, seeds: tuple[int, ...]) -> dict[str, Any]:
+    out = {}
+    # majority — modal train class, constant prediction
+    maj = int(np.bincount(train_y, minlength=3).argmax())
+    pred = np.full_like(test_y, maj)
+    out["majority"] = {**_score(test_y, pred), "training": "none", "ci": _bootstrap_ci(test_y, pred)}
+    # stratified-random — sample from train class frequencies, per seed
+    freq = np.bincount(train_y, minlength=3) / len(train_y)
+    seed_f1 = []
+    for s in seeds:
+        rng = np.random.default_rng(s)
+        pr = rng.choice(3, size=len(test_y), p=freq)
+        seed_f1.append(f1_score(test_y, pr, average="macro", zero_division=0))
+    out["stratified_random"] = {"training": "none (5 seeds)", "macro_f1_ci": _seed_ci(seed_f1)}
+    return out
+
+
+def run_encoder_ft(
+    enc: str, train_pool: Any, test_df: Any, *, seeds: tuple[int, ...], epochs: int, lr: float,
+    device: torch.device,
+) -> dict[str, Any]:
+    test_texts = test_df["text"].tolist()
+    y_true = test_df["y"].to_numpy()
+    seed_f1, last_pred = [], None
+    for s in seeds:
+        enable_deterministic_mode(s)
+        tr, va = _val_carve(train_pool, seed=s)
+        model, tok = train(tr, va, device, epochs, lr, base_encoder=enc)
+        pred = _predict(model, tok, test_texts, device)
+        seed_f1.append(f1_score(y_true, pred, average="macro", zero_division=0))
+        last_pred = pred
+        del model
+        torch.cuda.empty_cache()
+    detail = _score(y_true, last_pred)  # per-class from the last seed
+    return {
+        "training": f"full fine-tune on TDW, {len(seeds)} seeds",
+        "macro_f1_ci": _seed_ci(seed_f1),
+        "seed_macro_f1": [round(float(x), 4) for x in seed_f1],
+        "per_class_f1_lastseed": detail["per_class_f1"],
+        "accuracy_lastseed": detail["accuracy"],
+    }
+
+
+def run_zeroshot_hf(
+    slug: str, test_df: Any, device: torch.device, *, forced_map: dict[int, int] | None = None,
+) -> dict[str, Any]:
+    from transformers import AutoModelForSequenceClassification, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(slug, token=os.environ.get("HF_TOKEN"))
+    model = AutoModelForSequenceClassification.from_pretrained(
+        slug, token=os.environ.get("HF_TOKEN")
+    ).to(device)
+    raw = _predict(model, tok, test_df["text"].tolist(), device)
+    id2label = {int(k): str(v) for k, v in (getattr(model.config, "id2label", {}) or {}).items()}
+    mapping = forced_map or _hf_label_map(model)
+    if len(mapping) < 3:
+        raise ValueError(f"could not map id2label={id2label} to stance labels for {slug}")
+    pred = np.array([mapping[int(p)] for p in raw])
+    y_true = test_df["y"].to_numpy()
+    return {
+        "training": "zero-shot (native stance head)",
+        "id2label": id2label,
+        "label_map": {k: LABELS[v] for k, v in mapping.items()},
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def run_frozen_embed(model_name: str, train_pool: Any, test_df: Any) -> dict[str, Any]:
+    from sentence_transformers import SentenceTransformer
+    from sklearn.linear_model import LogisticRegression
+
+    enc = SentenceTransformer(model_name, device="cuda" if torch.cuda.is_available() else "cpu")
+    xtr = enc.encode(train_pool["text"].tolist(), batch_size=64, show_progress_bar=False,
+                     normalize_embeddings=True)
+    xte = enc.encode(test_df["text"].tolist(), batch_size=64, show_progress_bar=False,
+                     normalize_embeddings=True)
+    clf = LogisticRegression(max_iter=2000, C=1.0, class_weight="balanced")
+    clf.fit(xtr, train_pool["y"].to_numpy())
+    pred = clf.predict(xte)
+    y_true = test_df["y"].to_numpy()
+    return {
+        "training": "frozen embeddings + LogReg head on TDW",
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def run_llm_gemini(test_df: Any, *, model_name: str = "gemini-2.5-flash") -> dict[str, Any]:
+    """Zero-shot Gemini @ temp 0 via the REST endpoint (no SDK dependency)."""
+    import json as _json
+    import time
+    import urllib.error
+    import urllib.request
+
+    key = os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+    if not key:
+        raise RuntimeError("no GEMINI_API_KEY / GOOGLE_API_KEY in env")
+    url = (
+        f"https://generativelanguage.googleapis.com/v1beta/models/{model_name}"
+        f":generateContent?key={key}"
+    )
+    sysmsg = (
+        "You are a monetary-policy stance classifier for central-bank communications. "
+        "Read the snippet and respond with exactly one word, lowercased, from this set: "
+        "hawkish, dovish, neutral. Do not explain."
+    )
+
+    def classify(txt: str) -> str:
+        body = {
+            "system_instruction": {"parts": [{"text": sysmsg}]},
+            "contents": [{"parts": [{"text": txt[:4000]}]}],
+            "generationConfig": {"temperature": 0.0, "maxOutputTokens": 4},
+        }
+        data = _json.dumps(body).encode()
+        for attempt in range(5):
+            try:
+                req = urllib.request.Request(
+                    url, data=data, headers={"Content-Type": "application/json"}
+                )
+                with urllib.request.urlopen(req, timeout=60) as resp:
+                    out = _json.loads(resp.read())
+                cand = out.get("candidates", [{}])[0]
+                parts = cand.get("content", {}).get("parts", [{}])
+                return (parts[0].get("text", "") or "").strip().lower()
+            except urllib.error.HTTPError as e:
+                if e.code == 429 and attempt < 4:
+                    time.sleep(2 ** attempt)
+                    continue
+                return ""
+            except Exception:
+                if attempt < 4:
+                    time.sleep(1 + attempt)
+                    continue
+                return ""
+        return ""
+
+    name2idx = {"hawkish": 0, "dovish": 1, "neutral": 2}
+    preds, y_true, n_parsed = [], test_df["y"].to_numpy(), 0
+    for i, txt in enumerate(test_df["text"].tolist()):
+        resp = classify(txt)
+        word = resp.split()[0] if resp else ""
+        idx = name2idx.get(word)
+        if idx is not None:
+            n_parsed += 1
+        preds.append(idx if idx is not None else 2)
+        if (i + 1) % 200 == 0:
+            print(f"    gemini {i + 1}/{len(y_true)}")
+    pred = np.array(preds)
+    return {
+        "training": f"zero-shot LLM ({model_name}, temp 0)",
+        "n_parsed": int(n_parsed),
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def run_llm_anthropic(
+    test_df: Any, *, model_name: str = "claude-haiku-4-5-20251001"
+) -> dict[str, Any]:
+    """Zero-shot Claude @ temp 0 via the Anthropic SDK. Reproducible, no GPU."""
+    import time
+
+    import anthropic
+
+    key = os.environ.get("ANTHROPIC_API_KEY")
+    if not key:
+        raise RuntimeError("no ANTHROPIC_API_KEY in env")
+    client = anthropic.Anthropic(api_key=key)
+    sysmsg = (
+        "You are a monetary-policy stance classifier for central-bank communications. "
+        "Read the snippet and respond with exactly one word, lowercased, from this set: "
+        "hawkish, dovish, neutral. Do not explain."
+    )
+
+    def classify(txt: str) -> str:
+        for attempt in range(5):
+            try:
+                r = client.messages.create(
+                    model=model_name, max_tokens=8, temperature=0.0, system=sysmsg,
+                    messages=[{"role": "user", "content": txt[:4000]}],
+                )
+                return (r.content[0].text if r.content else "").strip().lower()
+            except Exception as e:  # noqa: BLE001 — retry transient/rate-limit
+                if attempt < 4:
+                    time.sleep(2 ** attempt)
+                    continue
+                return ""
+        return ""
+
+    name2idx = {"hawkish": 0, "dovish": 1, "neutral": 2}
+    preds, y_true, n_parsed = [], test_df["y"].to_numpy(), 0
+    for i, txt in enumerate(test_df["text"].tolist()):
+        resp = classify(txt)
+        word = resp.split()[0] if resp else ""
+        idx = name2idx.get(word)
+        if idx is not None:
+            n_parsed += 1
+        preds.append(idx if idx is not None else 2)
+        if (i + 1) % 200 == 0:
+            print(f"    {model_name} {i + 1}/{len(y_true)}")
+    pred = np.array(preds)
+    return {
+        "training": f"zero-shot LLM ({model_name}, temp 0)",
+        "n_parsed": int(n_parsed),
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def run_llm_local(
+    test_df: Any, device: torch.device, *, model_name: str = "Qwen/Qwen2.5-3B-Instruct"
+) -> dict[str, Any]:
+    """Zero-shot local LLM (Qwen) @ temp 0 (greedy). 4-bit if bitsandbytes is
+    available, else fp16. Reproducible; no API quota. Fallback model on OOM."""
+    from transformers import AutoModelForCausalLM, AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained(model_name, token=os.environ.get("HF_TOKEN"))
+    load_kw: dict[str, Any] = {"token": os.environ.get("HF_TOKEN"), "torch_dtype": torch.float16}
+    try:
+        from transformers import BitsAndBytesConfig
+
+        load_kw["quantization_config"] = BitsAndBytesConfig(load_in_4bit=True)
+        load_kw["device_map"] = "auto"
+    except Exception:
+        pass
+    model = AutoModelForCausalLM.from_pretrained(model_name, **load_kw)
+    if "device_map" not in load_kw:
+        model = model.to(device)
+    model.eval()
+    sysmsg = (
+        "You are a monetary-policy stance classifier for central-bank communications. "
+        "Read the snippet and respond with exactly one word, lowercased, from this set: "
+        "hawkish, dovish, neutral. Do not explain."
+    )
+    name2idx = {"hawkish": 0, "dovish": 1, "neutral": 2}
+    preds, y_true, n_parsed = [], test_df["y"].to_numpy(), 0
+    for i, txt in enumerate(test_df["text"].tolist()):
+        msgs = [{"role": "system", "content": sysmsg}, {"role": "user", "content": txt[:3000]}]
+        prompt = tok.apply_chat_template(msgs, tokenize=False, add_generation_prompt=True)
+        enc = tok(prompt, return_tensors="pt", truncation=True, max_length=2048).to(model.device)
+        with torch.no_grad():
+            out = model.generate(**enc, max_new_tokens=4, do_sample=False,
+                                 pad_token_id=tok.eos_token_id)
+        gen = tok.decode(out[0][enc["input_ids"].shape[1]:], skip_special_tokens=True)
+        word = gen.strip().lower().split()[0] if gen.strip() else ""
+        idx = name2idx.get(word)
+        if idx is not None:
+            n_parsed += 1
+        preds.append(idx if idx is not None else 2)
+        if (i + 1) % 200 == 0:
+            print(f"    {model_name} {i + 1}/{len(y_true)}")
+    pred = np.array(preds)
+    return {
+        "training": f"zero-shot LLM ({model_name}, greedy/temp 0)",
+        "n_parsed": int(n_parsed),
+        **_score(y_true, pred),
+        "macro_f1_bootstrap_ci": _bootstrap_ci(y_true, pred),
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--labels", type=Path, default=Path(
+        "/data/processed/tp_v3_full_rebuild_2026_05_30/registry_normalized.parquet"))
+    p.add_argument("--out-dir", type=Path, default=Path("/data/artifacts/stance_bakeoff"))
+    p.add_argument("--epochs", type=int, default=10)
+    p.add_argument("--lr", type=float, default=2e-5)
+    p.add_argument("--seeds", type=int, nargs="+", default=list(OFFICIAL_SEEDS))
+    p.add_argument("--skip", nargs="*", default=[], help="row keys to skip")
+    p.add_argument("--only", nargs="*", default=None, help="run only these row keys")
+    args = p.parse_args()
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    df = load_labeled(args.labels)
+    train_pool = df[df["source"].isin(TRAIN_SOURCES)].reset_index(drop=True)
+    test_df = df[df["source"].isin(TEST_SOURCES)].reset_index(drop=True)
+    train_y, test_y = train_pool["y"].to_numpy(), test_df["y"].to_numpy()
+    print(f"train pool (TDW): {len(train_pool)} | held-out test: {len(test_df)}")
+    print(f"test by class: {dict(test_df['mapped_label'].value_counts())}")
+
+    seeds = tuple(args.seeds)
+    # (key, callable) — encoder rows marked with the HF slug to fine-tune
+    ENCODERS = {
+        "bert_base_uncased": "bert-base-uncased",
+        "prosusai_finbert_ft": "ProsusAI/finbert",
+        "ours_finbert_fed_adjacent": "yusufizzetmurat/finbert-fed-adjacent",
+        "ours_finbert_fed_adjacent_xbank": "yusufizzetmurat/finbert-fed-adjacent-xbank",
+        "ours_finbert_fed_adjacent_xbank_dapt": "yusufizzetmurat/finbert-fed-adjacent-xbank-dapt",
+    }
+    ZEROSHOT = {
+        "ziweichen_finbert_fomc": "ZiweiChen/FinBERT-FOMC",
+        "gtfintechlab_fomc_roberta_CEILING": "gtfintechlab/FOMC-RoBERTa",
+    }
+    FROZEN = {
+        "frozen_bge_large_linear": "BAAI/bge-large-en-v1.5",
+        "frozen_minilm_linear": "sentence-transformers/all-MiniLM-L6-v2",
+    }
+
+    def want(key: str) -> bool:
+        if args.only is not None:
+            return key in args.only
+        return key not in args.skip
+
+    results: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+
+    if want("baselines"):
+        try:
+            results.update(run_baselines(train_y, test_y, seeds))
+        except Exception as e:  # noqa: BLE001
+            errors["baselines"] = traceback.format_exc()[-800:]
+
+    for key, slug in ENCODERS.items():
+        if not want(key):
+            continue
+        print(f"\n[encoder-ft] {key} ({slug})")
+        try:
+            results[key] = run_encoder_ft(
+                slug, train_pool, test_df, seeds=seeds, epochs=args.epochs, lr=args.lr, device=device
+            )
+        except Exception:  # noqa: BLE001
+            errors[key] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors[key].splitlines()[-1]}")
+
+    for key, slug in ZEROSHOT.items():
+        if not want(key):
+            continue
+        print(f"\n[zero-shot] {key} ({slug})")
+        try:
+            if slug == "gtfintechlab/FOMC-RoBERTa":
+                fm = _ROBERTA_MAP_IDX
+            elif slug == "ZiweiChen/FinBERT-FOMC":
+                # sentiment head {0:Neutral,1:Positive,2:Negative} → stance under
+                # the standard FOMC convention: Positive=dovish, Negative=hawkish.
+                fm = {0: LABELS.index("neutral"), 1: LABELS.index("dovish"), 2: LABELS.index("hawkish")}
+            else:
+                fm = None
+            results[key] = run_zeroshot_hf(slug, test_df, device, forced_map=fm)
+        except Exception:  # noqa: BLE001
+            errors[key] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors[key].splitlines()[-1]}")
+
+    for key, name in FROZEN.items():
+        if not want(key):
+            continue
+        print(f"\n[frozen-embed] {key} ({name})")
+        try:
+            results[key] = run_frozen_embed(name, train_pool, test_df)
+        except Exception:  # noqa: BLE001
+            errors[key] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors[key].splitlines()[-1]}")
+
+    if want("llm_gemini"):
+        print("\n[llm] gemini zero-shot")
+        try:
+            results["llm_gemini"] = run_llm_gemini(test_df)
+        except Exception:  # noqa: BLE001
+            errors["llm_gemini"] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors['llm_gemini'].splitlines()[-1]}")
+
+    if want("llm_anthropic"):
+        print("\n[llm] anthropic claude zero-shot")
+        try:
+            results["llm_anthropic"] = run_llm_anthropic(test_df)
+        except Exception:  # noqa: BLE001
+            errors["llm_anthropic"] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors['llm_anthropic'].splitlines()[-1]}")
+
+    if want("llm_local"):
+        print("\n[llm] local Qwen zero-shot")
+        try:
+            results["llm_local"] = run_llm_local(test_df, device)
+        except Exception:  # noqa: BLE001
+            errors["llm_local"] = traceback.format_exc()[-800:]
+            print(f"  FAILED: {errors['llm_local'].splitlines()[-1]}")
+
+    payload = {
+        "split": "gtfintechlab_federal_reserve_system + op_fed (Fed-stance held-out)",
+        "n_test": int(len(test_df)),
+        "n_train_tdw": int(len(train_pool)),
+        "seeds": list(seeds),
+        "test_class_counts": {k: int(v) for k, v in test_df["mapped_label"].value_counts().items()},
+        "results": results,
+        "errors": errors,
+    }
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    (args.out_dir / "stance_bakeoff.json").write_text(json.dumps(payload, indent=2, default=str))
+
+    # leaderboard
+    def macro(row: dict[str, Any]) -> float:
+        if "macro_f1_ci" in row:
+            return row["macro_f1_ci"]["mean"]
+        return row.get("macro_f1", float("nan"))
+
+    print("\n===== STANCE BAKE-OFF (macro-F1 on n=%d held-out) =====" % len(test_df))
+    print(f"{'model':<40}{'macroF1':>9}{'  CI':>18}{'  training':<10}")
+    for k in sorted(results, key=lambda k: -(macro(results[k]) if macro(results[k]) == macro(results[k]) else -1)):
+        r = results[k]
+        m = macro(r)
+        ci = r.get("macro_f1_ci", {})
+        ci_s = (f"[{ci['ci95_lo']},{ci['ci95_hi']}]" if ci else
+                f"{r.get('macro_f1_bootstrap_ci', r.get('ci', ''))}")
+        print(f"{k:<40}{m:>9.4f}  {str(ci_s):>16}  {r.get('training','')[:30]}")
+    if errors:
+        print("\nERRORS:", list(errors))
+    print(f"\nwrote {args.out_dir / 'stance_bakeoff.json'}")
+    return 0
+
+
+# FOMC-RoBERTa fixed index→stance map, derived from the project's _ROBERTA_MAP
+# ({LABEL_0/1/2} → stance name) so we don't depend on its id2label being present.
+_ROBERTA_MAP_IDX = {i: LABELS.index(_ROBERTA_MAP[f"LABEL_{i}"]) for i in range(3)}
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/snapshots/openapi.json
+++ b/tests/snapshots/openapi.json
@@ -215,6 +215,7 @@
         "type": "object"
       },
       "AnalyzeResponse": {
+        "description": "Top-level envelope for `POST /analyze`. Bundles the stance classifier\noutput, the forecaster headline + bands, the market snapshot used as\nanchor, runtime diagnostics, and the optional XAI, replay, multi-axis,\nregime, rates and policy sub-blocks.",
         "properties": {
           "credibility": {
             "anyOf": [
@@ -224,13 +225,16 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Stance-drift and credibility signals; null when no history is available."
           },
           "market": {
-            "$ref": "#/components/schemas/MarketDataResponse"
+            "$ref": "#/components/schemas/MarketDataResponse",
+            "description": "Market snapshot at the trading session used as forecast anchor."
           },
           "model": {
-            "$ref": "#/components/schemas/ModelDiagnosticsResponse"
+            "$ref": "#/components/schemas/ModelDiagnosticsResponse",
+            "description": "Forecaster runtime + checkpoint diagnostics for this response."
           },
           "multi_axis": {
             "anyOf": [
@@ -240,7 +244,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Multi-task head per-axis predictions; null when no multi-axis checkpoint is loaded."
           },
           "policy_action": {
             "anyOf": [
@@ -250,10 +255,12 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Mechanical policy decision extracted from the text via regex/keyword; null when the statement names no target range."
           },
           "prediction": {
-            "$ref": "#/components/schemas/PredictionResponse"
+            "$ref": "#/components/schemas/PredictionResponse",
+            "description": "Headline scalar forecast at the chosen horizon."
           },
           "rates_reaction": {
             "anyOf": [
@@ -267,6 +274,7 @@
                 "type": "null"
               }
             ],
+            "description": "Per-rates-head reaction cards (2y/5y/terminal); null on legacy single-head runs, empty when heads exist but no rows were produced.",
             "title": "Rates Reaction"
           },
           "realised_outcome": {
@@ -277,7 +285,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "What-actually-happened reveal beside the forecast; populated only in replay mode."
           },
           "regime_classification": {
             "anyOf": [
@@ -287,7 +296,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Calibrated regime prediction set; null when the active checkpoint has no regime head."
           },
           "regime_classification_status": {
             "anyOf": [
@@ -297,7 +307,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Structured degradation surface mutually exclusive with `regime_classification`; carries the reason the regime card was not built."
           },
           "regime_regression": {
             "anyOf": [
@@ -307,7 +318,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Regression sibling of the regime card carrying `log_rv_point` + conformal interval; null when the dual-head regression is absent."
           },
           "replay": {
             "anyOf": [
@@ -317,13 +329,16 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Replay-mode metadata; populated only when the request set `as_of_date`."
           },
           "sentiment": {
-            "$ref": "#/components/schemas/SentimentResponse"
+            "$ref": "#/components/schemas/SentimentResponse",
+            "description": "Stance classifier output for the input statement including OOD chip."
           },
           "series": {
-            "$ref": "#/components/schemas/ForecastSeriesResponse"
+            "$ref": "#/components/schemas/ForecastSeriesResponse",
+            "description": "Chart-ready history, forecast and band arrays for the panel."
           },
           "xai": {
             "anyOf": [
@@ -333,7 +348,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "XAI sentence + panel attribution; populated when `include_xai=true`."
           }
         },
         "required": [
@@ -360,6 +376,7 @@
             "type": "string"
           },
           "size_bytes": {
+            "description": "File size in bytes as reported by the filesystem.",
             "title": "Size Bytes",
             "type": "integer"
           },
@@ -446,6 +463,7 @@
                 "type": "null"
               }
             ],
+            "description": "Strategy cumulative return minus benchmark cumulative return; null when either side is unavailable.",
             "title": "Alpha Cum Pct"
           },
           "benchmark_cum_pct": {
@@ -457,6 +475,7 @@
                 "type": "null"
               }
             ],
+            "description": "Cumulative % return of buy-and-hold on `symbol` over the same window; null when unavailable.",
             "title": "Benchmark Cum Pct"
           },
           "cum_return_pct": {
@@ -468,6 +487,7 @@
                 "type": "null"
               }
             ],
+            "description": "Cumulative % return of the strategy across all resolved trades; null when none resolved.",
             "title": "Cum Return Pct"
           },
           "hit_rate": {
@@ -479,9 +499,11 @@
                 "type": "null"
               }
             ],
+            "description": "Fraction of resolved trades with positive strategy return in `[0, 1]`; null when none resolved.",
             "title": "Hit Rate"
           },
           "horizon_days": {
+            "description": "Forward holding period in trading days echoed from the request.",
             "title": "Horizon Days",
             "type": "integer"
           },
@@ -494,9 +516,11 @@
                 "type": "null"
               }
             ],
+            "description": "Maximum % drawdown of the cumulative strategy curve; null when unavailable.",
             "title": "Max Dd Pct"
           },
           "n_trades": {
+            "description": "Number of trades executed in the backtest.",
             "title": "N Trades",
             "type": "integer"
           },
@@ -509,13 +533,16 @@
                 "type": "null"
               }
             ],
+            "description": "Annualised Sharpe ratio of the strategy returns; null when fewer than two resolved trades.",
             "title": "Sharpe"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the backtest was run against.",
             "title": "Symbol",
             "type": "string"
           },
           "trades": {
+            "description": "Per-signal trade rows produced by the backtest.",
             "items": {
               "$ref": "#/components/schemas/BacktestTradeRow"
             },
@@ -532,8 +559,10 @@
         "type": "object"
       },
       "BacktestTradeRow": {
+        "description": "One realised trade row from the stance-directional backtest.",
         "properties": {
           "date": {
+            "description": "ISO `YYYY-MM-DD` date of the signal entry.",
             "title": "Date",
             "type": "string"
           },
@@ -546,9 +575,11 @@
                 "type": "null"
               }
             ],
+            "description": "Forward holding-period close-to-close % return from `date`; null when forward bars are missing.",
             "title": "Forward Return Pct"
           },
           "position": {
+            "description": "Position taken on `date`: -1 short, 0 flat, +1 long.",
             "title": "Position",
             "type": "integer"
           },
@@ -561,6 +592,7 @@
                 "type": "null"
               }
             ],
+            "description": "Strategy % return for the trade = `position * forward_return_pct`; null when the trade is unresolved.",
             "title": "Strategy Return Pct"
           }
         },
@@ -612,12 +644,15 @@
         "type": "object"
       },
       "ChunkAttentionDiagnostics": {
+        "description": "Per-chunk attention trace from the encoder's long-document aggregator.\nExposed so the XAI panel can show which chunks of a long FOMC document\ndominated the pooled representation and how the elapsed-time decay\nreshaped their weights.",
         "properties": {
           "chunk_count": {
+            "description": "Number of fixed-size chunks the input was split into before pooling.",
             "title": "Chunk Count",
             "type": "integer"
           },
           "chunk_previews": {
+            "description": "Leading text snippet of each chunk for display in the XAI panel.",
             "items": {
               "type": "string"
             },
@@ -625,6 +660,7 @@
             "type": "array"
           },
           "decay_coeffs": {
+            "description": "Time-decay multiplier applied to each chunk before softmax; in `(0, 1]`.",
             "items": {
               "type": "number"
             },
@@ -632,10 +668,12 @@
             "type": "array"
           },
           "lambda_value": {
+            "description": "Decay rate used to compute `decay_coeffs`; higher = older chunks down-weighted faster.",
             "title": "Lambda Value",
             "type": "number"
           },
           "weights": {
+            "description": "Post-softmax attention weight per chunk after time-decay; sums to ~1.0.",
             "items": {
               "type": "number"
             },
@@ -654,12 +692,15 @@
         "type": "object"
       },
       "ClassificationBreakdownClass": {
+        "description": "Per-class accuracy metrics for one class in the regime breakdown.",
         "properties": {
           "class_id": {
+            "description": "Integer class index in canonical regime ordering (0=calm, 1=normal, 2=high).",
             "title": "Class Id",
             "type": "integer"
           },
           "f1": {
+            "description": "F1 score for this class in `[0, 1]`: harmonic mean of precision and recall.",
             "title": "F1",
             "type": "number"
           },
@@ -672,13 +713,16 @@
                 "type": "null"
               }
             ],
+            "description": "One-vs-rest PR AUC for this class; null when the source artifact omits it.",
             "title": "Pr Auc"
           },
           "precision": {
+            "description": "Precision for this class in `[0, 1]`: true positives / predicted positives.",
             "title": "Precision",
             "type": "number"
           },
           "recall": {
+            "description": "Recall for this class in `[0, 1]`: true positives / actual positives.",
             "title": "Recall",
             "type": "number"
           },
@@ -691,9 +735,11 @@
                 "type": "null"
               }
             ],
+            "description": "One-vs-rest ROC AUC for this class; null when the source artifact omits it.",
             "title": "Roc Auc"
           },
           "support": {
+            "description": "Number of ground-truth samples in this class.",
             "title": "Support",
             "type": "integer"
           }
@@ -712,6 +758,7 @@
         "description": "The richer eval emitted by app/evaluation/classification_breakdown.py.\n\nSurfaces the freshest ``best_trial.summary.metrics.classification_breakdown``\nblock written under ``data/artifacts/regime_*``. ``available`` is\nfalse when no qualifying artifact exists \u2014 the UI then falls back to\nits client-side aggregation across history rows.",
         "properties": {
           "available": {
+            "description": "True when a qualifying artifact was found; false flags UI fallback to client-side aggregation.",
             "title": "Available",
             "type": "boolean"
           },
@@ -727,6 +774,7 @@
                 "type": "null"
               }
             ],
+            "description": "Ordered class labels (e.g. calm/normal/high) from the source artifact; null when the artifact omits them.",
             "title": "Class Labels"
           },
           "confusion_matrix": {
@@ -744,6 +792,7 @@
                 "type": "null"
               }
             ],
+            "description": "Row-actual, column-predicted confusion matrix in canonical class order; null when unavailable.",
             "title": "Confusion Matrix"
           },
           "macro_f1": {
@@ -755,6 +804,7 @@
                 "type": "null"
               }
             ],
+            "description": "Unweighted mean F1 across classes in `[0, 1]`; null when unavailable.",
             "title": "Macro F1"
           },
           "macro_pr_auc": {
@@ -766,6 +816,7 @@
                 "type": "null"
               }
             ],
+            "description": "Unweighted mean one-vs-rest PR AUC across classes; null when unavailable.",
             "title": "Macro Pr Auc"
           },
           "macro_precision": {
@@ -777,6 +828,7 @@
                 "type": "null"
               }
             ],
+            "description": "Unweighted mean precision across classes in `[0, 1]`; null when unavailable.",
             "title": "Macro Precision"
           },
           "macro_recall": {
@@ -788,6 +840,7 @@
                 "type": "null"
               }
             ],
+            "description": "Unweighted mean recall across classes in `[0, 1]`; null when unavailable.",
             "title": "Macro Recall"
           },
           "macro_roc_auc": {
@@ -799,6 +852,7 @@
                 "type": "null"
               }
             ],
+            "description": "Unweighted mean one-vs-rest ROC AUC across classes; null when unavailable.",
             "title": "Macro Roc Auc"
           },
           "n_classes": {
@@ -810,6 +864,7 @@
                 "type": "null"
               }
             ],
+            "description": "Number of classes in the breakdown; null when unavailable.",
             "title": "N Classes"
           },
           "per_class": {
@@ -824,6 +879,7 @@
                 "type": "null"
               }
             ],
+            "description": "Per-class precision/recall/F1/support entries; null when the artifact is missing.",
             "title": "Per Class"
           },
           "source": {
@@ -834,7 +890,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Provenance of the backing artifact; null when no artifact was found."
           },
           "weighted_f1": {
             "anyOf": [
@@ -845,6 +902,7 @@
                 "type": "null"
               }
             ],
+            "description": "Support-weighted mean F1 across classes in `[0, 1]`; null when unavailable.",
             "title": "Weighted F1"
           }
         },
@@ -855,6 +913,7 @@
         "type": "object"
       },
       "ClassificationBreakdownSource": {
+        "description": "Provenance metadata for the artifact backing a classification breakdown.",
         "properties": {
           "checkpoint_path": {
             "anyOf": [
@@ -865,13 +924,16 @@
                 "type": "null"
               }
             ],
+            "description": "Checkpoint path the breakdown was computed against; null when not recorded.",
             "title": "Checkpoint Path"
           },
           "modified_at": {
+            "description": "ISO-8601 mtime of the source artifact in UTC.",
             "title": "Modified At",
             "type": "string"
           },
           "relative_path": {
+            "description": "Path of the source artifact relative to `data/artifacts/`.",
             "title": "Relative Path",
             "type": "string"
           },
@@ -884,6 +946,7 @@
                 "type": "null"
               }
             ],
+            "description": "Training package ID the artifact was produced under; null when the field is absent on disk.",
             "title": "Training Package Id"
           }
         },
@@ -895,12 +958,15 @@
         "type": "object"
       },
       "CredibilityResponse": {
+        "description": "Credibility / drift signals beside the headline forecast. Combines\na stance-drift score against prior statements with realised-vs-stated\nand market-implied gap estimates when those calibration sources are\navailable.",
         "properties": {
           "drift_score": {
+            "description": "Cosine drift of the current statement embedding vs the mean of prior statements; higher = larger shift.",
             "title": "Drift Score",
             "type": "number"
           },
           "drift_trend": {
+            "description": "Per-meeting drift sparkline newest-last; each entry is the cosine distance of one prior statement embedding to the mean of the remaining priors.",
             "items": {
               "type": "number"
             },
@@ -916,6 +982,7 @@
                 "type": "null"
               }
             ],
+            "description": "Signed gap between market-implied path and the statement's stated trajectory; null when futures data is unavailable.",
             "title": "Market Implied Gap"
           },
           "months_since_reversal": {
@@ -927,6 +994,7 @@
                 "type": "null"
               }
             ],
+            "description": "Months since the last hawkish<->dovish reversal in the stance series; null when no reversal is on record.",
             "title": "Months Since Reversal"
           },
           "realized_vs_stated_gap": {
@@ -938,6 +1006,7 @@
                 "type": "null"
               }
             ],
+            "description": "Signed gap between realised path and the statement's stated trajectory; null when no calibration is on disk.",
             "title": "Realized Vs Stated Gap"
           }
         },
@@ -951,6 +1020,7 @@
         "description": "One central-bank card on the cross-bank dashboard panel.\n\nMirrors the dict shape emitted by\n:func:`app.services.cross_bank_snapshot.build_bank_card`. Heads\nthat could not be filled (corpus missing for a bank, classifier\ncheckpoint unavailable, market-data lookup failed) leave the\nmatching field as ``None`` and surface the reason in ``status`` /\n``vol_regime_status`` so the frontend renders an explicit\n\"Coming soon\" placeholder rather than blank space.",
         "properties": {
           "bank": {
+            "description": "Full bank name identifier, e.g. `federal_reserve`, `european_central_bank`.",
             "title": "Bank",
             "type": "string"
           },
@@ -963,6 +1033,7 @@
                 "type": "null"
               }
             ],
+            "description": "Probability of `certainty_label` in `[0, 1]`; null when the head is unavailable.",
             "title": "Certainty Confidence"
           },
           "certainty_label": {
@@ -974,13 +1045,16 @@
                 "type": "null"
               }
             ],
+            "description": "Argmax certainty label; null when the head is unavailable.",
             "title": "Certainty Label"
           },
           "display_name": {
+            "description": "Human-readable bank name shown on the card.",
             "title": "Display Name",
             "type": "string"
           },
           "flag": {
+            "description": "Flag emoji or ISO code for the bank's jurisdiction.",
             "title": "Flag",
             "type": "string"
           },
@@ -993,13 +1067,16 @@
                 "type": "null"
               }
             ],
+            "description": "ISO `YYYY-MM-DD` event date of the latest statement scored; null when no statement was found.",
             "title": "Latest Statement Date"
           },
           "sample_size": {
+            "description": "Number of historical statements that fed the card's distribution.",
             "title": "Sample Size",
             "type": "integer"
           },
           "short_code": {
+            "description": "Short code used in artifacts/keys, e.g. `fed`, `ecb`, `boj`.",
             "title": "Short Code",
             "type": "string"
           },
@@ -1015,6 +1092,7 @@
                 "type": "null"
               }
             ],
+            "description": "Per-class stance distribution over hawkish/dovish/neutral; null when the head is unavailable.",
             "title": "Stance"
           },
           "stance_confidence": {
@@ -1026,6 +1104,7 @@
                 "type": "null"
               }
             ],
+            "description": "Probability of `stance_label` in `[0, 1]`; null when the head is unavailable.",
             "title": "Stance Confidence"
           },
           "stance_label": {
@@ -1037,13 +1116,16 @@
                 "type": "null"
               }
             ],
+            "description": "Argmax stance label; null when the head is unavailable.",
             "title": "Stance Label"
           },
           "status": {
+            "description": "Overall status string for the card, e.g. `ok` or the reason the card is partial.",
             "title": "Status",
             "type": "string"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the vol-regime card was anchored to.",
             "title": "Symbol",
             "type": "string"
           },
@@ -1056,6 +1138,7 @@
                 "type": "null"
               }
             ],
+            "description": "Forward-looking time axis label; null when the head is unavailable.",
             "title": "Time Axis"
           },
           "vol_regime_as_of": {
@@ -1067,6 +1150,7 @@
                 "type": "null"
               }
             ],
+            "description": "ISO `YYYY-MM-DD` of the trading session the vol-regime card was anchored at; null when unavailable.",
             "title": "Vol Regime As Of"
           },
           "vol_regime_confidence": {
@@ -1078,6 +1162,7 @@
                 "type": "null"
               }
             ],
+            "description": "Probability of `vol_regime_label` in `[0, 1]`; null when the head is unavailable.",
             "title": "Vol Regime Confidence"
           },
           "vol_regime_label": {
@@ -1089,6 +1174,7 @@
                 "type": "null"
               }
             ],
+            "description": "Argmax vol-regime label (calm/normal/high); null when the head is unavailable.",
             "title": "Vol Regime Label"
           },
           "vol_regime_status": {
@@ -1100,6 +1186,7 @@
                 "type": "null"
               }
             ],
+            "description": "Status string for the vol-regime card, e.g. `ok` or a degradation reason.",
             "title": "Vol Regime Status"
           }
         },
@@ -1130,6 +1217,7 @@
         "description": "Response wire shape for ``GET /cross-bank/snapshot``.\n\nSix-card side-by-side stance + vol-regime read across Fed, ECB,\nBoE, BoC, BoJ, RBA. Cached in-process for an hour (statements do\nnot change minute-to-minute and the classifier cold-start is\nexpensive).",
         "properties": {
           "banks": {
+            "description": "Six-bank stance+vol-regime card list ordered for display.",
             "items": {
               "$ref": "#/components/schemas/CrossBankCard"
             },
@@ -1137,10 +1225,12 @@
             "type": "array"
           },
           "cache_ttl_seconds": {
+            "description": "Seconds the in-process cache holds this snapshot before re-deriving.",
             "title": "Cache Ttl Seconds",
             "type": "integer"
           },
           "generated_at": {
+            "description": "ISO-8601 UTC timestamp the snapshot was generated at.",
             "title": "Generated At",
             "type": "string"
           }
@@ -1154,12 +1244,15 @@
         "type": "object"
       },
       "CrossBankTransferSection": {
+        "description": "Cross-bank transfer matrix surfaced on the research page.",
         "properties": {
           "available": {
+            "description": "True when at least one source/target cell was found on disk.",
             "title": "Available",
             "type": "boolean"
           },
           "cells": {
+            "description": "Flattened (source, target, metric) cells of the transfer matrix.",
             "items": {
               "$ref": "#/components/schemas/TransferMatrixCell"
             },
@@ -1168,10 +1261,12 @@
           },
           "metric_name": {
             "default": "macro_f1",
+            "description": "Metric carried in each cell, e.g. `macro_f1` or `accuracy`.",
             "title": "Metric Name",
             "type": "string"
           },
           "source_files": {
+            "description": "Relative paths of artefact files contributing to this section.",
             "items": {
               "type": "string"
             },
@@ -1179,6 +1274,7 @@
             "type": "array"
           },
           "sources": {
+            "description": "Distinct source banks present in `cells`, ordered for display.",
             "items": {
               "type": "string"
             },
@@ -1186,6 +1282,7 @@
             "type": "array"
           },
           "targets": {
+            "description": "Distinct target banks present in `cells`, ordered for display.",
             "items": {
               "type": "string"
             },
@@ -1257,12 +1354,15 @@
         "type": "object"
       },
       "DocumentParseResponse": {
+        "description": "Parsed plain-text payload extracted from a fetched FOMC document.",
         "properties": {
           "char_count": {
+            "description": "Length of `text` in characters.",
             "title": "Char Count",
             "type": "integer"
           },
           "source_kind": {
+            "description": "Detected source kind, e.g. `pdf`, `html`, `text`.",
             "title": "Source Kind",
             "type": "string"
           },
@@ -1270,10 +1370,12 @@
             "additionalProperties": {
               "type": "string"
             },
+            "description": "Extracted metadata key/value pairs from the source, e.g. title or author.",
             "title": "Source Metadata",
             "type": "object"
           },
           "text": {
+            "description": "Extracted plain-text body after parsing the source document.",
             "title": "Text",
             "type": "string"
           }
@@ -1288,34 +1390,42 @@
         "type": "object"
       },
       "EncoderAxisStanceRow": {
+        "description": "One encoder's validity-study row on the stance axis.",
         "properties": {
           "auc_hike_vs_cut": {
+            "description": "AUC of stance scores separating hike vs cut meetings.",
             "title": "Auc Hike Vs Cut",
             "type": "number"
           },
           "encoder_alias": {
+            "description": "Registry alias of the encoder being compared.",
             "title": "Encoder Alias",
             "type": "string"
           },
           "encoder_display": {
+            "description": "Display name of the encoder for UI rendering.",
             "title": "Encoder Display",
             "type": "string"
           },
           "held_out_f1": {
+            "description": "Held-out macro-F1 of the stance head fine-tuned on this encoder.",
             "title": "Held Out F1",
             "type": "number"
           },
           "is_held_out_winner": {
             "default": false,
+            "description": "True when this encoder won on the held-out macro-F1 metric.",
             "title": "Is Held Out Winner",
             "type": "boolean"
           },
           "is_validity_winner": {
             "default": false,
+            "description": "True when this encoder won the validity-study tie-break.",
             "title": "Is Validity Winner",
             "type": "boolean"
           },
           "spearman_rho": {
+            "description": "Spearman correlation between predicted stance scores and the labelled axis.",
             "title": "Spearman Rho",
             "type": "number"
           }
@@ -1331,12 +1441,15 @@
         "type": "object"
       },
       "EncoderAxisStanceSection": {
+        "description": "Validity-study table for the stance axis on the research page.",
         "properties": {
           "available": {
+            "description": "True when at least one validity-study row was found on disk.",
             "title": "Available",
             "type": "boolean"
           },
           "rows": {
+            "description": "Per-encoder validity rows ordered by display priority.",
             "items": {
               "$ref": "#/components/schemas/EncoderAxisStanceRow"
             },
@@ -1345,6 +1458,7 @@
           },
           "source_doc": {
             "default": "",
+            "description": "Citation of the source document the rows were lifted from.",
             "title": "Source Doc",
             "type": "string"
           }
@@ -1356,6 +1470,7 @@
         "type": "object"
       },
       "EncoderBakeoffRow": {
+        "description": "One encoder's seed-aggregated macro-F1 row in the bake-off table.",
         "properties": {
           "accuracy_mean": {
             "anyOf": [
@@ -1366,9 +1481,11 @@
                 "type": "null"
               }
             ],
+            "description": "Mean accuracy across seeds in `[0, 1]`; null when not recorded.",
             "title": "Accuracy Mean"
           },
           "checkpoint": {
+            "description": "Checkpoint path or HF revision the bake-off was run against.",
             "title": "Checkpoint",
             "type": "string"
           },
@@ -1381,9 +1498,11 @@
                 "type": "null"
               }
             ],
+            "description": "Mean Cohen kappa across seeds; null when not recorded.",
             "title": "Cohen Kappa"
           },
           "encoder_key": {
+            "description": "Registry alias of the encoder being compared.",
             "title": "Encoder Key",
             "type": "string"
           },
@@ -1396,6 +1515,7 @@
                 "type": "null"
               }
             ],
+            "description": "Upper edge of the macro-F1 95% bootstrap CI; null when CI was not computed.",
             "title": "Macro F1 Ci High"
           },
           "macro_f1_ci_low": {
@@ -1407,13 +1527,16 @@
                 "type": "null"
               }
             ],
+            "description": "Lower edge of the macro-F1 95% bootstrap CI; null when CI was not computed.",
             "title": "Macro F1 Ci Low"
           },
           "macro_f1_mean": {
+            "description": "Mean macro-F1 across `seeds` in `[0, 1]`.",
             "title": "Macro F1 Mean",
             "type": "number"
           },
           "macro_f1_values": {
+            "description": "Per-seed macro-F1 values aligned to `seeds`.",
             "items": {
               "type": "number"
             },
@@ -1421,6 +1544,7 @@
             "type": "array"
           },
           "seeds": {
+            "description": "Seed set the bake-off was averaged across.",
             "items": {
               "type": "integer"
             },
@@ -1436,6 +1560,7 @@
                 "type": "null"
               }
             ],
+            "description": "Support-weighted mean F1 across seeds; null when not recorded.",
             "title": "Weighted F1 Mean"
           }
         },
@@ -1450,8 +1575,10 @@
         "type": "object"
       },
       "EncoderBakeoffSection": {
+        "description": "Encoder bake-off table for the research artefacts response.",
         "properties": {
           "available": {
+            "description": "True when at least one bake-off artifact was found on disk.",
             "title": "Available",
             "type": "boolean"
           },
@@ -1464,9 +1591,11 @@
                 "type": "null"
               }
             ],
+            "description": "Fraction of the official seed set covered by the rows in `[0, 1]`; null when unavailable.",
             "title": "Coverage"
           },
           "rows": {
+            "description": "Per-encoder bake-off rows ordered by descending macro-F1 mean.",
             "items": {
               "$ref": "#/components/schemas/EncoderBakeoffRow"
             },
@@ -1474,6 +1603,7 @@
             "type": "array"
           },
           "source_files": {
+            "description": "Relative paths of artefact files contributing to this section.",
             "items": {
               "type": "string"
             },
@@ -1491,6 +1621,7 @@
         "description": "Empirical conformal coverage aggregated across recent history runs.\n\n``nominal`` is the conformal target the active model was calibrated\nto (read off the most-recent run that carries\n``series.forecast_confidence_level``). ``empirical`` is the fraction\nof runs whose realized regime label fell inside the predicted set.\nBoth are None when no qualifying runs exist.",
         "properties": {
           "computed_at": {
+            "description": "ISO-8601 UTC timestamp the aggregate was computed at.",
             "title": "Computed At",
             "type": "string"
           },
@@ -1503,6 +1634,7 @@
                 "type": "null"
               }
             ],
+            "description": "Empirical hit rate of the predicted set across qualifying runs; null when no runs qualify.",
             "title": "Empirical"
           },
           "nominal": {
@@ -1514,13 +1646,16 @@
                 "type": "null"
               }
             ],
+            "description": "Conformal target the active model was calibrated to; null when no recent run carries one.",
             "title": "Nominal"
           },
           "runs_total": {
+            "description": "Total number of history runs considered before filtering.",
             "title": "Runs Total",
             "type": "integer"
           },
           "sample_size": {
+            "description": "Number of qualifying runs the empirical coverage was computed over.",
             "title": "Sample Size",
             "type": "integer"
           }
@@ -1537,10 +1672,12 @@
         "description": "Multi-horizon HAR-volume forecast for the Expected Volume card.\nMarket-data-only forecast; never wired to text features.",
         "properties": {
           "generated_at": {
+            "description": "ISO-8601 UTC timestamp the response was generated at.",
             "title": "Generated At",
             "type": "string"
           },
           "horizons": {
+            "description": "Per-horizon volume forecast rows ordered ascending by `h`.",
             "items": {
               "$ref": "#/components/schemas/ExpectedVolumeHorizonForecast"
             },
@@ -1548,10 +1685,12 @@
             "type": "array"
           },
           "model_revision": {
+            "description": "Model revision identifier the forecast was produced under.",
             "title": "Model Revision",
             "type": "string"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the volume forecast was produced for.",
             "title": "Symbol",
             "type": "string"
           }
@@ -1569,34 +1708,42 @@
         "description": "HAR-based forecast of expected log-residual trading volume for\none horizon. ``point_log_residual`` is the model's point estimate\nin log-volume residual space (after calendar adjustment when the\nflag is set); ``point_pct_vs_baseline`` is the same number\nexpressed as a % deviation from the rolling calendar-adjusted\nbaseline so the card can render a human-readable headline.\n``r2_har`` is the offline pooled walk-forward R^2 of the HAR\nvolume head at this horizon, surfaced for the calibration chip.",
         "properties": {
           "band_hi_80": {
+            "description": "Upper edge of the 80% conformal band on `point_log_residual`.",
             "title": "Band Hi 80",
             "type": "number"
           },
           "band_hi_90": {
+            "description": "Upper edge of the 90% conformal band on `point_log_residual`.",
             "title": "Band Hi 90",
             "type": "number"
           },
           "band_lo_80": {
+            "description": "Lower edge of the 80% conformal band on `point_log_residual`.",
             "title": "Band Lo 80",
             "type": "number"
           },
           "band_lo_90": {
+            "description": "Lower edge of the 90% conformal band on `point_log_residual`.",
             "title": "Band Lo 90",
             "type": "number"
           },
           "calendar_adjusted": {
+            "description": "True when the baseline subtraction used a calendar-adjusted rolling mean.",
             "title": "Calendar Adjusted",
             "type": "boolean"
           },
           "h": {
+            "description": "Forecast horizon in trading days, e.g. 1, 5, or 22.",
             "title": "H",
             "type": "integer"
           },
           "point_log_residual": {
+            "description": "Point estimate in log-volume residual space after optional calendar adjustment.",
             "title": "Point Log Residual",
             "type": "number"
           },
           "point_pct_vs_baseline": {
+            "description": "Point estimate as a % deviation from the rolling calendar-adjusted baseline.",
             "title": "Point Pct Vs Baseline",
             "type": "number"
           },
@@ -1609,6 +1756,7 @@
                 "type": "null"
               }
             ],
+            "description": "Pooled walk-forward R^2 of the HAR volume head at this horizon; null when unavailable.",
             "title": "R2 Har"
           }
         },
@@ -1626,8 +1774,10 @@
         "type": "object"
       },
       "FomcCalendarResponse": {
+        "description": "Past and upcoming FOMC meetings for the calendar panel.",
         "properties": {
           "past": {
+            "description": "Past FOMC meetings ordered newest-first.",
             "items": {
               "$ref": "#/components/schemas/FomcMeetingResponse"
             },
@@ -1635,6 +1785,7 @@
             "type": "array"
           },
           "upcoming": {
+            "description": "Scheduled future FOMC meetings ordered soonest-first.",
             "items": {
               "$ref": "#/components/schemas/FomcMeetingResponse"
             },
@@ -1650,17 +1801,21 @@
         "type": "object"
       },
       "FomcMeetingResponse": {
+        "description": "One FOMC meeting row in the calendar response.",
         "properties": {
           "meeting_date": {
+            "description": "ISO `YYYY-MM-DD` date of the FOMC meeting.",
             "title": "Meeting Date",
             "type": "string"
           },
           "meeting_type": {
+            "description": "Meeting type label, e.g. `scheduled` or `unscheduled`.",
             "title": "Meeting Type",
             "type": "string"
           },
           "minutes_available": {
             "default": false,
+            "description": "True when the minutes body is available in the `/documents` cache.",
             "title": "Minutes Available",
             "type": "boolean"
           },
@@ -1673,6 +1828,7 @@
                 "type": "null"
               }
             ],
+            "description": "ISO date the minutes were released; null when not yet released.",
             "title": "Minutes Release Date"
           },
           "notes": {
@@ -1684,15 +1840,18 @@
                 "type": "null"
               }
             ],
+            "description": "Free-text annotation on the meeting, e.g. inter-meeting context; null when absent.",
             "title": "Notes"
           },
           "press_conference_available": {
             "default": false,
+            "description": "True when a press-conference transcript is available in the cache.",
             "title": "Press Conference Available",
             "type": "boolean"
           },
           "statement_available": {
             "default": false,
+            "description": "True when the statement body is available in the `/documents` cache.",
             "title": "Statement Available",
             "type": "boolean"
           },
@@ -1705,6 +1864,7 @@
                 "type": "null"
               }
             ],
+            "description": "ISO date the statement was released; null when not yet scheduled or recorded.",
             "title": "Statement Release Date"
           }
         },
@@ -1716,6 +1876,7 @@
         "type": "object"
       },
       "ForecastSeriesResponse": {
+        "description": "Chart-ready timeseries arrays for the forecaster panel \u2014 history,\nforecast point + confidence bands, and the optional realised overlay\nfor replay mode. Indices are aligned across all parallel lists.",
         "properties": {
           "conformal_coverage": {
             "anyOf": [
@@ -1736,6 +1897,7 @@
             "type": "string"
           },
           "forecast_close": {
+            "description": "Forecast point estimate of close at each forecast timestamp.",
             "items": {
               "type": "number"
             },
@@ -1743,6 +1905,7 @@
             "type": "array"
           },
           "forecast_close_lower": {
+            "description": "Lower edge of the close confidence band at each forecast timestamp.",
             "items": {
               "type": "number"
             },
@@ -1750,6 +1913,7 @@
             "type": "array"
           },
           "forecast_close_upper": {
+            "description": "Upper edge of the close confidence band at each forecast timestamp.",
             "items": {
               "type": "number"
             },
@@ -1757,10 +1921,12 @@
             "type": "array"
           },
           "forecast_confidence_level": {
+            "description": "Nominal confidence level of the forecast bands in `(0, 1)`, e.g. 0.8 for 80%.",
             "title": "Forecast Confidence Level",
             "type": "number"
           },
           "forecast_timestamps": {
+            "description": "ISO timestamps for each forecast step, ordered ascending.",
             "items": {
               "type": "string"
             },
@@ -1768,6 +1934,7 @@
             "type": "array"
           },
           "forecast_volatility": {
+            "description": "Forecast point estimate of realised volatility at each forecast timestamp.",
             "items": {
               "type": "number"
             },
@@ -1775,6 +1942,7 @@
             "type": "array"
           },
           "forecast_volatility_lower": {
+            "description": "Lower edge of the volatility confidence band at each forecast timestamp.",
             "items": {
               "type": "number"
             },
@@ -1782,6 +1950,7 @@
             "type": "array"
           },
           "forecast_volatility_upper": {
+            "description": "Upper edge of the volatility confidence band at each forecast timestamp.",
             "items": {
               "type": "number"
             },
@@ -1789,6 +1958,7 @@
             "type": "array"
           },
           "history_close": {
+            "description": "Historical close prices aligned to `timestamps`, in the ticker's native currency.",
             "items": {
               "type": "number"
             },
@@ -1796,6 +1966,7 @@
             "type": "array"
           },
           "history_volatility": {
+            "description": "Historical realised volatility aligned to `timestamps`.",
             "items": {
               "type": "number"
             },
@@ -1814,6 +1985,7 @@
                 "type": "null"
               }
             ],
+            "description": "Realised close prices aligned to `realized_timestamps`; null in live mode.",
             "title": "Realized Close"
           },
           "realized_timestamps": {
@@ -1828,6 +2000,7 @@
                 "type": "null"
               }
             ],
+            "description": "ISO timestamps for the realised overlay; null when replay mode is off.",
             "title": "Realized Timestamps"
           },
           "realized_volatility": {
@@ -1842,9 +2015,11 @@
                 "type": "null"
               }
             ],
+            "description": "Realised volatility aligned to `realized_timestamps`; null in live mode.",
             "title": "Realized Volatility"
           },
           "timestamps": {
+            "description": "ISO timestamps for the historical close/vol arrays, oldest-first.",
             "items": {
               "type": "string"
             },
@@ -1855,6 +2030,7 @@
             "additionalProperties": {
               "type": "number"
             },
+            "description": "Scaling constants applied to the volatility series so chart axes can re-scale display units.",
             "title": "Volatility Scale",
             "type": "object"
           }
@@ -1880,26 +2056,32 @@
         "description": "One horizon of the fed-funds futures implied-path consensus.\n\nProbabilities are derived from the implied-rate distribution and\nbucketed against the current target band; they sum to 1.0 across\nhike / cut / pause.",
         "properties": {
           "change_vs_current_bps": {
+            "description": "Signed change in basis points vs the current target midpoint.",
             "title": "Change Vs Current Bps",
             "type": "number"
           },
           "horizon_label": {
+            "description": "Horizon identifier for the futures contract, e.g. `next` or `+3m`.",
             "title": "Horizon Label",
             "type": "string"
           },
           "implied_rate_bps": {
+            "description": "Futures-implied fed-funds rate at this horizon in basis points.",
             "title": "Implied Rate Bps",
             "type": "number"
           },
           "probability_cut": {
+            "description": "Implied probability of a rate cut at this horizon in `[0, 1]`.",
             "title": "Probability Cut",
             "type": "number"
           },
           "probability_hike": {
+            "description": "Implied probability of a rate hike at this horizon in `[0, 1]`.",
             "title": "Probability Hike",
             "type": "number"
           },
           "probability_pause": {
+            "description": "Implied probability of a hold at this horizon in `[0, 1]`.",
             "title": "Probability Pause",
             "type": "number"
           }
@@ -1919,22 +2101,27 @@
         "description": "FRED / CME-derived futures consensus panel.\n\nDescriptive only \u2014 the rate-path expectations chart reads off\nrealized futures prices and never feeds the forecast cards.",
         "properties": {
           "current_target_hi_bps": {
+            "description": "Upper bound of the current fed-funds target range in basis points.",
             "title": "Current Target Hi Bps",
             "type": "number"
           },
           "current_target_lo_bps": {
+            "description": "Lower bound of the current fed-funds target range in basis points.",
             "title": "Current Target Lo Bps",
             "type": "number"
           },
           "data_source": {
+            "description": "Upstream data source identifier, e.g. `FRED` or `CME`.",
             "title": "Data Source",
             "type": "string"
           },
           "generated_at": {
+            "description": "ISO-8601 UTC timestamp the response was generated at.",
             "title": "Generated At",
             "type": "string"
           },
           "horizons": {
+            "description": "Per-horizon implied-rate + bucket-probability rows ordered by horizon.",
             "items": {
               "$ref": "#/components/schemas/FuturesConsensusHorizon"
             },
@@ -1942,10 +2129,12 @@
             "type": "array"
           },
           "meeting_date": {
+            "description": "ISO `YYYY-MM-DD` of the FOMC meeting the consensus targets.",
             "title": "Meeting Date",
             "type": "string"
           },
           "methodology": {
+            "description": "Short description of how the implied probabilities were derived.",
             "title": "Methodology",
             "type": "string"
           }
@@ -1987,20 +2176,24 @@
                 "type": "null"
               }
             ],
+            "description": "Hit rate across resolved rows in `[0, 1]`; null when none resolved.",
             "title": "Accuracy Overall"
           },
           "per_tercile_hit_rate": {
             "additionalProperties": {
               "type": "number"
             },
+            "description": "Per-predicted-tercile hit rate keyed by predicted label.",
             "title": "Per Tercile Hit Rate",
             "type": "object"
           },
           "resolved_runs": {
+            "description": "Number of rows whose realised tercile could be derived.",
             "title": "Resolved Runs",
             "type": "integer"
           },
           "total_runs": {
+            "description": "Total rows in the window regardless of forward-window resolution.",
             "title": "Total Runs",
             "type": "integer"
           }
@@ -2016,17 +2209,21 @@
         "description": "Response wire shape for ``GET /forecast/har-tercile-backtest``.\n\nSurfaces the last N FOMC meetings with their on-demand HAR-tercile\nprediction and the realized tercile derived from forward market\nhistory. Drives the HarAccuracyPanel card.",
         "properties": {
           "generated_at": {
+            "description": "ISO-8601 UTC timestamp the response was generated at.",
             "title": "Generated At",
             "type": "string"
           },
           "horizon": {
+            "description": "Forward horizon in trading days the realised tercile was measured at.",
             "title": "Horizon",
             "type": "integer"
           },
           "metrics": {
-            "$ref": "#/components/schemas/HarAccuracyMetrics"
+            "$ref": "#/components/schemas/HarAccuracyMetrics",
+            "description": "Aggregate accuracy metrics across the rows."
           },
           "rows": {
+            "description": "Per-event backtest rows ordered by `event_date`.",
             "items": {
               "$ref": "#/components/schemas/HarTercileBacktestRow"
             },
@@ -2034,6 +2231,7 @@
             "type": "array"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the backtest was run against.",
             "title": "Symbol",
             "type": "string"
           }
@@ -2060,9 +2258,11 @@
                 "type": "null"
               }
             ],
+            "description": "True when `predicted_tercile == realized_tercile`; null when the row is unresolved.",
             "title": "Correct"
           },
           "event_date": {
+            "description": "ISO `YYYY-MM-DD` event date the row was anchored to.",
             "title": "Event Date",
             "type": "string"
           },
@@ -2075,6 +2275,7 @@
                 "type": "null"
               }
             ],
+            "description": "Probability of the predicted tercile in `[0, 1]`; null when the forecast is unavailable.",
             "title": "Predicted Prob"
           },
           "predicted_tercile": {
@@ -2086,6 +2287,7 @@
                 "type": "null"
               }
             ],
+            "description": "HAR-tercile predicted bucket (low/medium/high) at the event; null when the forecast was outside the warmup window.",
             "title": "Predicted Tercile"
           },
           "realized_rv": {
@@ -2097,6 +2299,7 @@
                 "type": "null"
               }
             ],
+            "description": "Realised RV measured at the forward bar; null when the forward window has not yet closed.",
             "title": "Realized Rv"
           },
           "realized_tercile": {
@@ -2108,6 +2311,7 @@
                 "type": "null"
               }
             ],
+            "description": "Realised forward-vol tercile bucketed off the same cutoffs; null when the forward window has not yet closed.",
             "title": "Realized Tercile"
           }
         },
@@ -2131,10 +2335,12 @@
             "type": "number"
           },
           "generated_at": {
+            "description": "ISO-8601 UTC timestamp the response was generated at.",
             "title": "Generated At",
             "type": "string"
           },
           "horizons": {
+            "description": "Per-horizon HAR-tercile rows ordered ascending by `h`.",
             "items": {
               "$ref": "#/components/schemas/HarTercileHorizon"
             },
@@ -2142,10 +2348,12 @@
             "type": "array"
           },
           "model_revision": {
+            "description": "Model revision identifier the baseline was produced under.",
             "title": "Model Revision",
             "type": "string"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the HAR-tercile baseline was produced for.",
             "title": "Symbol",
             "type": "string"
           }
@@ -2165,6 +2373,7 @@
         "description": "HAR-tercile baseline classification for one forecast horizon.\n\n``predicted_rv`` is HAR's OLS point in realized-variance units.\n``tercile`` is the argmax bucket against the q33 / q67 cutoffs the\nresponse also returns; ``tercile_probs`` is the Gaussian-CDF mass\ntriple in log-RV space (sums to 1.0). ``macro_f1`` is wired through\nfrom wiki section 20 \u2014 the published HAR-tercile pooled macro-F1 on\nthe canonical 5-fold expanding walk-forward (0.687 / 0.685 / 0.654\nat h=1 / 5 / 22). The serving path does not recompute this number;\nit surfaces the offline-measured one so the frontend can render an\nhonest chip alongside the live point forecast.",
         "properties": {
           "h": {
+            "description": "Forecast horizon in trading days, e.g. 1, 5, or 22.",
             "title": "H",
             "type": "integer"
           },
@@ -2186,6 +2395,7 @@
             "type": "string"
           },
           "predicted_rv": {
+            "description": "HAR-OLS point forecast of realized variance at horizon h.",
             "title": "Predicted Rv",
             "type": "number"
           },
@@ -2214,6 +2424,7 @@
             "title": "Qlike Model"
           },
           "tercile": {
+            "description": "Argmax tercile bucket for `predicted_rv` against the q33/q67 cutoffs.",
             "enum": [
               "low",
               "medium",
@@ -2251,6 +2462,7 @@
                 "type": "null"
               }
             ],
+            "description": "Probability of the `argmax_regime` label in `[0, 1]`; null when no regime card was persisted.",
             "title": "Argmax Probability"
           },
           "argmax_regime": {
@@ -2262,9 +2474,11 @@
                 "type": "null"
               }
             ],
+            "description": "Argmax regime label from the persisted regime card; null when the row pre-dates the regime head.",
             "title": "Argmax Regime"
           },
           "created_at": {
+            "description": "ISO-8601 UTC timestamp the run was persisted.",
             "title": "Created At",
             "type": "string"
           },
@@ -2277,26 +2491,32 @@
                 "type": "null"
               }
             ],
+            "description": "Anchor-session close from the persisted market snapshot; null when missing.",
             "title": "Current Close"
           },
           "document_date": {
+            "description": "ISO `YYYY-MM-DD` event date of the analyzed FOMC document.",
             "title": "Document Date",
             "type": "string"
           },
           "forecast_mode": {
+            "description": "Forecast mode the run was executed under: `fast`, `quick_train`, or `real_train`.",
             "title": "Forecast Mode",
             "type": "string"
           },
           "horizon": {
+            "description": "Forecast horizon label, e.g. `1d`, `3d`, `5d`.",
             "title": "Horizon",
             "type": "string"
           },
           "id": {
+            "description": "UUID identifier of the persisted analyze run.",
             "title": "Id",
             "type": "string"
           },
           "payload": {
             "additionalProperties": true,
+            "description": "Full persisted analyze payload as a raw JSON object.",
             "title": "Payload",
             "type": "object"
           },
@@ -2309,6 +2529,7 @@
                 "type": "null"
               }
             ],
+            "description": "Persisted point forecast of close at the chosen horizon; null when missing.",
             "title": "Predicted Close"
           },
           "predicted_volatility": {
@@ -2320,6 +2541,7 @@
                 "type": "null"
               }
             ],
+            "description": "Persisted point forecast of realised volatility at the chosen horizon; null when missing.",
             "title": "Predicted Volatility"
           },
           "regime_set_size": {
@@ -2331,6 +2553,7 @@
                 "type": "null"
               }
             ],
+            "description": "Cardinality of the persisted conformal regime set; null when no regime card was persisted.",
             "title": "Regime Set Size"
           },
           "sentiment_score": {
@@ -2342,9 +2565,11 @@
                 "type": "null"
               }
             ],
+            "description": "Unsigned confidence of the persisted stance label in `[0, 1]`; null when missing.",
             "title": "Sentiment Score"
           },
           "stance": {
+            "description": "Aggregated stance label persisted with the row: hawkish/dovish/neutral/UNKNOWN.",
             "title": "Stance",
             "type": "string"
           },
@@ -2357,9 +2582,11 @@
                 "type": "null"
               }
             ],
+            "description": "Signed stance value `P(hawkish) - P(dovish)` from the multi-axis distribution; null when the row pre-dates multi-axis.",
             "title": "Stance Score"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the run was anchored to.",
             "title": "Symbol",
             "type": "string"
           },
@@ -2372,6 +2599,7 @@
                 "type": "null"
               }
             ],
+            "description": "Leading excerpt of the analyzed statement text for the listing tile; null when redacted.",
             "title": "Text Excerpt"
           }
         },
@@ -2389,6 +2617,7 @@
         "type": "object"
       },
       "HistoryEntry": {
+        "description": "One persisted analyze run summarised for the history list. Carries\nthe headline scalars and regime summary so the listing page can render\nwithout re-fetching the full payload.",
         "properties": {
           "argmax_probability": {
             "anyOf": [
@@ -2399,6 +2628,7 @@
                 "type": "null"
               }
             ],
+            "description": "Probability of the `argmax_regime` label in `[0, 1]`; null when no regime card was persisted.",
             "title": "Argmax Probability"
           },
           "argmax_regime": {
@@ -2410,9 +2640,11 @@
                 "type": "null"
               }
             ],
+            "description": "Argmax regime label from the persisted regime card; null when the row pre-dates the regime head.",
             "title": "Argmax Regime"
           },
           "created_at": {
+            "description": "ISO-8601 UTC timestamp the run was persisted.",
             "title": "Created At",
             "type": "string"
           },
@@ -2425,21 +2657,26 @@
                 "type": "null"
               }
             ],
+            "description": "Anchor-session close from the persisted market snapshot; null when missing.",
             "title": "Current Close"
           },
           "document_date": {
+            "description": "ISO `YYYY-MM-DD` event date of the analyzed FOMC document.",
             "title": "Document Date",
             "type": "string"
           },
           "forecast_mode": {
+            "description": "Forecast mode the run was executed under: `fast`, `quick_train`, or `real_train`.",
             "title": "Forecast Mode",
             "type": "string"
           },
           "horizon": {
+            "description": "Forecast horizon label, e.g. `1d`, `3d`, `5d`.",
             "title": "Horizon",
             "type": "string"
           },
           "id": {
+            "description": "UUID identifier of the persisted analyze run.",
             "title": "Id",
             "type": "string"
           },
@@ -2452,6 +2689,7 @@
                 "type": "null"
               }
             ],
+            "description": "Persisted point forecast of close at the chosen horizon; null when missing.",
             "title": "Predicted Close"
           },
           "predicted_volatility": {
@@ -2463,6 +2701,7 @@
                 "type": "null"
               }
             ],
+            "description": "Persisted point forecast of realised volatility at the chosen horizon; null when missing.",
             "title": "Predicted Volatility"
           },
           "regime_set_size": {
@@ -2474,6 +2713,7 @@
                 "type": "null"
               }
             ],
+            "description": "Cardinality of the persisted conformal regime set; null when no regime card was persisted.",
             "title": "Regime Set Size"
           },
           "sentiment_score": {
@@ -2485,9 +2725,11 @@
                 "type": "null"
               }
             ],
+            "description": "Unsigned confidence of the persisted stance label in `[0, 1]`; null when missing.",
             "title": "Sentiment Score"
           },
           "stance": {
+            "description": "Aggregated stance label persisted with the row: hawkish/dovish/neutral/UNKNOWN.",
             "title": "Stance",
             "type": "string"
           },
@@ -2500,9 +2742,11 @@
                 "type": "null"
               }
             ],
+            "description": "Signed stance value `P(hawkish) - P(dovish)` from the multi-axis distribution; null when the row pre-dates multi-axis.",
             "title": "Stance Score"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the run was anchored to.",
             "title": "Symbol",
             "type": "string"
           },
@@ -2515,6 +2759,7 @@
                 "type": "null"
               }
             ],
+            "description": "Leading excerpt of the analyzed statement text for the listing tile; null when redacted.",
             "title": "Text Excerpt"
           }
         },
@@ -2534,10 +2779,12 @@
         "description": "Forward 10-trading-day price path anchored on the event date.\n\nBacks the event-study chart on /history/[id]: the realised close path\nplus the bucketed realised regime label so the headline can read\n\"predicted X, realized Y\".",
         "properties": {
           "event_date": {
+            "description": "ISO `YYYY-MM-DD` event date the forward path is anchored to.",
             "title": "Event Date",
             "type": "string"
           },
           "forward_close": {
+            "description": "Realised close prices aligned to `forward_dates`.",
             "items": {
               "type": "number"
             },
@@ -2545,6 +2792,7 @@
             "type": "array"
           },
           "forward_dates": {
+            "description": "ISO dates of the 10 forward trading sessions, oldest-first.",
             "items": {
               "type": "string"
             },
@@ -2552,6 +2800,7 @@
             "type": "array"
           },
           "forward_log_returns": {
+            "description": "Bar-to-bar log returns aligned to `forward_dates`.",
             "items": {
               "type": "number"
             },
@@ -2567,6 +2816,7 @@
                 "type": "null"
               }
             ],
+            "description": "Predicted regime label persisted with the original run; null when no regime card was persisted.",
             "title": "Predicted Regime"
           },
           "realized_regime": {
@@ -2578,6 +2828,7 @@
                 "type": "null"
               }
             ],
+            "description": "Realised regime label bucketed from `realized_vol_10d`; null when cutoffs are unavailable.",
             "title": "Realized Regime"
           },
           "realized_vol_10d": {
@@ -2589,9 +2840,11 @@
                 "type": "null"
               }
             ],
+            "description": "Realised 10-day forward volatility derived from `forward_log_returns`; null when insufficient bars.",
             "title": "Realized Vol 10D"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the forward series was pulled for.",
             "title": "Symbol",
             "type": "string"
           }
@@ -2607,8 +2860,10 @@
         "type": "object"
       },
       "HistoryList": {
+        "description": "Paginated listing envelope for the history page.",
         "properties": {
           "items": {
+            "description": "History entries on the current page, newest-first by default.",
             "items": {
               "$ref": "#/components/schemas/HistoryEntry"
             },
@@ -2616,14 +2871,17 @@
             "type": "array"
           },
           "limit": {
+            "description": "Page size echoed from the request.",
             "title": "Limit",
             "type": "integer"
           },
           "offset": {
+            "description": "Page offset echoed from the request.",
             "title": "Offset",
             "type": "integer"
           },
           "total": {
+            "description": "Total number of history entries available across all pages.",
             "title": "Total",
             "type": "integer"
           }
@@ -2644,10 +2902,12 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/HistoryRealizedResponse"
             },
+            "description": "Realised payloads keyed by history run UUID.",
             "title": "Items",
             "type": "object"
           },
           "missing": {
+            "description": "Run UUIDs for which realised data could not be fetched.",
             "items": {
               "type": "string"
             },
@@ -2663,8 +2923,10 @@
         "type": "object"
       },
       "HistoryRealizedResponse": {
+        "description": "Realised forward market path for a single persisted history run,\nplus the bucketed realised regime label so the detail page can\nrender a predicted-vs-realised badge.",
         "properties": {
           "close": {
+            "description": "Realised close prices aligned to `timestamps`.",
             "items": {
               "type": "number"
             },
@@ -2672,10 +2934,12 @@
             "type": "array"
           },
           "document_date": {
+            "description": "ISO `YYYY-MM-DD` event date the run anchored to.",
             "title": "Document Date",
             "type": "string"
           },
           "horizon": {
+            "description": "Forecast horizon label echoed from the run, e.g. `3d`.",
             "title": "Horizon",
             "type": "string"
           },
@@ -2688,17 +2952,21 @@
                 "type": "null"
               }
             ],
+            "description": "Realised regime label derived from the 10d-forward vol path; null when the classifier cutoffs are unavailable on this host.",
             "title": "Realized Regime"
           },
           "run_id": {
+            "description": "UUID of the history run this realised payload belongs to.",
             "title": "Run Id",
             "type": "string"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the realised series was pulled for.",
             "title": "Symbol",
             "type": "string"
           },
           "timestamps": {
+            "description": "ISO timestamps of the forward sessions, oldest-first.",
             "items": {
               "type": "string"
             },
@@ -2706,6 +2974,7 @@
             "type": "array"
           },
           "volatility": {
+            "description": "Realised volatility aligned to `timestamps`.",
             "items": {
               "type": "number"
             },
@@ -2737,6 +3006,7 @@
                 "type": "null"
               }
             ],
+            "description": "Free-text message lifted from the caught exception so operators can grep without parsing logs.",
             "title": "Detail"
           },
           "exception_class": {
@@ -2748,6 +3018,7 @@
                 "type": "null"
               }
             ],
+            "description": "Python class name of the caught exception when status is 'unexpected_exception'; None otherwise.",
             "title": "Exception Class"
           },
           "missing_kwarg": {
@@ -2759,9 +3030,11 @@
                 "type": "null"
               }
             ],
+            "description": "Name of the inference kwarg the checkpoint expected but did not receive; only set when status is 'inference_kwarg_missing'.",
             "title": "Missing Kwarg"
           },
           "status": {
+            "description": "Degradation branch token: 'not_classification_mode', 'inference_kwarg_missing', or 'unexpected_exception'.",
             "title": "Status",
             "type": "string"
           }
@@ -2773,28 +3046,35 @@
         "type": "object"
       },
       "MarketDataResponse": {
+        "description": "Snapshot of the market series at the trading session used as the\nforecast anchor. ``requested_date`` is what the caller asked for and\n``date_used`` is the actual session resolved after weekend/holiday\nrollback.",
         "properties": {
           "close": {
+            "description": "Adjusted close price at `date_used` in the ticker's native currency.",
             "title": "Close",
             "type": "number"
           },
           "date_used": {
+            "description": "ISO `YYYY-MM-DD` of the trading session actually used after rolling back over weekends/holidays.",
             "title": "Date Used",
             "type": "string"
           },
           "lookback_days": {
+            "description": "Calendar-day lookback window pulled from yfinance to populate the history series.",
             "title": "Lookback Days",
             "type": "integer"
           },
           "requested_date": {
+            "description": "ISO `YYYY-MM-DD` date the caller asked for in the original request.",
             "title": "Requested Date",
             "type": "string"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the snapshot was fetched for, e.g. `^GSPC` or `DX-Y.NYB`.",
             "title": "Symbol",
             "type": "string"
           },
           "volatility_5d": {
+            "description": "Trailing 5-session realised volatility of log returns ending at `date_used`.",
             "title": "Volatility 5D",
             "type": "number"
           }
@@ -2822,6 +3102,7 @@
                 "type": "null"
               }
             ],
+            "description": "Absolute path of the checkpoint that produced these cards; null when no checkpoint is loaded.",
             "title": "Checkpoint Path"
           },
           "encoder_alias": {
@@ -2833,9 +3114,11 @@
                 "type": "null"
               }
             ],
+            "description": "Registry alias of the encoder backing this market-reaction panel; null on a stateless build.",
             "title": "Encoder Alias"
           },
           "rates": {
+            "description": "One reaction card per mounted rates head (2y/5y/terminal); empty when no rates heads are mounted.",
             "items": {
               "$ref": "#/components/schemas/RatesReactionCard"
             },
@@ -2850,13 +3133,15 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Vol-regime reaction card; null when the active checkpoint has no regime head."
           }
         },
         "title": "MarketReactionPanel",
         "type": "object"
       },
       "ModelDiagnosticsResponse": {
+        "description": "Forecaster runtime + checkpoint metadata surfaced beside the prediction.\nExposes which file the service loaded, the network shape it was built\nwith, and the most recent training/adaptation losses recorded on disk.",
         "properties": {
           "adaptation_best_epoch": {
             "anyOf": [
@@ -2867,6 +3152,7 @@
                 "type": "null"
               }
             ],
+            "description": "Epoch index of the lowest adaptation loss in the most recent run.",
             "title": "Adaptation Best Epoch"
           },
           "adaptation_combined_rmse": {
@@ -2878,6 +3164,7 @@
                 "type": "null"
               }
             ],
+            "description": "Combined close+volatility RMSE from the most recent adaptation pass.",
             "title": "Adaptation Combined Rmse"
           },
           "adaptation_epochs_completed": {
@@ -2889,6 +3176,7 @@
                 "type": "null"
               }
             ],
+            "description": "Number of adaptation epochs completed in the most recent quick_train/real_train pass.",
             "title": "Adaptation Epochs Completed"
           },
           "adaptation_loss": {
@@ -2900,6 +3188,7 @@
                 "type": "null"
               }
             ],
+            "description": "Best loss value observed during the most recent adaptation pass.",
             "title": "Adaptation Loss"
           },
           "best_loss": {
@@ -2911,17 +3200,21 @@
                 "type": "null"
               }
             ],
+            "description": "Best validation loss recorded during the most recent training run; null when no run logged it.",
             "title": "Best Loss"
           },
           "checkpoint_exists": {
+            "description": "True when the checkpoint file is present on disk at `checkpoint_path`.",
             "title": "Checkpoint Exists",
             "type": "boolean"
           },
           "checkpoint_loaded": {
+            "description": "True when the in-memory forecaster matches the on-disk checkpoint.",
             "title": "Checkpoint Loaded",
             "type": "boolean"
           },
           "checkpoint_path": {
+            "description": "Absolute path of the forecaster checkpoint the service loaded.",
             "title": "Checkpoint Path",
             "type": "string"
           },
@@ -2933,9 +3226,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Per-chunk attention trace from the encoder aggregator; null when the input was short enough to skip chunking."
           },
           "close_scale": {
+            "description": "Scaling factor applied to close-price targets before training.",
             "title": "Close Scale",
             "type": "number"
           },
@@ -2948,6 +3243,7 @@
                 "type": "null"
               }
             ],
+            "description": "Combined close+volatility RMSE from the best run; null when unavailable.",
             "title": "Combined Rmse"
           },
           "decay_rate": {
@@ -2959,9 +3255,11 @@
                 "type": "null"
               }
             ],
+            "description": "Elapsed-time decay rate (lambda) used by the chunk aggregator; null when no decay is configured.",
             "title": "Decay Rate"
           },
           "dropout": {
+            "description": "Dropout probability applied between LSTM layers in `[0, 1)`.",
             "title": "Dropout",
             "type": "number"
           },
@@ -2974,25 +3272,31 @@
                 "type": "null"
               }
             ],
+            "description": "Encoder alias backing the multi-axis classifier (e.g. `finbert_fed_adjacent`); null when no multi-axis checkpoint is loaded.",
             "title": "Encoder Key"
           },
           "head_hidden_size": {
+            "description": "Hidden dimension of the regression head MLP in units.",
             "title": "Head Hidden Size",
             "type": "integer"
           },
           "hidden_size": {
+            "description": "Hidden dimension of the LSTM backbone in units.",
             "title": "Hidden Size",
             "type": "integer"
           },
           "num_layers": {
+            "description": "Number of stacked LSTM layers in the forecaster.",
             "title": "Num Layers",
             "type": "integer"
           },
           "runtime_mode": {
+            "description": "Runtime mode the model is served under, e.g. `fast`, `quick_train`, `real_train`.",
             "title": "Runtime Mode",
             "type": "string"
           },
           "sequence_length": {
+            "description": "Number of past timesteps fed into the LSTM each forward pass.",
             "title": "Sequence Length",
             "type": "integer"
           }
@@ -3016,6 +3320,7 @@
         "description": "Monetary-policy surprise (descriptive panel, not a forecast input).\n\n``mp_surprise_level_bps`` is the realized rate-path surprise in\nbasis points relative to the pre-meeting fed-funds futures\nconsensus. ``direction`` is the discrete sign bucket the panel\nrenders; ``no_surprise`` covers the inside-the-band cases.\n``is_intermeeting`` flags off-cycle actions where the consensus\nbaseline is constructed differently.",
         "properties": {
           "direction": {
+            "description": "Discrete sign bucket of the surprise the panel renders.",
             "enum": [
               "hawkish",
               "dovish",
@@ -3025,6 +3330,7 @@
             "type": "string"
           },
           "event_date": {
+            "description": "ISO `YYYY-MM-DD` of the FOMC event the surprise was measured at.",
             "title": "Event Date",
             "type": "string"
           },
@@ -3037,17 +3343,21 @@
                 "type": "null"
               }
             ],
+            "description": "Prior fed-funds target midpoint in basis points; null when unavailable.",
             "title": "Ff Target Prior Bps"
           },
           "is_intermeeting": {
+            "description": "True when the action was off-cycle and the consensus baseline was constructed differently.",
             "title": "Is Intermeeting",
             "type": "boolean"
           },
           "magnitude_bps": {
+            "description": "Absolute magnitude of the surprise in basis points (non-negative).",
             "title": "Magnitude Bps",
             "type": "number"
           },
           "mp_surprise_level_bps": {
+            "description": "Realised rate-path surprise vs the pre-meeting fed-funds futures consensus, in basis points (signed).",
             "title": "Mp Surprise Level Bps",
             "type": "number"
           }
@@ -3073,10 +3383,12 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Certainty head prediction; null when the active checkpoint omits this axis."
           },
           "stance": {
-            "$ref": "#/components/schemas/MultiAxisStanceCard"
+            "$ref": "#/components/schemas/MultiAxisStanceCard",
+            "description": "Stance head prediction (hawkish/dovish/neutral) with class distribution."
           },
           "time": {
             "anyOf": [
@@ -3086,7 +3398,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Forward-looking time head prediction; null when the active checkpoint omits this axis."
           }
         },
         "required": [
@@ -3099,6 +3412,7 @@
         "description": "Certainty prediction from the multi-task head.",
         "properties": {
           "confidence": {
+            "description": "Probability of the predicted certainty label in `[0, 1]` after softmax.",
             "maximum": 1.0,
             "minimum": 0.0,
             "title": "Confidence",
@@ -3108,6 +3422,7 @@
             "additionalProperties": {
               "type": "number"
             },
+            "description": "Per-class softmax probability over the three certainty classes.",
             "title": "Distribution",
             "type": "object"
           },
@@ -3128,6 +3443,7 @@
         "description": "Stance prediction from the multi-task head.",
         "properties": {
           "confidence": {
+            "description": "Probability of the predicted stance label in `[0, 1]` after softmax.",
             "maximum": 1.0,
             "minimum": 0.0,
             "title": "Confidence",
@@ -3158,6 +3474,7 @@
         "description": "Forward-looking horizon classification from the multi-task head.\n\nTwo classes: ``forward looking`` (the statement references future\nactions or expectations) vs ``not forward looking`` (backward-looking\nor current-state only). Sourced from the gtfintechlab ``time_label``\ncolumn; trained on ~5 992 labelled sentences.",
         "properties": {
           "confidence": {
+            "description": "Probability of the predicted label in `[0, 1]` after softmax.",
             "maximum": 1.0,
             "minimum": 0.0,
             "title": "Confidence",
@@ -3167,6 +3484,7 @@
             "additionalProperties": {
               "type": "number"
             },
+            "description": "Per-class softmax probability over the two forward-looking classes.",
             "title": "Distribution",
             "type": "object"
           },
@@ -3184,6 +3502,7 @@
         "type": "object"
       },
       "NextFomcAttributionRow": {
+        "description": "One feature-family attribution row in the next-FOMC ablation table.",
         "properties": {
           "brier": {
             "anyOf": [
@@ -3194,9 +3513,11 @@
                 "type": "null"
               }
             ],
+            "description": "Multiclass Brier score for this row; null when unavailable.",
             "title": "Brier"
           },
           "families": {
+            "description": "Feature families included in this ablation row.",
             "items": {
               "type": "string"
             },
@@ -3212,6 +3533,7 @@
                 "type": "null"
               }
             ],
+            "description": "Mean cross-entropy loss for this row; null when unavailable.",
             "title": "Log Loss"
           },
           "macro_f1": {
@@ -3223,6 +3545,7 @@
                 "type": "null"
               }
             ],
+            "description": "Unweighted mean F1 across classes in `[0, 1]`; null when unavailable.",
             "title": "Macro F1"
           },
           "n": {
@@ -3234,6 +3557,7 @@
                 "type": "null"
               }
             ],
+            "description": "Number of resolved predictions used for the metrics; null when unavailable.",
             "title": "N"
           },
           "n_features": {
@@ -3245,9 +3569,11 @@
                 "type": "null"
               }
             ],
+            "description": "Number of features used after the family subset was applied; null when unavailable.",
             "title": "N Features"
           },
           "subset": {
+            "description": "Subset identifier the row was scored on (e.g. `full`, `ex_pandemic`).",
             "title": "Subset",
             "type": "string"
           },
@@ -3260,6 +3586,7 @@
                 "type": "null"
               }
             ],
+            "description": "Top-1 argmax accuracy in `[0, 1]`; null when unavailable.",
             "title": "Top1 Accuracy"
           }
         },
@@ -3271,16 +3598,20 @@
         "type": "object"
       },
       "NextFomcForecastResponse": {
+        "description": "Response envelope for `GET /forecast/next-fomc`.",
         "properties": {
           "artifacts_dir": {
+            "description": "Absolute path of the artifacts directory backing this response.",
             "title": "Artifacts Dir",
             "type": "string"
           },
           "available": {
+            "description": "True when a next-FOMC artifact was found on disk.",
             "title": "Available",
             "type": "boolean"
           },
           "feature_attribution": {
+            "description": "Feature-family ablation rows for the model attribution table.",
             "items": {
               "$ref": "#/components/schemas/NextFomcAttributionRow"
             },
@@ -3295,9 +3626,11 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Headline next-meeting prediction row; null when no prediction is available."
           },
           "history": {
+            "description": "Historical next-meeting predictions ordered oldest-first.",
             "items": {
               "$ref": "#/components/schemas/NextFomcMeetingPrediction"
             },
@@ -3308,6 +3641,7 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/NextFomcModelMetrics"
             },
+            "description": "Per-model aggregate metrics excluding the COVID pandemic window.",
             "title": "Metrics Ex Pandemic",
             "type": "object"
           },
@@ -3315,10 +3649,12 @@
             "additionalProperties": {
               "$ref": "#/components/schemas/NextFomcModelMetrics"
             },
+            "description": "Per-model aggregate metrics over the full window keyed by model name.",
             "title": "Metrics Full Window",
             "type": "object"
           },
           "model_names": {
+            "description": "Model identifiers compared in this response.",
             "items": {
               "type": "string"
             },
@@ -3326,6 +3662,7 @@
             "type": "array"
           },
           "ordinal_classes": {
+            "description": "Ordered class labels the next-FOMC heads emit, e.g. cut/hold/hike.",
             "items": {
               "type": "string"
             },
@@ -3336,6 +3673,7 @@
             "additionalProperties": {
               "type": "integer"
             },
+            "description": "Free-form integer summary counters surfaced beside the response.",
             "title": "Summary",
             "type": "object"
           },
@@ -3347,7 +3685,8 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Descriptor of the upcoming meeting the headline targets; null when none is scheduled."
           }
         },
         "required": [
@@ -3359,8 +3698,10 @@
         "type": "object"
       },
       "NextFomcMeetingPrediction": {
+        "description": "One next-FOMC ordinal prediction row keyed by model name.",
         "properties": {
           "n_train_rows": {
+            "description": "Number of training rows that fed the model for this target.",
             "title": "N Train Rows",
             "type": "integer"
           },
@@ -3368,6 +3709,7 @@
             "additionalProperties": {
               "type": "string"
             },
+            "description": "Per-model argmax class label drawn from `probabilities`.",
             "title": "Predicted Class",
             "type": "object"
           },
@@ -3378,10 +3720,12 @@
               },
               "type": "object"
             },
+            "description": "Per-model dict of class -> probability for the target meeting.",
             "title": "Probabilities",
             "type": "object"
           },
           "target_as_of_ts": {
+            "description": "ISO-8601 UTC timestamp the features were anchored at.",
             "title": "Target As Of Ts",
             "type": "string"
           },
@@ -3398,6 +3742,7 @@
             "title": "Target Class"
           },
           "target_event_date": {
+            "description": "ISO `YYYY-MM-DD` event date the prediction targets.",
             "title": "Target Event Date",
             "type": "string"
           }
@@ -3413,6 +3758,7 @@
         "type": "object"
       },
       "NextFomcModelMetrics": {
+        "description": "Aggregate accuracy metrics for one next-FOMC model on a window.",
         "properties": {
           "brier": {
             "anyOf": [
@@ -3423,6 +3769,7 @@
                 "type": "null"
               }
             ],
+            "description": "Multiclass Brier score over the window; null when unavailable.",
             "title": "Brier"
           },
           "confusion_matrix": {
@@ -3432,6 +3779,7 @@
               },
               "type": "object"
             },
+            "description": "Nested actual -> predicted counts over the window.",
             "title": "Confusion Matrix",
             "type": "object"
           },
@@ -3444,6 +3792,7 @@
                 "type": "null"
               }
             ],
+            "description": "Mean cross-entropy loss over the window; null when unavailable.",
             "title": "Log Loss"
           },
           "macro_f1": {
@@ -3455,9 +3804,11 @@
                 "type": "null"
               }
             ],
+            "description": "Unweighted mean F1 across classes in `[0, 1]`; null when unavailable.",
             "title": "Macro F1"
           },
           "n": {
+            "description": "Number of resolved predictions in the window.",
             "title": "N",
             "type": "integer"
           },
@@ -3470,6 +3821,7 @@
                 "type": "null"
               }
             ],
+            "description": "Top-1 argmax accuracy in `[0, 1]`; null when unavailable.",
             "title": "Top1 Accuracy"
           }
         },
@@ -3480,6 +3832,7 @@
         "type": "object"
       },
       "NextFomcUpcomingMeeting": {
+        "description": "Lightweight descriptor of the upcoming meeting the headline targets.",
         "properties": {
           "days_until": {
             "anyOf": [
@@ -3490,13 +3843,16 @@
                 "type": "null"
               }
             ],
+            "description": "Calendar days from today to `meeting_date`; null when unavailable.",
             "title": "Days Until"
           },
           "meeting_date": {
+            "description": "ISO `YYYY-MM-DD` date of the next FOMC meeting.",
             "title": "Meeting Date",
             "type": "string"
           },
           "meeting_type": {
+            "description": "Meeting type label, e.g. `scheduled`.",
             "title": "Meeting Type",
             "type": "string"
           },
@@ -3509,6 +3865,7 @@
                 "type": "null"
               }
             ],
+            "description": "ISO date the statement is expected; null when not yet scheduled.",
             "title": "Statement Release Date"
           }
         },
@@ -3597,16 +3954,20 @@
         "type": "object"
       },
       "PredictionResponse": {
+        "description": "Point forecast emitted by the forecaster head for the chosen horizon.\nConfidence bands and the underlying trajectory are exposed separately in\n``ForecastSeriesResponse``; this object only carries the headline scalars.",
         "properties": {
           "close": {
+            "description": "Forecasted adjusted close at the end of the horizon, in the ticker's native currency.",
             "title": "Close",
             "type": "number"
           },
           "horizon": {
+            "description": "Horizon label this forecast applies to, e.g. `1d`, `3d`, `5d` trading sessions ahead.",
             "title": "Horizon",
             "type": "string"
           },
           "volatility": {
+            "description": "Forecasted realised volatility at the end of the horizon, in the same units as `market.volatility_5d`.",
             "title": "Volatility",
             "type": "number"
           }
@@ -3719,12 +4080,15 @@
         "type": "object"
       },
       "RealisedOutcomeBlock": {
+        "description": "Replay-mode reveal block \u2014 what actually happened forward of\n`as_of_date` for each tracked horizon. Surfaced only when the request\nset `as_of_date` and the forward bars are on disk.",
         "properties": {
           "as_of_date": {
+            "description": "ISO `YYYY-MM-DD` replay anchor the realised outcomes are measured forward of.",
             "title": "As Of Date",
             "type": "string"
           },
           "horizons": {
+            "description": "Per-horizon realised outcomes ordered ascending by `horizon`.",
             "items": {
               "$ref": "#/components/schemas/RealisedOutcomeHorizon"
             },
@@ -3732,6 +4096,7 @@
             "type": "array"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the realised series was pulled for.",
             "title": "Symbol",
             "type": "string"
           }
@@ -3756,6 +4121,7 @@
                 "type": "null"
               }
             ],
+            "description": "Realised adjusted close at t+h in the ticker's native currency.",
             "title": "Close"
           },
           "date": {
@@ -3767,9 +4133,11 @@
                 "type": "null"
               }
             ],
+            "description": "ISO `YYYY-MM-DD` of the trading session at t+h; null when the forward bar is unavailable.",
             "title": "Date"
           },
           "horizon": {
+            "description": "Trading-day horizon offset from the replay anchor, e.g. 1, 3, 5.",
             "title": "Horizon",
             "type": "integer"
           },
@@ -3782,6 +4150,7 @@
                 "type": "null"
               }
             ],
+            "description": "Realised log return from anchor close to t+h close; null when forward data is missing.",
             "title": "Log Return"
           },
           "realised_volatility_5d_post_event": {
@@ -3793,6 +4162,7 @@
                 "type": "null"
               }
             ],
+            "description": "Rolling 5-bar realised volatility ending at t+h, measured strictly post-event.",
             "title": "Realised Volatility 5D Post Event"
           }
         },
@@ -3817,9 +4187,11 @@
                 "type": "null"
               }
             ],
+            "description": "Per-day walk-forward h=1 conformal bands for the sparkline; null when unavailable.",
             "title": "Historical Bands"
           },
           "history": {
+            "description": "Last-60d realised RV history aligned to `history_dates`.",
             "items": {
               "type": "number"
             },
@@ -3827,6 +4199,7 @@
             "type": "array"
           },
           "history_dates": {
+            "description": "ISO dates aligned to `history` entries, oldest-first.",
             "items": {
               "type": "string"
             },
@@ -3834,6 +4207,7 @@
             "type": "array"
           },
           "horizons": {
+            "description": "Per-horizon point + conformal-band forecasts ordered ascending by `h`.",
             "items": {
               "$ref": "#/components/schemas/RealizedVolHorizonForecast"
             },
@@ -3841,6 +4215,7 @@
             "type": "array"
           },
           "model_revision": {
+            "description": "Model revision identifier the forecast was produced under.",
             "title": "Model Revision",
             "type": "string"
           },
@@ -3853,14 +4228,17 @@
                 "type": "null"
               }
             ],
+            "description": "ISO date of the most-recent intraday session the live measures were reduced from; null when the head fell back to training_means.",
             "title": "Realized Features Date"
           },
           "realized_features_source": {
             "default": "training_means",
+            "description": "`live` when intraday-derived measures filled the QLIKE head; `training_means` when the head fell back to feat_mean.",
             "title": "Realized Features Source",
             "type": "string"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the RV forecast was produced for.",
             "title": "Symbol",
             "type": "string"
           }
@@ -3877,14 +4255,17 @@
         "description": "Single walk-forward h=1 conformal band aligned to a realized day.\n\nRenders behind the realized sparkline so the card shows the band\nactually covered each day's outcome.",
         "properties": {
           "band_hi_80": {
+            "description": "Upper edge of the 80% conformal band at this session in RV units.",
             "title": "Band Hi 80",
             "type": "number"
           },
           "band_lo_80": {
+            "description": "Lower edge of the 80% conformal band at this session in RV units.",
             "title": "Band Lo 80",
             "type": "number"
           },
           "date": {
+            "description": "ISO `YYYY-MM-DD` of the trading session this band targeted.",
             "title": "Date",
             "type": "string"
           },
@@ -3897,6 +4278,7 @@
                 "type": "null"
               }
             ],
+            "description": "Realised RV on this session; null when the bar is unavailable.",
             "title": "Realized Rv"
           }
         },
@@ -3912,18 +4294,22 @@
         "description": "Banded RV forecast for one horizon (1, 5, or 22 trading days).\n\n``point`` and the four ``band_*`` numbers are RV (variance) units, not\nlog-RV. ``qlike_model`` / ``qlike_har`` are the pooled walk-forward\nQLIKE losses (lower is better); the card surfaces the gain as a\nbeat-HAR badge. ``coverage_empirical_90`` is the prospective empirical\ncoverage of the 90% conformal band, for the calibration chip.",
         "properties": {
           "band_hi_80": {
+            "description": "Upper edge of the 80% conformal band on `point` in RV units.",
             "title": "Band Hi 80",
             "type": "number"
           },
           "band_hi_90": {
+            "description": "Upper edge of the 90% conformal band on `point` in RV units.",
             "title": "Band Hi 90",
             "type": "number"
           },
           "band_lo_80": {
+            "description": "Lower edge of the 80% conformal band on `point` in RV units.",
             "title": "Band Lo 80",
             "type": "number"
           },
           "band_lo_90": {
+            "description": "Lower edge of the 90% conformal band on `point` in RV units.",
             "title": "Band Lo 90",
             "type": "number"
           },
@@ -3936,13 +4322,16 @@
                 "type": "null"
               }
             ],
+            "description": "Prospective empirical coverage of the 90% band in `[0, 1]`; null when unavailable.",
             "title": "Coverage Empirical 90"
           },
           "h": {
+            "description": "Forecast horizon in trading days, e.g. 1, 5, or 22.",
             "title": "H",
             "type": "integer"
           },
           "point": {
+            "description": "Point forecast of realized variance at horizon h.",
             "title": "Point",
             "type": "number"
           },
@@ -3955,6 +4344,7 @@
                 "type": "null"
               }
             ],
+            "description": "Pooled walk-forward QLIKE loss for HAR-OLS at this horizon (baseline); null when unavailable.",
             "title": "Qlike Har"
           },
           "qlike_model": {
@@ -3966,6 +4356,7 @@
                 "type": "null"
               }
             ],
+            "description": "Pooled walk-forward QLIKE loss for the model at this horizon (lower is better); null when unavailable.",
             "title": "Qlike Model"
           }
         },
@@ -3984,6 +4375,7 @@
         "description": "Calibrated prediction-set output from the vol-regime classifier (#216).\n\nSurfaces the conformal APS set on the /analyze response. ``predicted_set``\nholds the class labels the calibrated threshold admits at the\n``coverage`` level; ``set_label`` is the UI-friendly bracketed string;\n``distribution`` is the raw per-class softmax for the inference row so\nthe frontend can render a bar chart alongside the set chips.\n\nPopulated only when the active checkpoint is classification-mode AND\na sibling ``.conformal.json`` manifest with ``softmax_quantile`` exists.\nPre-#216 regression-only checkpoints leave the field as ``None`` on\nthe response and the legacy uncalibrated max-softmax stays on the\n``sentiment`` block.",
         "properties": {
           "argmax_class": {
+            "description": "Argmax regime label drawn from `distribution`; one of calm/normal/high.",
             "title": "Argmax Class",
             "type": "string"
           },
@@ -3998,6 +4390,7 @@
             "type": "string"
           },
           "coverage": {
+            "description": "Nominal coverage of the conformal APS set in `(0, 1)`.",
             "title": "Coverage",
             "type": "number"
           },
@@ -4005,6 +4398,7 @@
             "additionalProperties": {
               "type": "number"
             },
+            "description": "Per-class softmax probabilities over the regime labels for the inference row.",
             "title": "Distribution",
             "type": "object"
           },
@@ -4045,6 +4439,7 @@
             "title": "Log Rv Upper"
           },
           "predicted_set": {
+            "description": "Calibrated APS prediction set of regime labels admitted at the `coverage` level.",
             "items": {
               "type": "string"
             },
@@ -4052,10 +4447,12 @@
             "type": "array"
           },
           "set_label": {
+            "description": "UI-friendly bracketed label of the prediction set, e.g. `{calm, normal}`.",
             "title": "Set Label",
             "type": "string"
           },
           "set_size": {
+            "description": "Cardinality of `predicted_set`; ranges 1-3 for the 3-class regime head.",
             "title": "Set Size",
             "type": "integer"
           }
@@ -4095,9 +4492,11 @@
                 "type": "null"
               }
             ],
+            "description": "Lower edge of the symmetric conformal interval at `coverage`; null when no sidecar is on disk.",
             "title": "Log Rv Lower"
           },
           "log_rv_point": {
+            "description": "Regression-head point prediction in standardised log(forward realized vol) space.",
             "title": "Log Rv Point",
             "type": "number"
           },
@@ -4110,6 +4509,7 @@
                 "type": "null"
               }
             ],
+            "description": "Upper edge of the symmetric conformal interval at `coverage`; null when no sidecar is on disk.",
             "title": "Log Rv Upper"
           }
         },
@@ -4123,11 +4523,13 @@
         "description": "Replay-mode metadata for the /analyze response.\n\nPopulated only when the request set ``as_of_date``. ``fold_id`` is\nthe walk-forward fold whose checkpoint served this prediction;\n``train_end`` is the latest date the model saw at training time --\neverything strictly after that is unseen ground truth from the\nmodel's point of view. ``classifier_rewind`` flags that the\ntext-encoder weights are NOT rewound to ``as_of_date`` (the\nDAPT-pinned encoder is post-X), so any text-conditioned head is\nserved with later-than-X weights -- documented as a known caveat\nrather than silently leaked.",
         "properties": {
           "as_of_date": {
+            "description": "ISO `YYYY-MM-DD` replay anchor echoed from the request.",
             "title": "As Of Date",
             "type": "string"
           },
           "classifier_rewind": {
             "default": false,
+            "description": "True when the text-encoder weights are also rewound to `as_of_date`; false flags the known DAPT-pinned caveat.",
             "title": "Classifier Rewind",
             "type": "boolean"
           },
@@ -4140,14 +4542,17 @@
                 "type": "null"
               }
             ],
+            "description": "Walk-forward fold identifier whose checkpoint served this prediction; null when no fold matched.",
             "title": "Fold Id"
           },
           "forecaster_checkpoint_rewound": {
             "default": false,
+            "description": "True once the forecaster is wired to load the per-fold checkpoint identified by `fold_id`; false flags the scaffolding-only state.",
             "title": "Forecaster Checkpoint Rewound",
             "type": "boolean"
           },
           "notes": {
+            "description": "Free-text advisories on the replay run, e.g. caveats about partial rewind.",
             "items": {
               "type": "string"
             },
@@ -4163,6 +4568,7 @@
                 "type": "null"
               }
             ],
+            "description": "Latest date the fold's training slice contained; everything after is unseen by the model.",
             "title": "Train End"
           }
         },
@@ -4173,19 +4579,24 @@
         "type": "object"
       },
       "ResearchArtifactsResponse": {
+        "description": "Aggregate research-page envelope: artifact file index plus the\nbake-off / validity / cross-bank-transfer sections.",
         "properties": {
           "artifacts_root": {
+            "description": "Absolute path of the `data/artifacts/` root the listing was taken from.",
             "title": "Artifacts Root",
             "type": "string"
           },
           "cross_bank_transfer": {
-            "$ref": "#/components/schemas/CrossBankTransferSection"
+            "$ref": "#/components/schemas/CrossBankTransferSection",
+            "description": "Cross-bank transfer matrix across the six covered central banks."
           },
           "encoder_axis_stance": {
-            "$ref": "#/components/schemas/EncoderAxisStanceSection"
+            "$ref": "#/components/schemas/EncoderAxisStanceSection",
+            "description": "Validity-study table for the stance axis."
           },
           "encoder_bakeoff": {
-            "$ref": "#/components/schemas/EncoderBakeoffSection"
+            "$ref": "#/components/schemas/EncoderBakeoffSection",
+            "description": "Encoder bake-off table on the canonical seed set."
           },
           "sections": {
             "additionalProperties": {
@@ -4194,6 +4605,7 @@
               },
               "type": "array"
             },
+            "description": "Mapping from section name to its artifact file index.",
             "title": "Sections",
             "type": "object"
           }
@@ -4208,6 +4620,7 @@
         "type": "object"
       },
       "ResearchRegistryBaseline": {
+        "description": "No-text baseline reference row for the encoder registry.",
         "properties": {
           "cls_f1": {
             "anyOf": [
@@ -4218,6 +4631,7 @@
                 "type": "null"
               }
             ],
+            "description": "Baseline macro-F1 on the classification-only surface; null when not recorded.",
             "title": "Cls F1"
           },
           "dual_f1": {
@@ -4229,9 +4643,11 @@
                 "type": "null"
               }
             ],
+            "description": "Baseline macro-F1 on the dual-head surface; null when not recorded.",
             "title": "Dual F1"
           },
           "label": {
+            "description": "Label of the no-text baseline, e.g. `market_only`.",
             "title": "Label",
             "type": "string"
           },
@@ -4244,6 +4660,7 @@
                 "type": "null"
               }
             ],
+            "description": "Baseline macro-F1 on the regression-only surface; null when not recorded.",
             "title": "Regression F1"
           }
         },
@@ -4257,6 +4674,7 @@
         "description": "Quant-facing encoder registry response (\u00a76.41 manifest).\n\nFiltered by default to non-negative \u0394 on the requested surface so\nthe dashboard does not surface negative-lift encoders. Use\n?include_rejected=true to see the full table including nulls and\nnegatives.",
         "properties": {
           "available": {
+            "description": "True when a registry manifest was found on disk.",
             "title": "Available",
             "type": "boolean"
           },
@@ -4268,19 +4686,23 @@
               {
                 "type": "null"
               }
-            ]
+            ],
+            "description": "Reference no-text baseline row; null when not recorded."
           },
           "head": {
             "default": "",
+            "description": "Head identifier within the package the rows were computed on.",
             "title": "Head",
             "type": "string"
           },
           "rejected_count": {
             "default": 0,
+            "description": "Number of rows filtered out for negative or null lift.",
             "title": "Rejected Count",
             "type": "integer"
           },
           "rows": {
+            "description": "Per-encoder registry rows after filtering on lift sign.",
             "items": {
               "$ref": "#/components/schemas/ResearchRegistryRow"
             },
@@ -4288,6 +4710,7 @@
             "type": "array"
           },
           "seeds": {
+            "description": "Seed set the registry rows were averaged across.",
             "items": {
               "type": "integer"
             },
@@ -4296,10 +4719,12 @@
           },
           "source_wiki_section": {
             "default": "",
+            "description": "Wiki section identifier the registry sources its baseline from.",
             "title": "Source Wiki Section",
             "type": "string"
           },
           "surface": {
+            "description": "Which head surface the lift is computed on: `dual` or `cls`.",
             "enum": [
               "dual",
               "cls"
@@ -4309,6 +4734,7 @@
           },
           "training_package_id": {
             "default": "",
+            "description": "Training package ID the registry was assembled from.",
             "title": "Training Package Id",
             "type": "string"
           }
@@ -4321,6 +4747,7 @@
         "type": "object"
       },
       "ResearchRegistryRow": {
+        "description": "One encoder's row in the registry table comparing it to the no-text baseline.",
         "properties": {
           "cache_uri": {
             "anyOf": [
@@ -4343,6 +4770,7 @@
                 "type": "null"
               }
             ],
+            "description": "Path of the encoder checkpoint relative to the models directory; null when not published.",
             "title": "Checkpoint Relpath"
           },
           "cls_f1": {
@@ -4354,6 +4782,7 @@
                 "type": "null"
               }
             ],
+            "description": "Encoder macro-F1 on the classification-only surface; null when not recorded.",
             "title": "Cls F1"
           },
           "delta_cls": {
@@ -4389,13 +4818,16 @@
                 "type": "null"
               }
             ],
+            "description": "Encoder macro-F1 on the dual-head surface; null when not recorded.",
             "title": "Dual F1"
           },
           "encoder_alias": {
+            "description": "Registry alias of the encoder being compared.",
             "title": "Encoder Alias",
             "type": "string"
           },
           "encoder_display": {
+            "description": "Display name of the encoder for UI rendering.",
             "title": "Encoder Display",
             "type": "string"
           },
@@ -4407,6 +4839,7 @@
           },
           "notes": {
             "default": "",
+            "description": "Free-text notes for the row, e.g. caveats; empty when none.",
             "title": "Notes",
             "type": "string"
           },
@@ -4419,6 +4852,7 @@
                 "type": "null"
               }
             ],
+            "description": "Encoder macro-F1 on the regression-only surface; null when not recorded.",
             "title": "Regression F1"
           }
         },
@@ -4441,6 +4875,7 @@
                 "type": "null"
               }
             ],
+            "description": "Fraction of resolved rows whose realised RV landed inside the 80% band; null when none resolved.",
             "title": "Empirical Coverage 80"
           },
           "empirical_coverage_90": {
@@ -4452,28 +4887,34 @@
                 "type": "null"
               }
             ],
+            "description": "Fraction of resolved rows whose realised RV landed inside the 90% band; null when none resolved.",
             "title": "Empirical Coverage 90"
           },
           "nominal_coverage_80": {
             "default": 0.8,
+            "description": "Calibration target for the 80% band, pinned to 0.80.",
             "title": "Nominal Coverage 80",
             "type": "number"
           },
           "nominal_coverage_90": {
             "default": 0.9,
+            "description": "Calibration target for the 90% band, pinned to 0.90.",
             "title": "Nominal Coverage 90",
             "type": "number"
           },
           "pending_runs": {
             "default": 0,
+            "description": "Rows that could not be scored because the event sits in the HAR warmup or beyond available RV history.",
             "title": "Pending Runs",
             "type": "integer"
           },
           "resolved_runs": {
+            "description": "Number of rows with realised RV on the predicted bar.",
             "title": "Resolved Runs",
             "type": "integer"
           },
           "total_runs": {
+            "description": "Total rows in the backtest window regardless of resolution.",
             "title": "Total Runs",
             "type": "integer"
           }
@@ -4489,17 +4930,21 @@
         "description": "Response wire shape for ``GET /forecast/rv-backtest``.\n\nWalks the last N persisted ^GSPC analyze runs and reports the\nQLIKE-RV h=1 point forecast + 80% / 90% bands against the realized\nRV on the same bar. Drives the RvAccuracyPanel card alongside the\nHAR-tercile accuracy surface.",
         "properties": {
           "coverage": {
-            "$ref": "#/components/schemas/RvBacktestCoverage"
+            "$ref": "#/components/schemas/RvBacktestCoverage",
+            "description": "Aggregate empirical-vs-nominal coverage across the rows."
           },
           "generated_at": {
+            "description": "ISO-8601 UTC timestamp the response was generated at.",
             "title": "Generated At",
             "type": "string"
           },
           "horizon": {
+            "description": "Forward horizon in trading days the bands were calibrated for (h=1).",
             "title": "Horizon",
             "type": "integer"
           },
           "rows": {
+            "description": "Per-event RV backtest rows ordered by `event_date`.",
             "items": {
               "$ref": "#/components/schemas/RvBacktestRow"
             },
@@ -4507,6 +4952,7 @@
             "type": "array"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker the RV backtest was run against.",
             "title": "Symbol",
             "type": "string"
           }
@@ -4533,6 +4979,7 @@
                 "type": "null"
               }
             ],
+            "description": "Upper edge of the 80% conformal band; null on pending rows.",
             "title": "Band Hi 80"
           },
           "band_hi_90": {
@@ -4544,6 +4991,7 @@
                 "type": "null"
               }
             ],
+            "description": "Upper edge of the 90% conformal band; null on pending rows.",
             "title": "Band Hi 90"
           },
           "band_lo_80": {
@@ -4555,6 +5003,7 @@
                 "type": "null"
               }
             ],
+            "description": "Lower edge of the 80% conformal band; null on pending rows.",
             "title": "Band Lo 80"
           },
           "band_lo_90": {
@@ -4566,9 +5015,11 @@
                 "type": "null"
               }
             ],
+            "description": "Lower edge of the 90% conformal band; null on pending rows.",
             "title": "Band Lo 90"
           },
           "event_date": {
+            "description": "ISO `YYYY-MM-DD` event date the row was anchored to.",
             "title": "Event Date",
             "type": "string"
           },
@@ -4581,6 +5032,7 @@
                 "type": "null"
               }
             ],
+            "description": "True when `realized_rv` lies inside the 80% band; null when realised RV is unresolved.",
             "title": "In Band 80"
           },
           "in_band_90": {
@@ -4592,6 +5044,7 @@
                 "type": "null"
               }
             ],
+            "description": "True when `realized_rv` lies inside the 90% band; null when realised RV is unresolved.",
             "title": "In Band 90"
           },
           "point_forecast_rv": {
@@ -4603,6 +5056,7 @@
                 "type": "null"
               }
             ],
+            "description": "h=1 point forecast of realised variance; null on pending rows inside the HAR warmup or beyond RV history.",
             "title": "Point Forecast Rv"
           },
           "realized_rv": {
@@ -4614,6 +5068,7 @@
                 "type": "null"
               }
             ],
+            "description": "Realised RV on the predicted bar; null when the bar is unresolved.",
             "title": "Realized Rv"
           }
         },
@@ -4649,10 +5104,12 @@
         "description": "Semantic diff between the current statement and its prior.\n\nDescriptive panel \u2014 the spans and topic deltas are post-hoc\nexplanations of the realized text change and never feed the\nforecast surface.\n\n``status`` carries a parseable signal for the panel to surface\nan informational banner when the service could not produce a\nmeaningful diff (empty / near-empty / non-Latin input, or no\nstrict-prior on file). The field is optional and defaults to\n``None`` for backward compatibility \u2014 older clients that ignore\nit still see the same empty-list cold-start shape they used to.",
         "properties": {
           "current_date": {
+            "description": "ISO `YYYY-MM-DD` event date of the current statement.",
             "title": "Current Date",
             "type": "string"
           },
           "prior_date": {
+            "description": "ISO `YYYY-MM-DD` event date of the strict-prior statement on file; empty when none.",
             "title": "Prior Date",
             "type": "string"
           },
@@ -4671,13 +5128,16 @@
                 "type": "null"
               }
             ],
+            "description": "Parseable status flag for the panel banner; null on legacy responses that pre-date the field.",
             "title": "Status"
           },
           "summary": {
+            "description": "Short human-readable summary of the diff, e.g. headline phrase changes.",
             "title": "Summary",
             "type": "string"
           },
           "token_spans": {
+            "description": "Token-aligned span sequence between the two statements in current-statement order.",
             "items": {
               "$ref": "#/components/schemas/SemanticDiffSpan"
             },
@@ -4685,6 +5145,7 @@
             "type": "array"
           },
           "topic_deltas": {
+            "description": "Topic-emphasis delta rows ordered by absolute delta magnitude.",
             "items": {
               "$ref": "#/components/schemas/SemanticDiffTopic"
             },
@@ -4706,6 +5167,7 @@
         "description": "One token-aligned span of the current-vs-prior statement diff.\n\n``kind`` is the alignment bucket; ``paired_text`` carries the\nmatched span on the opposite side for ``substituted`` (and\noptionally for ``added`` / ``removed`` if the aligner emitted a\nnear-match neighbour).",
         "properties": {
           "kind": {
+            "description": "Alignment bucket of this span vs the prior statement.",
             "enum": [
               "unchanged",
               "added",
@@ -4724,9 +5186,11 @@
                 "type": "null"
               }
             ],
+            "description": "Matched span on the prior-statement side for `substituted` kinds; null when no near-match neighbour was emitted.",
             "title": "Paired Text"
           },
           "text": {
+            "description": "Surface text of the span on the current-statement side.",
             "title": "Text",
             "type": "string"
           }
@@ -4742,18 +5206,22 @@
         "description": "Topic-level emphasis delta across the two statements.\n\n``prior_emphasis`` and ``current_emphasis`` are the topic-share\nmasses in [0, 1]; ``delta`` = current - prior. ``sample_phrases``\nare the highest-loading n-grams the panel surfaces alongside the\nbar.",
         "properties": {
           "current_emphasis": {
+            "description": "Topic-share mass in the current statement in `[0, 1]`.",
             "title": "Current Emphasis",
             "type": "number"
           },
           "delta": {
+            "description": "Signed delta = current_emphasis - prior_emphasis.",
             "title": "Delta",
             "type": "number"
           },
           "prior_emphasis": {
+            "description": "Topic-share mass in the prior statement in `[0, 1]`.",
             "title": "Prior Emphasis",
             "type": "number"
           },
           "sample_phrases": {
+            "description": "Highest-loading n-grams the panel surfaces alongside the topic bar.",
             "items": {
               "type": "string"
             },
@@ -4761,6 +5229,7 @@
             "type": "array"
           },
           "topic": {
+            "description": "Topic identifier from the topic model used for the diff.",
             "title": "Topic",
             "type": "string"
           }
@@ -4775,6 +5244,7 @@
         "type": "object"
       },
       "SentimentResponse": {
+        "description": "Sentence-aggregated stance label for the FOMC excerpt plus an\nout-of-distribution chip so callers can tell when the input lies\noutside the corpus the head was trained on.",
         "properties": {
           "is_in_distribution": {
             "anyOf": [
@@ -4785,9 +5255,11 @@
                 "type": "null"
               }
             ],
+            "description": "`true` when `ood_energy <= ood_threshold`, i.e. the input embedding lies near the FOMC training distribution and the stance label is trustworthy. `false` flags off-domain inputs whose stance label should be ignored. `null` when no manifest is present.",
             "title": "Is In Distribution"
           },
           "label": {
+            "description": "Aggregated stance label across the input text. One of `hawkish`, `dovish`, `neutral`, or `UNKNOWN` when the input was empty / non-Latin / too short to score.",
             "title": "Label",
             "type": "string"
           },
@@ -4800,6 +5272,7 @@
                 "type": "null"
               }
             ],
+            "description": "OOD score for the input text. Carries the **Mahalanobis distance** to the nearest class centroid in the encoder's CLS embedding space when the active detector is the Lee et al. NeurIPS 2018 manifest (`forecaster_best.ood_mahalanobis.json`). Falls back to the Liu et al. NeurIPS 2020 free-energy score `E(x) = -T * logsumexp(logits / T)` when only the legacy manifest (`forecaster_best.ood.json`) is on disk. `null` when no calibration manifest is present. Lower means closer to the training distribution.",
             "title": "Ood Energy"
           },
           "ood_threshold": {
@@ -4811,9 +5284,11 @@
                 "type": "null"
               }
             ],
+            "description": "Calibrated in-distribution ceiling, set at the 95th percentile of training-corpus scores during calibration. Inputs above this score flag out-of-distribution. `null` when no manifest is present.",
             "title": "Ood Threshold"
           },
           "raw": {
+            "description": "Per-class probabilities from the underlying classifier before label selection. Each entry is `{label: str, score: float}`.",
             "items": {
               "additionalProperties": {
                 "anyOf": [
@@ -4831,6 +5306,7 @@
             "type": "array"
           },
           "score": {
+            "description": "Probability of the predicted `label` after chunk-level aggregation. In `[0, 1]`.",
             "title": "Score",
             "type": "number"
           }
@@ -4855,6 +5331,7 @@
                 "type": "null"
               }
             ],
+            "description": "True when a sibling conformal calibration sidecar is on disk; null on inactive rows.",
             "title": "Conformal Sidecar Present"
           },
           "encoder_alias": {
@@ -4866,9 +5343,11 @@
                 "type": "null"
               }
             ],
+            "description": "Registry alias of the encoder backing this checkpoint; null on inactive rows.",
             "title": "Encoder Alias"
           },
           "filename": {
+            "description": "Bare filename of the checkpoint under `backend/models/`.",
             "title": "Filename",
             "type": "string"
           },
@@ -4881,14 +5360,17 @@
                 "type": "null"
               }
             ],
+            "description": "`present` when a contract sidecar exists, `sidecar_absent` for legacy checkpoints.",
             "title": "Inference Contract Status"
           },
           "is_active": {
             "default": false,
+            "description": "True when the active service is currently loaded from this file.",
             "title": "Is Active",
             "type": "boolean"
           },
           "modified_at": {
+            "description": "ISO-8601 UTC mtime of the checkpoint file.",
             "title": "Modified At",
             "type": "string"
           },
@@ -4901,9 +5383,11 @@
                 "type": "null"
               }
             ],
+            "description": "Output mode declared by the active checkpoint (e.g. classification/regression/dual); null on inactive rows.",
             "title": "Output Mode"
           },
           "relative_path": {
+            "description": "Path of the checkpoint relative to the models directory.",
             "title": "Relative Path",
             "type": "string"
           },
@@ -4916,9 +5400,11 @@
                 "type": "null"
               }
             ],
+            "description": "HF Hub `owner/name` slug when `source == hf_cache`; null otherwise.",
             "title": "Repo"
           },
           "required_kwargs": {
+            "description": "Inference kwargs declared in the checkpoint's contract sidecar; empty for legacy artefacts.",
             "items": {
               "type": "string"
             },
@@ -4934,13 +5420,16 @@
                 "type": "null"
               }
             ],
+            "description": "Pinned HF commit hash when known; empty/null for unpinned artefacts.",
             "title": "Revision"
           },
           "role": {
+            "description": "Inferred role: forecaster / multi_axis / lora / calibration.",
             "title": "Role",
             "type": "string"
           },
           "size_bytes": {
+            "description": "File size in bytes as reported by the filesystem.",
             "title": "Size Bytes",
             "type": "integer"
           },
@@ -4953,10 +5442,12 @@
                 "type": "null"
               }
             ],
+            "description": "Absolute path inside the HF cache the file resolves to; null when `source == models_dir`.",
             "title": "Snapshot Path"
           },
           "source": {
             "default": "models_dir",
+            "description": "Origin of the file on disk: `models_dir` for the host-mounted directory or `hf_cache` for HF snapshot cache.",
             "title": "Source",
             "type": "string"
           },
@@ -4964,6 +5455,7 @@
             "additionalProperties": {
               "type": "boolean"
             },
+            "description": "Mapping from declared kwarg name to whether the live serving wiring supplies it.",
             "title": "Supplied At Inference",
             "type": "object"
           }
@@ -4979,8 +5471,10 @@
         "type": "object"
       },
       "SettingsCheckpointsResponse": {
+        "description": "Response envelope for the settings-page checkpoint inventory.",
         "properties": {
           "checkpoints": {
+            "description": "One entry per checkpoint file discovered under the models directory or HF cache.",
             "items": {
               "$ref": "#/components/schemas/SettingsCheckpoint"
             },
@@ -4988,6 +5482,7 @@
             "type": "array"
           },
           "models_dir": {
+            "description": "Absolute path of the host-mounted `backend/models/` directory.",
             "title": "Models Dir",
             "type": "string"
           }
@@ -5003,10 +5498,12 @@
         "description": "One historical (date, score) pair for the rolling z-score baseline.",
         "properties": {
           "document_date": {
+            "description": "ISO `YYYY-MM-DD` event date of the historical FOMC row.",
             "title": "Document Date",
             "type": "string"
           },
           "stance_score": {
+            "description": "Signed stance score `P(hawkish) - P(dovish)` for the historical row.",
             "title": "Stance Score",
             "type": "number"
           }
@@ -5022,6 +5519,7 @@
         "description": "Trailing stance-score summary for the dashboard tile.\n\n``stance_score = P(hawkish) - P(dovish)`` per the validity study;\nthe tile renders the current run as a z-score against this trailing\nmean/std rather than as a raw absolute number. ``mean`` and ``std``\nare ``null`` when fewer than two usable historical rows are found,\nin which case the tile falls back to the raw-value rendering.",
         "properties": {
           "history": {
+            "description": "Historical (date, score) pairs ordered oldest-first.",
             "items": {
               "$ref": "#/components/schemas/StanceContextPoint"
             },
@@ -5037,9 +5535,11 @@
                 "type": "null"
               }
             ],
+            "description": "Trailing mean of `stance_score`; null when fewer than two rows are usable.",
             "title": "Mean"
           },
           "n": {
+            "description": "Number of usable historical rows in `history`.",
             "title": "N",
             "type": "integer"
           },
@@ -5052,6 +5552,7 @@
                 "type": "null"
               }
             ],
+            "description": "Trailing sample standard deviation of `stance_score`; null when fewer than two rows are usable.",
             "title": "Std"
           }
         },
@@ -5065,20 +5566,25 @@
         "type": "object"
       },
       "SymbolDescriptor": {
+        "description": "One entry in the supported-symbols registry served to the asset picker.",
         "properties": {
           "category": {
+            "description": "Category bucket the symbol falls into, e.g. `equity_index`, `currency`, `rates`.",
             "title": "Category",
             "type": "string"
           },
           "default_horizon": {
+            "description": "Default forecast horizon label paired with this symbol on the workspace.",
             "title": "Default Horizon",
             "type": "string"
           },
           "name": {
+            "description": "Human-readable name of the instrument shown in the picker.",
             "title": "Name",
             "type": "string"
           },
           "symbol": {
+            "description": "Yahoo Finance ticker, e.g. `^GSPC` or `DX-Y.NYB`.",
             "title": "Symbol",
             "type": "string"
           }
@@ -5093,8 +5599,10 @@
         "type": "object"
       },
       "SymbolListResponse": {
+        "description": "Response envelope for `GET /symbols`.",
         "properties": {
           "symbols": {
+            "description": "Supported symbols ordered for display in the picker.",
             "items": {
               "$ref": "#/components/schemas/SymbolDescriptor"
             },
@@ -5343,16 +5851,20 @@
         "type": "object"
       },
       "TransferMatrixCell": {
+        "description": "One source -> target cell in the cross-bank transfer matrix.",
         "properties": {
           "metric": {
+            "description": "Transfer metric value (e.g. macro-F1) on `target` after training on `source`.",
             "title": "Metric",
             "type": "number"
           },
           "source": {
+            "description": "Source bank short code the model was fine-tuned on.",
             "title": "Source",
             "type": "string"
           },
           "target": {
+            "description": "Target bank short code the model was evaluated on.",
             "title": "Target",
             "type": "string"
           }
@@ -5417,6 +5929,7 @@
                 "type": "null"
               }
             ],
+            "description": "Nominal conformal coverage (1 - alpha) for the APS set; null when no sidecar is on disk.",
             "title": "Coverage"
           },
           "log_rv_lower": {
@@ -5428,6 +5941,7 @@
                 "type": "null"
               }
             ],
+            "description": "Lower edge of the 80% conformal band on `log_rv_point`; null when no conformal sidecar is present.",
             "title": "Log Rv Lower"
           },
           "log_rv_point": {
@@ -5451,6 +5965,7 @@
                 "type": "null"
               }
             ],
+            "description": "Upper edge of the 80% conformal band on `log_rv_point`; null when no conformal sidecar is present.",
             "title": "Log Rv Upper"
           },
           "predicted_set": {
@@ -5485,14 +6000,17 @@
         "description": "One feature-family bar on a panel attribution chart (#297).\n\nEmitted under :class:`XaiPanelAttribution.families`. ``magnitude`` is\nthe L1 attribution sum across all features in the family (always\nnon-negative); ``signed`` is the sum-with-sign so the frontend can\ncolour the bar by direction.",
         "properties": {
           "family": {
+            "description": "Feature-family identifier (e.g., sentiment, rates, vol, calendar) grouping related input features.",
             "title": "Family",
             "type": "string"
           },
           "magnitude": {
+            "description": "L1 sum of attribution across features in this family; always non-negative.",
             "title": "Magnitude",
             "type": "number"
           },
           "signed": {
+            "description": "Signed sum of attribution across features in this family; sign indicates push direction.",
             "title": "Signed",
             "type": "number"
           }
@@ -5509,6 +6027,7 @@
         "description": "Integrated-gradients attribution for one /analyze panel (#297).\n\nReturned under :class:`XaiResponse.panels`. One entry per active\npanel (regime, rates_2y/5y/terminal, trajectory). ``unavailable``\nflips to True when the panel cannot be explained (panel not active\non the checkpoint, kwarg mismatch, runtime error); the frontend\nthen renders the \"explanation unavailable\" badge rather than an\nempty bar chart.",
         "properties": {
           "families": {
+            "description": "Per-feature-family attribution bars; empty when the panel could not be explained.",
             "items": {
               "$ref": "#/components/schemas/XaiFeatureFamilyAttribution"
             },
@@ -5522,6 +6041,7 @@
             "type": "integer"
           },
           "panel": {
+            "description": "Panel identifier this attribution covers, e.g. `regime`, `rates_2y`, `trajectory`.",
             "title": "Panel",
             "type": "string"
           },
@@ -5534,14 +6054,17 @@
                 "type": "null"
               }
             ],
+            "description": "Structured reason string when `unavailable` is true; null otherwise.",
             "title": "Reason"
           },
           "target": {
+            "description": "Target output the attribution explains, e.g. predicted class or scalar head name.",
             "title": "Target",
             "type": "string"
           },
           "unavailable": {
             "default": false,
+            "description": "True when the panel could not be explained; the frontend then shows an unavailable badge.",
             "title": "Unavailable",
             "type": "boolean"
           }
@@ -5554,13 +6077,16 @@
         "type": "object"
       },
       "XaiResponse": {
+        "description": "XAI envelope on the /analyze response \u2014 keyword-salience sentence\nattribution plus optional per-panel integrated-gradients bars when\nthe active checkpoint exposes explainable panels.",
         "properties": {
           "method": {
             "default": "keyword_salience_v1",
+            "description": "XAI method identifier for the sentence-level explainer.",
             "title": "Method",
             "type": "string"
           },
           "panels": {
+            "description": "Per-panel integrated-gradients attribution; populated when include_xai is true and the checkpoint surfaces at least one explainable panel.",
             "items": {
               "$ref": "#/components/schemas/XaiPanelAttribution"
             },
@@ -5568,6 +6094,7 @@
             "type": "array"
           },
           "sentences": {
+            "description": "Per-sentence salience scores with top contributing tokens, in document order.",
             "items": {
               "$ref": "#/components/schemas/XaiSentenceAttribution"
             },
@@ -5579,16 +6106,20 @@
         "type": "object"
       },
       "XaiSentenceAttribution": {
+        "description": "One input sentence with its salience score and top contributing tokens.\n\nReturned under :class:`XaiResponse.sentences` for the keyword-salience\nexplainer. Sentences are listed in original document order.",
         "properties": {
           "score": {
+            "description": "Salience score in [0,1] reflecting this sentence's influence on the prediction.",
             "title": "Score",
             "type": "number"
           },
           "text": {
+            "description": "Verbatim sentence text as segmented from the input statement.",
             "title": "Text",
             "type": "string"
           },
           "topTokens": {
+            "description": "Highest-weighted tokens within this sentence, descending by weight; empty when no tokens cross the threshold.",
             "items": {
               "$ref": "#/components/schemas/XaiTokenAttribution"
             },
@@ -5604,12 +6135,15 @@
         "type": "object"
       },
       "XaiTokenAttribution": {
+        "description": "One token's contribution to a sentence's salience score.\n\nEmitted under :class:`XaiSentenceAttribution.topTokens` so the\nfrontend can highlight the highest-weighted tokens inline.",
         "properties": {
           "token": {
+            "description": "Surface token (whitespace-stripped) drawn from the input text.",
             "title": "Token",
             "type": "string"
           },
           "weight": {
+            "description": "Salience weight in [0,1] indicating this token's share of the sentence score.",
             "title": "Weight",
             "type": "number"
           }


### PR DESCRIPTION
Pushes the OpenAPI description refresh from PR #671 into the deploy stream.

## What's in this push

- **#671** Swagger: refresh OOD descriptions + per-field prose across response models. 547 ``Field(description=...)`` annotations on 76 models; 32 class docstrings; ``SentimentResponse`` OOD fields now describe the active Mahalanobis path with the Lee et al. 2018 citation instead of the energy formula. ``tests/snapshots/openapi.json`` regenerated.
- ``ci.yml`` pytest step now reads ``secrets.HF_TOKEN`` so model-download steps authenticate against HF Hub instead of sharing the per-IP anonymous quota. Removes the 429-flake that hit every PR this session.

## Test plan

- [ ] CI green on this PR
- [ ] Post-deploy: ``curl https://fedpulse.yusufizzetmurat.com/api/openapi.json`` shows ``SentimentResponse.ood_energy.description`` starting with "OOD score" and mentioning Mahalanobis
- [ ] Visit ``https://fedpulse.yusufizzetmurat.com/api/docs`` for the screenshot