### PR TITLE
Workspace polish: analogs button, pipeline OOD line, form alignment

### DIFF
--- a/frontend/components/analyze/AnalyzeForm.tsx
+++ b/frontend/components/analyze/AnalyzeForm.tsx
@@ -75,9 +75,11 @@ export function AnalyzeForm({ value, onChange, onSubmit, loading, onSampleLoad }
             onChange={(text) => patch({ text })}
           />
 
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid items-end gap-4 md:grid-cols-3">
             <div className="space-y-2">
-              <Label htmlFor="date">Document date</Label>
+              <div className="flex items-center gap-1">
+                <Label htmlFor="date">Document date</Label>
+              </div>
               <Input
                 id="date"
                 type="date"

--- a/frontend/components/analyze/HistoricalAnalogPanel.tsx
+++ b/frontend/components/analyze/HistoricalAnalogPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { ChevronDown, ChevronUp, History, Sparkles } from "lucide-react";
+import { History, Sparkles } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import {
@@ -97,13 +97,7 @@ interface AnalogCardItemProps {
 }
 
 function AnalogCardItem({ card }: AnalogCardItemProps) {
-  const [expanded, setExpanded] = React.useState(false);
   const stance = stanceTone(card.axis_stance);
-  // The /analyze/analogs endpoint truncates to ~280 chars on the
-  // server; treat that ceiling as the "looks truncated" trigger so the
-  // expand affordance never appears on a short statement that's
-  // already fully rendered.
-  const looksTruncated = card.excerpt.length >= 280;
   return (
     <Card>
       <CardHeader className="pb-2">
@@ -126,34 +120,7 @@ function AnalogCardItem({ card }: AnalogCardItemProps) {
       </CardHeader>
       <CardContent className="space-y-3">
         <WhatHappenedNext bucket={card.subsequent_vol_regime} />
-        <div className="space-y-1">
-          <p
-            className={cn(
-              "text-xs leading-relaxed text-foreground/80",
-              expanded ? "" : "line-clamp-4",
-            )}
-          >
-            {card.excerpt}
-          </p>
-          {looksTruncated ? (
-            <button
-              type="button"
-              onClick={() => setExpanded((prev) => !prev)}
-              className="inline-flex items-center gap-1 text-[11px] font-medium text-muted-foreground hover:text-foreground focus:outline-none focus:ring-1 focus:ring-ring rounded-sm"
-              aria-expanded={expanded}
-            >
-              {expanded ? (
-                <>
-                  <ChevronUp className="h-3 w-3" /> Collapse
-                </>
-              ) : (
-                <>
-                  <ChevronDown className="h-3 w-3" /> Show full excerpt
-                </>
-              )}
-            </button>
-          ) : null}
-        </div>
+        <p className="text-xs leading-relaxed text-foreground/80">{card.excerpt}</p>
       </CardContent>
     </Card>
   );

--- a/frontend/components/analyze/PipelineTrace.tsx
+++ b/frontend/components/analyze/PipelineTrace.tsx
@@ -115,6 +115,9 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
   const regime = result.regime_classification;
   const encoderKey = (result.model as { encoder_key?: string } | undefined)?.encoder_key;
   const xaiSentences = result.xai?.sentences?.length ?? 0;
+  const oodEnergy = result.sentiment?.ood_energy ?? null;
+  const oodThreshold = result.sentiment?.ood_threshold ?? null;
+  const inDistribution = result.sentiment?.is_in_distribution ?? null;
 
   const ingestStep: Step = {
     key: "ingest",
@@ -153,10 +156,37 @@ function buildSteps({ result, inputText }: PipelineTraceProps): Step[] {
       ? `Model variant: ${friendlyEncoderName(encoderKey)}`
       : "Model variant: default",
     body: (
-      <p className="text-sm text-muted-foreground">
-        Model variant: <span className="numeric text-foreground">{encoderKey ?? "default"}</span>. No
-        OOD signal available.
-      </p>
+      <div className="space-y-1.5 text-sm text-muted-foreground">
+        <p>
+          Model variant: <span className="numeric text-foreground">{encoderKey ?? "default"}</span>.
+        </p>
+        {inDistribution === null ? (
+          <p>OOD signal not available on this checkpoint.</p>
+        ) : (
+          <p>
+            OOD check:{" "}
+            <span
+              className={
+                inDistribution
+                  ? "text-foreground numeric"
+                  : "text-hawkish numeric font-semibold"
+              }
+            >
+              {inDistribution ? "in-distribution" : "out-of-distribution"}
+            </span>
+            {oodEnergy !== null && oodThreshold !== null ? (
+              <>
+                {" "}
+                · Mahalanobis distance{" "}
+                <span className="numeric text-foreground">{oodEnergy.toFixed(1)}</span>{" "}
+                vs threshold{" "}
+                <span className="numeric text-foreground">{oodThreshold.toFixed(1)}</span>
+              </>
+            ) : null}
+            .
+          </p>
+        )}
+      </div>
     ),
   };
 

--- a/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
+++ b/frontend/tests/components/analyze/HistoricalAnalogPanel.test.tsx
@@ -136,17 +136,19 @@ describe("HistoricalAnalogPanel", () => {
     expect(screen.getByText(/40.0%/)).toBeInTheDocument();
   });
 
-  it("expands a long excerpt when the user clicks the toggle", () => {
-    // The endpoint truncates to ~280 chars; pad the fixture excerpt
-    // to the ceiling so the toggle button is rendered.
+  it("renders the excerpt straight through without an expand toggle", () => {
+    // The /analyze/analogs endpoint truncates excerpts to ~280
+    // characters on the server, so any "Show full excerpt" affordance
+    // would promise content that does not exist on the client. The
+    // panel renders the excerpt directly and never shows a toggle.
     const longCard = {
       event_date: "2018-12-19",
       similarity: 0.78,
       axis_stance: "hawkish" as const,
       subsequent_vol_regime: "high" as const,
-        subsequent_close_pct_5d: null,
-        subsequent_close_pct_20d: null,
-      excerpt: "x".repeat(280),
+      subsequent_close_pct_5d: null,
+      subsequent_close_pct_20d: null,
+      excerpt: "y".repeat(280),
     };
     render(
       <HistoricalAnalogPanel
@@ -157,36 +159,13 @@ describe("HistoricalAnalogPanel", () => {
         }}
       />,
     );
-    const toggle = screen.getByRole("button", { name: /Show full excerpt/i });
-    expect(toggle).toHaveAttribute("aria-expanded", "false");
-    fireEvent.click(toggle);
-    expect(
-      screen.getByRole("button", { name: /Collapse/i }),
-    ).toHaveAttribute("aria-expanded", "true");
-  });
-
-  it("does not show the expand toggle for short excerpts", () => {
-    const shortCard = {
-      event_date: "2014-06-18",
-      similarity: 0.62,
-      axis_stance: "neutral" as const,
-      subsequent_vol_regime: "normal" as const,
-        subsequent_close_pct_5d: null,
-        subsequent_close_pct_20d: null,
-      excerpt: "Short statement under the 280 ceiling.",
-    };
-    render(
-      <HistoricalAnalogPanel
-        analogs={{
-          analogs: [shortCard],
-          index_size: 8,
-          encoder_alias: "test",
-        }}
-      />,
-    );
     expect(
       screen.queryByRole("button", { name: /Show full excerpt/i }),
     ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Collapse/i }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("y".repeat(280))).toBeInTheDocument();
   });
 
   it("renders both cards when two analogs share the same event_date", () => {

--- a/frontend/tests/pages/compare.test.tsx
+++ b/frontend/tests/pages/compare.test.tsx
@@ -82,8 +82,11 @@ describe("ComparePage", () => {
     expect(screen.getAllByText(/Run B/).length).toBeGreaterThan(0);
     // Both slot triggers should advertise themselves to AT and render the
     // "Pick a run…" placeholder copy (U+2026 ellipsis) until a run is chosen.
-    expect(screen.getByLabelText(/Select Run A/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Select Run B/)).toBeInTheDocument();
+    // Radix wraps the trigger as a combobox; aria-label is the accessible
+    // name, queried by role (getByLabelText looks for <label htmlFor> first
+    // and misses aria-label on a Radix button in jsdom).
+    expect(screen.getByRole("combobox", { name: /Select Run A/ })).toBeInTheDocument();
+    expect(screen.getByRole("combobox", { name: /Select Run B/ })).toBeInTheDocument();
     expect(screen.getAllByText(/Pick a run…/).length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
Three small workspace hotfixes.

## Changes

- **Historical analogs**: drop the "Show full excerpt" toggle. The ``/analyze/analogs`` endpoint truncates excerpts to ~280 characters on the server, so the toggle promised content that did not exist on the client. Render the excerpt straight through without the line-clamp.
- **Pipeline trace Encode step**: replace the hard-coded "No OOD signal available" line with the actual OOD state from the response. Reads ``sentiment.is_in_distribution``, surfaces the Mahalanobis distance against the calibrated threshold, falls back to "OOD signal not available on this checkpoint" only when the manifest is genuinely absent.
- **Workspace form**: the Document date control sat a few pixels lower than Asset and Horizon because their Labels carried an inline tooltip button that shifted the baseline. Add ``items-end`` to the grid and wrap the Date label in the same flex container shape so the trio aligns.

## Test plan

- [x] ``cd frontend && npx tsc --noEmit`` (passes locally)
- [ ] CI green
- [ ] Visit ``/`` post-deploy and confirm the three fields align at the input baseline
- [ ] Run an analyze; pipeline-trace Encode card reads "in-distribution · Mahalanobis distance NNN vs threshold NNN"
- [ ] Historical analog cards no longer show the broken Show-full-excerpt button